### PR TITLE
chore(ci): Add dev tests with master dependencies

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 100
-extend-ignore = W503

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -10,6 +10,10 @@ on:
       - reopened
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: Check PR Title

--- a/.github/workflows/github-stale.yaml
+++ b/.github/workflows/github-stale.yaml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: "0 */5 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -3,6 +3,10 @@ name: E2E Test
 on:
   pull_request
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e-test:
     name: E2E Test

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -8,6 +8,15 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dependency-group:
+          - {name: dev,  make-target: test-python-dev}
+          - {name: prod, make-target: test-python}
+
+    name: Test ${{ matrix.dependency-group.name }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -21,9 +30,10 @@ jobs:
 
       - name: Run Tests
         run: |
-          make test-python report=xml
+          make ${{ matrix.dependency-group.make-target }} report=xml
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }} # Pass the GITHUB_TOKEN
+          flag-name: ${{ matrix.dependency-group.name }}

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -16,11 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.11']
-        dependency-group:
-          - {name: dev,  make-target: test-python-dev}
-          - {name: prod, make-target: test-python}
 
-    name: Test ${{ matrix.dependency-group.name }} (Python ${{ matrix.python-version }})
+    name: Test (Python ${{ matrix.python-version }})
 
     steps:
       - uses: actions/checkout@v4
@@ -35,13 +32,13 @@ jobs:
 
       - name: Run Tests
         run: |
-          make ${{ matrix.dependency-group.make-target }} report=xml
+          make test-python report=xml
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: ${{ matrix.dependency-group.name }}-py${{ matrix.python-version }}
+          flag-name: py${{ matrix.python-version }}
           parallel: true
 
   coverage:

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -5,25 +5,30 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        python-version: ['3.9', '3.11']
         dependency-group:
           - {name: dev,  make-target: test-python-dev}
           - {name: prod, make-target: test-python}
 
-    name: Test ${{ matrix.dependency-group.name }}
+    name: Test ${{ matrix.dependency-group.name }} (Python ${{ matrix.python-version }})
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python-version }}
 
       - name: Verify
         run: make verify
@@ -35,5 +40,17 @@ jobs:
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }} # Pass the GITHUB_TOKEN
-          flag-name: ${{ matrix.dependency-group.name }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: ${{ matrix.dependency-group.name }}-py${{ matrix.python-version }}
+          parallel: true
+
+  coverage:
+    if: ${{ always() }}
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -38,16 +38,3 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: py${{ matrix.python-version }}
-          parallel: true
-
-  coverage:
-    if: ${{ always() }}
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,14 @@ To run the unit tests (if present), execute:
 pytest
 ```
 
+#### Development Testing
+For development and before submitting PRs, run:
+```sh
+make test-python-dev
+```
+
+This tests against latest master branch dependencies to catch integration issues early.
+
 ### Code Coverage
 To run tests and measure coverage:
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,14 +29,9 @@ pip install -e .
 ```
 
 #### Development Build (Optional)
-To install the latest API modules directly from the master branch:
+To install development tools and the latest API modules directly from the master branch:
 ```sh
 pip install -e ".[dev]"
-```
-
-Install development tools:
-```sh
-pip install pytest black isort flake8 coverage pre-commit
 ```
 
 ## Development Workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,12 @@ cd python
 pip install -e .
 ```
 
+#### Development Build (Optional)
+To install the latest API modules directly from the master branch:
+```sh
+pip install -e ".[dev]"
+```
+
 Install development tools:
 ```sh
 pip install pytest black isort flake8 coverage pre-commit
@@ -50,14 +56,6 @@ To run the unit tests (if present), execute:
 ```sh
 pytest
 ```
-
-#### Development Testing
-For development and before submitting PRs, run:
-```sh
-make test-python-dev
-```
-
-This tests against latest master branch dependencies to catch integration issues early.
 
 ### Code Coverage
 To run tests and measure coverage:

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,20 @@ uv-venv:
 	fi
 
  # make test-unit will produce html coverage by default. Run with `make test-unit report=xml` to produce xml report.
+.PHONY: test-python-dev
+test-python-dev: uv-venv
+	@uv pip install --project $(PY_DIR) --group dev "$(PY_DIR)[test]"
+	@uv run coverage run --source=kubeflow.trainer.api.trainer_client,kubeflow.trainer.utils.utils -m pytest ./python/kubeflow/trainer/api/trainer_client_test.py
+	@uv run coverage report -m kubeflow/trainer/api/trainer_client.py kubeflow/trainer/utils/utils.py
+ifeq ($(report),xml)
+	@uv run coverage xml
+else
+	@uv run coverage html
+endif
+
 .PHONY: test-python
 test-python: uv-venv
-	@uv pip install "./python[test]"
+	@uv pip install --project $(PY_DIR) "$(PY_DIR)[test]"
 	@uv run coverage run --source=kubeflow.trainer.api.trainer_client,kubeflow.trainer.utils.utils -m pytest ./python/kubeflow/trainer/api/trainer_client_test.py
 	@uv run coverage report -m kubeflow/trainer/api/trainer_client.py kubeflow/trainer/utils/utils.py
 ifeq ($(report),xml)

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ uv-venv:
  # make test-python will produce html coverage by default. Run with `make test-python report=xml` to produce xml report.
 .PHONY: test-python
 test-python: uv-venv
-	@uv pip install --project $(PY_DIR) --group dev "$(PY_DIR)[test,dev]"
+	@uv pip install --project $(PY_DIR) -e "$(PY_DIR)[dev]"
 	@uv run coverage run --source=kubeflow.trainer.api.trainer_client,kubeflow.trainer.utils.utils -m pytest ./python/kubeflow/trainer/api/trainer_client_test.py
 	@uv run coverage report -m kubeflow/trainer/api/trainer_client.py kubeflow/trainer/utils/utils.py
 ifeq ($(report),xml)

--- a/Makefile
+++ b/Makefile
@@ -66,21 +66,10 @@ uv-venv:
 		echo "uv virtual environment already exists in $(VENV_DIR)."; \
 	fi
 
- # make test-unit will produce html coverage by default. Run with `make test-unit report=xml` to produce xml report.
-.PHONY: test-python-dev
-test-python-dev: uv-venv
-	@uv pip install --project $(PY_DIR) --group dev "$(PY_DIR)[test,dev]"
-	@uv run coverage run --source=kubeflow.trainer.api.trainer_client,kubeflow.trainer.utils.utils -m pytest ./python/kubeflow/trainer/api/trainer_client_test.py
-	@uv run coverage report -m kubeflow/trainer/api/trainer_client.py kubeflow/trainer/utils/utils.py
-ifeq ($(report),xml)
-	@uv run coverage xml
-else
-	@uv run coverage html
-endif
-
+ # make test-python will produce html coverage by default. Run with `make test-python report=xml` to produce xml report.
 .PHONY: test-python
 test-python: uv-venv
-	@uv pip install --project $(PY_DIR) "$(PY_DIR)[test]"
+	@uv pip install --project $(PY_DIR) --group dev "$(PY_DIR)[test,dev]"
 	@uv run coverage run --source=kubeflow.trainer.api.trainer_client,kubeflow.trainer.utils.utils -m pytest ./python/kubeflow/trainer/api/trainer_client_test.py
 	@uv run coverage report -m kubeflow/trainer/api/trainer_client.py kubeflow/trainer/utils/utils.py
 ifeq ($(report),xml)

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ uv-venv:
  # make test-unit will produce html coverage by default. Run with `make test-unit report=xml` to produce xml report.
 .PHONY: test-python-dev
 test-python-dev: uv-venv
-	@uv pip install --project $(PY_DIR) --group dev "$(PY_DIR)[test]"
+	@uv pip install --project $(PY_DIR) --group dev "$(PY_DIR)[test,dev]"
 	@uv run coverage run --source=kubeflow.trainer.api.trainer_client,kubeflow.trainer.utils.utils -m pytest ./python/kubeflow/trainer/api/trainer_client_test.py
 	@uv run coverage report -m kubeflow/trainer/api/trainer_client.py kubeflow/trainer/utils/utils.py
 ifeq ($(report),xml)

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ uv-venv:
  # make test-python will produce html coverage by default. Run with `make test-python report=xml` to produce xml report.
 .PHONY: test-python
 test-python: uv-venv
-	@uv pip install --project $(PY_DIR) -e "$(PY_DIR)[dev]"
+	@uv pip install -e "$(PY_DIR)[dev]"
 	@uv run coverage run --source=kubeflow.trainer.api.trainer_client,kubeflow.trainer.utils.utils -m pytest ./python/kubeflow/trainer/api/trainer_client_test.py
 	@uv run coverage report -m kubeflow/trainer/api/trainer_client.py kubeflow/trainer/utils/utils.py
 ifeq ($(report),xml)

--- a/python/kubeflow/trainer/api/__init__.py
+++ b/python/kubeflow/trainer/api/__init__.py
@@ -1,4 +1,4 @@
-# flake8: noqa
+# ruff: noqa
 
 # import apis into api package
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -55,6 +55,7 @@ ignore = ["E203"]
 [dependency-groups]
 dev = [
     "ruff>=0.12.2",
+    "kubeflow_trainer_api@git+https://github.com/kubeflow/trainer.git@master#subdirectory=api/python_api",
 ]
 
 [tool.uv]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -31,13 +31,13 @@ dependencies = [
   "kubeflow-trainer-api>=2.0.0",
 ]
 [project.optional-dependencies]
-test = [
+dev = [
   "pytest>=7.0",
   "pytest-mock>=3.10",
   "coverage>=7.0",
-]
-dev = [
   "kubeflow_trainer_api@git+https://github.com/kubeflow/trainer.git@master#subdirectory=api/python_api",
+  "ruff>=0.12.2",
+  "pre-commit>=4.2.0",
 ]
 
 [project.urls]
@@ -55,10 +55,7 @@ line-length = 100
 select = ["E", "F", "W"]
 ignore = ["E203"]
 
-[dependency-groups]
-dev = [
-    "ruff>=0.12.2",
-]
+
 
 [tool.uv]
 package = true

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,13 +28,16 @@ classifiers = [
 dependencies = [
   "kubernetes>=27.2.0",
   "pydantic>=2.10.0",
-  "kubeflow_trainer_api@git+https://github.com/kubeflow/trainer.git@master#subdirectory=api/python_api"
+  "kubeflow-trainer-api>=2.0.0",
 ]
 [project.optional-dependencies]
 test = [
   "pytest>=7.0",
   "pytest-mock>=3.10",
   "coverage>=7.0",
+]
+dev = [
+  "kubeflow_trainer_api@git+https://github.com/kubeflow/trainer.git@master#subdirectory=api/python_api",
 ]
 
 [project.urls]
@@ -55,7 +58,6 @@ ignore = ["E203"]
 [dependency-groups]
 dev = [
     "ruff>=0.12.2",
-    "kubeflow_trainer_api@git+https://github.com/kubeflow/trainer.git@master#subdirectory=api/python_api",
 ]
 
 [tool.uv]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -257,6 +257,7 @@ test = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "kubeflow-trainer-api" },
     { name = "ruff" },
 ]
 
@@ -272,7 +273,10 @@ requires-dist = [
 provides-extras = ["test"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.12.2" }]
+dev = [
+    { name = "kubeflow-trainer-api", git = "https://github.com/kubeflow/trainer.git?subdirectory=api%2Fpython_api&rev=master" },
+    { name = "ruff", specifier = ">=0.12.2" },
+]
 
 [[package]]
 name = "kubeflow-trainer-api"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -30,6 +30,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249 },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -187,6 +196,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047 },
+]
+
+[[package]]
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -208,6 +226,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215 },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.40.3"
 source = { registry = "https://pypi.org/simple" }
@@ -219,6 +246,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/9b/e92ef23b84fa10a64ce4831390b7a4c2e53c0132568d99d4ae61d04c8855/google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77", size = 281029 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/63/b19553b658a1692443c62bd07e5868adaa0ad746a0751ba62c59568cd45b/google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca", size = 216137 },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/88/d193a27416618628a5eea64e3223acd800b40749a96ffb322a9b55a49ed1/identify-2.6.12.tar.gz", hash = "sha256:d8de45749f1efb108badef65ee8386f0f7bb19a7f26185f74de6367bffbaf0e6", size = 99254 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/cd/18f8da995b658420625f7ef13f037be53ae04ec5ad33f9b718240dcfd48c/identify-2.6.12-py2.py3-none-any.whl", hash = "sha256:ad9672d5a72e0d2ff7c5c8809b62dfa60458626352fb0eb7b55e69bdc45334a2", size = 99145 },
 ]
 
 [[package]]
@@ -250,33 +286,27 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "kubeflow-trainer-api" },
-]
-test = [
     { name = "coverage" },
+    { name = "kubeflow-trainer-api" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-mock" },
-]
-
-[package.dev-dependencies]
-dev = [
     { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "coverage", marker = "extra == 'test'", specifier = ">=7.0" },
+    { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "kubeflow-trainer-api", specifier = ">=2.0.0" },
     { name = "kubeflow-trainer-api", marker = "extra == 'dev'", git = "https://github.com/kubeflow/trainer.git?subdirectory=api%2Fpython_api&rev=master" },
     { name = "kubernetes", specifier = ">=27.2.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
-    { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.10" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.10" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.2" },
 ]
-provides-extras = ["dev", "test"]
-
-[package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.12.2" }]
+provides-extras = ["dev"]
 
 [[package]]
 name = "kubeflow-trainer-api"
@@ -309,6 +339,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -327,12 +366,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567 },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/39/679ca9b26c7bb2999ff122d50faa301e49af82ca9c066ec061cfbc0c6784/pre_commit-4.2.0.tar.gz", hash = "sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146", size = 193424 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/74/a88bf1b1efeae488a0c0b7bdf71429c313722d1fc0f377537fbe554e6180/pre_commit-4.2.0-py2.py3-none-any.whl", hash = "sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd", size = 220707 },
 ]
 
 [[package]]
@@ -725,6 +789,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680 },
+]
+
+[[package]]
+name = "virtualenv"
+version = "20.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2e/8a70dcbe8bf15213a08f9b0325ede04faca5d362922ae0d62ef0fa4b069d/virtualenv-20.33.0.tar.gz", hash = "sha256:47e0c0d2ef1801fce721708ccdf2a28b9403fa2307c3268aebd03225976f61d2", size = 6082069 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/87/b22cf40cdf7e2b2bf83f38a94d2c90c5ad6c304896e5a12d0c08a602eb59/virtualenv-20.33.0-py3-none-any.whl", hash = "sha256:106b6baa8ab1b526d5a9b71165c85c456fbd49b16976c88e2bc9352ee3bc5d3f", size = 6060205 },
 ]
 
 [[package]]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -249,6 +249,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+dev = [
+    { name = "kubeflow-trainer-api" },
+]
 test = [
     { name = "coverage" },
     { name = "pytest" },
@@ -257,26 +260,23 @@ test = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "kubeflow-trainer-api" },
     { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "coverage", marker = "extra == 'test'", specifier = ">=7.0" },
-    { name = "kubeflow-trainer-api", git = "https://github.com/kubeflow/trainer.git?subdirectory=api%2Fpython_api&rev=master" },
+    { name = "kubeflow-trainer-api", specifier = ">=2.0.0" },
+    { name = "kubeflow-trainer-api", marker = "extra == 'dev'", git = "https://github.com/kubeflow/trainer.git?subdirectory=api%2Fpython_api&rev=master" },
     { name = "kubernetes", specifier = ">=27.2.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.10" },
 ]
-provides-extras = ["test"]
+provides-extras = ["dev", "test"]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "kubeflow-trainer-api", git = "https://github.com/kubeflow/trainer.git?subdirectory=api%2Fpython_api&rev=master" },
-    { name = "ruff", specifier = ">=0.12.2" },
-]
+dev = [{ name = "ruff", specifier = ">=0.12.2" }]
 
 [[package]]
 name = "kubeflow-trainer-api"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
I added a test-python-dev target and changed the unit test CI jobs with a dev/prod matrix

Dev leg installs the dev dependency group, which now pulls `kubeflow_trainer_api` from the master branch. Prod leg will run with the packages published to PyPI (once API models are available there)

I also updated the CI job to run unit tests for two Python vesions -- `3.9` and `3.11`

I removed flake8 since ruff replaced it

/assign @andreyvelich @astefanutti @Electronic-Waste @tenzen-y @briangallagher

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
