### PR TITLE
fix(trainer): fix __all__ import.

### DIFF
--- a/python/kubeflow/trainer/__init__.py
+++ b/python/kubeflow/trainer/__init__.py
@@ -40,7 +40,7 @@ from kubeflow.trainer.types.types import (
 )
 
 __all__ = [
-    "BuiltinTrainer", "CustomTrainer", "DataFormat", "DATASET_PATH", "MODEL_PATH", "DataType", "Framework",
-    "HuggingFaceDatasetInitializer", "HuggingFaceModelInitializer", "Initializer", "Loss", "Runtime",
-    "TorchTuneConfig", "TorchTuneInstructDataset", "Trainer", "TrainerClient", "TrainerType"
+    "BuiltinTrainer", "CustomTrainer", "DataFormat", "DATASET_PATH", "DataType", "Framework",
+    "HuggingFaceDatasetInitializer", "HuggingFaceModelInitializer", "Initializer", "Loss", "MODEL_PATH",
+    "Runtime", "TorchTuneConfig", "TorchTuneInstructDataset", "Trainer", "TrainerClient", "TrainerType"
 ]

--- a/python/kubeflow/trainer/__init__.py
+++ b/python/kubeflow/trainer/__init__.py
@@ -40,7 +40,7 @@ from kubeflow.trainer.types.types import (
 )
 
 __all__ = [
-    "BuiltinTrainer", "CustomTrainer", "DataFormat", "DataType", "Framework",
-    "HuggingFaceDatasetInitializer", "HuggingFaceModelInitializer", "Initializer",
-    "Loss", "Runtime", "TorchTuneConfig", "TorchTuneInstructDataset", "Trainer", "TrainerType"
+    "BuiltinTrainer", "CustomTrainer", "DataFormat", "DATASET_PATH", "MODEL_PATH", "DataType", "Framework",
+    "HuggingFaceDatasetInitializer", "HuggingFaceModelInitializer", "Initializer", "Loss", "Runtime",
+    "TorchTuneConfig", "TorchTuneInstructDataset", "Trainer", "TrainerClient", "TrainerType"
 ]

--- a/python/kubeflow/trainer/__init__.py
+++ b/python/kubeflow/trainer/__init__.py
@@ -41,6 +41,7 @@ from kubeflow.trainer.types.types import (
 
 __all__ = [
     "BuiltinTrainer", "CustomTrainer", "DataFormat", "DATASET_PATH", "DataType", "Framework",
-    "HuggingFaceDatasetInitializer", "HuggingFaceModelInitializer", "Initializer", "Loss", "MODEL_PATH",
-    "Runtime", "TorchTuneConfig", "TorchTuneInstructDataset", "Trainer", "TrainerClient", "TrainerType"
+    "HuggingFaceDatasetInitializer", "HuggingFaceModelInitializer", "Initializer", "Loss",
+    "MODEL_PATH", "Runtime", "TorchTuneConfig", "TorchTuneInstructDataset", "Trainer",
+    "TrainerClient", "TrainerType"
 ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Current `__all__` for package import omits several items: `TrainerClient`, `DATASET_PATH` and `MODEL_PATH`. This prevents users from using `TrainerClient` through `from kubeflow.trainer import *`.

In this PR, I adds them to `__all__` array:)

/cc @kubeflow/wg-training-leads @astefanutti @eoinfennessy 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
