### PR TITLE
chore: Remove tool.hatch.build.targets from pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,5 @@ package = true
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.build.targets]
-packages = ["kubeflow"]
-
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

I removed the redundant hatch build target from pyproject.toml

The old table `[tool.hatch.build.targets]` is not correct, it's supposed to be in `[tool.hatch.build.targets.wheel]` instead -- https://hatch.pypa.io/1.9/config/build/#packages
But since we have a single package, I’m not adding `[tool.hatch.build.targets.wheel]` either, because hatchling finds the package on its own -- https://hatch.pypa.io/1.9/plugins/builder/wheel/#default-file-selection

/assign @andreyvelich @astefanutti @Electronic-Waste 
