### PR TITLE
feat(ci): Add GitHub action to verify PR titles

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -1,0 +1,38 @@
+name: Check PR Title
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  check:
+    name: Check PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            chore
+            fix
+            feat
+            revert
+
+          scopes: |
+            ci
+            docs
+            examples
+            scripts
+            test
+            trainer
+          requireScope: false
+          ignoreLabels: |
+            do-not-merge/work-in-progress
+            dependencies


### PR DESCRIPTION
I added GitHub action to verify PR title.
Same as here: https://github.com/kubeflow/trainer/pull/2724

/assign @Electronic-Waste @astefanutti @szaher @kramaranya @briangallagher @eoinfennessy 

/hold for scope review
