### PR TITLE
chore(docs): Add Coveralls Badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kubeflow SDK
 
+[![Coverage Status](https://coveralls.io/repos/github/kubeflow/sdk/badge.svg?branch=main)](https://coveralls.io/github/kubeflow/sdk?branch=main)
+
 ## Overview
 
 Kubeflow SDK streamlines user experience for data scientists and ML engineers to interact with


### PR DESCRIPTION
Adding Coveralls badge to the Kubeflow SDK readme.

/assign @astefanutti @szaher @kramaranya @eoinfennessy @briangallagher @Electronic-Waste 