### PR TITLE
chore: Enable parallel builds for coveralls

### DIFF
--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -38,3 +38,16 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
+          flag-name: python-${{ matrix.python-version }}
+
+  finish:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close parallel build
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true


### PR DESCRIPTION
I noticed we get this error sometimes when running unit test CI job:
```
Error: Unprocessable Entity
Response: {"message":"Can't add a job to a build that is already closed. Build 17225808879 is closed. See docs.coveralls.io/parallel-builds","error":true}
```
Example from https://github.com/kubeflow/sdk/actions/runs/17225808879/job/48870011364
So I enabled parallel mode to upload coverage data for both Python versions simultaneously and keep the Coveralls build open
https://docs.coveralls.io/parallel-builds

/assign @andreyvelich @astefanutti @Electronic-Waste 