### PR TITLE
feat: Implement Training Options pattern for flexible TrainJob customization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,8 @@ release: install-dev
 .PHONY: test-python
 test-python: uv-venv  ## Run Python unit tests
 	@uv sync
-	@uv run coverage run --source=kubeflow.trainer.backends.kubernetes.backend,kubeflow.trainer.utils.utils -m pytest \
-		./kubeflow/trainer/backends/kubernetes/backend_test.py \
-		./kubeflow/trainer/backends/kubernetes/utils_test.py
-	@uv run coverage report -m \
-		kubeflow/trainer/backends/kubernetes/backend.py \
-		kubeflow/trainer/backends/kubernetes/utils.py
+	@uv run coverage run --source=kubeflow -m pytest ./kubeflow/
+	@uv run coverage report --omit='*_test.py' --skip-covered --skip-empty
 ifeq ($(report),xml)
 	@uv run coverage xml
 else

--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -107,6 +107,7 @@ class TrainerClient:
         trainer: Optional[
             Union[types.CustomTrainer, types.CustomTrainerContainer, types.BuiltinTrainer]
         ] = None,
+        options: Optional[list] = None,
     ) -> str:
         """Create a TrainJob. You can configure the TrainJob using one of these trainers:
 
@@ -124,6 +125,8 @@ class TrainerClient:
             trainer: Optional configuration for a CustomTrainer, CustomTrainerContainer, or
                 BuiltinTrainer. If not specified, the TrainJob will use the
                 runtime's default values.
+            options: Optional list of configuration options to apply to the TrainJob.
+                Options can be imported from kubeflow.trainer.options.
 
         Returns:
             The unique name of the TrainJob that has been generated.
@@ -133,7 +136,12 @@ class TrainerClient:
             TimeoutError: Timeout to create TrainJobs.
             RuntimeError: Failed to create TrainJobs.
         """
-        return self.backend.train(runtime=runtime, initializer=initializer, trainer=trainer)
+        return self.backend.train(
+            runtime=runtime,
+            initializer=initializer,
+            trainer=trainer,
+            options=options,
+        )
 
     def list_jobs(self, runtime: Optional[types.Runtime] = None) -> list[types.TrainJob]:
         """List of the created TrainJobs. If a runtime is specified, only TrainJobs associated with

--- a/kubeflow/trainer/api/trainer_client_test.py
+++ b/kubeflow/trainer/api/trainer_client_test.py
@@ -1,0 +1,72 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for TrainerClient backend selection.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from kubeflow.common.types import KubernetesBackendConfig
+from kubeflow.trainer.api.trainer_client import TrainerClient
+from kubeflow.trainer.backends.localprocess.types import LocalProcessBackendConfig
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "name": "default_backend_is_kubernetes",
+            "backend_config": None,
+            "expected_backend": "KubernetesBackend",
+            "use_k8s_mocks": True,
+        },
+        {
+            "name": "local_process_backend_selection",
+            "backend_config": LocalProcessBackendConfig(),
+            "expected_backend": "LocalProcessBackend",
+            "use_k8s_mocks": False,
+        },
+        {
+            "name": "kubernetes_backend_selection",
+            "backend_config": KubernetesBackendConfig(),
+            "expected_backend": "KubernetesBackend",
+            "use_k8s_mocks": True,
+        },
+    ],
+)
+def test_backend_selection(test_case):
+    """Test TrainerClient backend selection logic."""
+    if test_case["use_k8s_mocks"]:
+        with (
+            patch("kubernetes.config.load_kube_config"),
+            patch("kubernetes.client.CustomObjectsApi") as mock_custom_api,
+            patch("kubernetes.client.CoreV1Api") as mock_core_api,
+        ):
+            mock_custom_api.return_value = Mock()
+            mock_core_api.return_value = Mock()
+
+            if test_case["backend_config"]:
+                client = TrainerClient(backend_config=test_case["backend_config"])
+            else:
+                client = TrainerClient()
+
+            backend_name = client.backend.__class__.__name__
+            assert backend_name == test_case["expected_backend"]
+    else:
+        client = TrainerClient(backend_config=test_case["backend_config"])
+        backend_name = client.backend.__class__.__name__
+        assert backend_name == test_case["expected_backend"]

--- a/kubeflow/trainer/backends/base.py
+++ b/kubeflow/trainer/backends/base.py
@@ -21,6 +21,11 @@ from kubeflow.trainer.types import types
 
 
 class RuntimeBackend(abc.ABC):
+    """Base class for runtime backends.
+
+    Options self-validate by checking the backend instance type in their __call__ method.
+    """
+
     @abc.abstractmethod
     def list_runtimes(self) -> list[types.Runtime]:
         raise NotImplementedError()
@@ -41,6 +46,7 @@ class RuntimeBackend(abc.ABC):
         trainer: Optional[
             Union[types.CustomTrainer, types.CustomTrainerContainer, types.BuiltinTrainer]
         ] = None,
+        options: Optional[list] = None,
     ) -> str:
         raise NotImplementedError()
 

--- a/kubeflow/trainer/backends/kubernetes/constants.py
+++ b/kubeflow/trainer/backends/kubernetes/constants.py
@@ -1,0 +1,15 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Kubernetes backend-specific constants."""

--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -349,6 +349,10 @@ def get_trainer_cr_from_custom_trainer(
 ) -> models.TrainerV1alpha1Trainer:
     """
     Get the Trainer CR from the custom trainer.
+
+    Args:
+        runtime: The runtime configuration.
+        trainer: The custom trainer or container configuration.
     """
     trainer_cr = models.TrainerV1alpha1Trainer()
 
@@ -361,7 +365,7 @@ def get_trainer_cr_from_custom_trainer(
         trainer_cr.resources_per_node = get_resources_per_node(trainer.resources_per_node)
 
     if isinstance(trainer, types.CustomTrainer):
-        # If CustomTrainer is used, add command to the Trainer.
+        # If CustomTrainer is used, generate command from function.
         trainer_cr.command = get_command_using_train_func(
             runtime,
             trainer.func,

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -238,8 +238,6 @@ def test_get_script_for_python_packages(test_case):
     ],
 )
 def test_get_command_using_train_func(test_case: TestCase):
-    print("Executing test:", test_case.name)
-
     try:
         command = utils.get_command_using_train_func(
             runtime=test_case.config["runtime"],
@@ -254,7 +252,6 @@ def test_get_command_using_train_func(test_case: TestCase):
 
     except Exception as e:
         assert type(e) is test_case.expected_error
-    print("test execution complete")
 
 
 def test_get_dataset_initializer():

--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -1,0 +1,488 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the LocalProcessBackend class in the Kubeflow Trainer SDK.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from kubeflow.trainer.backends.localprocess.backend import LocalProcessBackend
+from kubeflow.trainer.backends.localprocess.types import (
+    LocalProcessBackendConfig,
+    LocalRuntimeTrainer,
+)
+from kubeflow.trainer.constants import constants
+from kubeflow.trainer.options import (
+    Annotations,
+    Labels,
+    Name,
+    PodTemplateOverride,
+    PodTemplateOverrides,
+)
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
+from kubeflow.trainer.types import types
+
+# Test constants
+TORCH_RUNTIME = constants.TORCH_RUNTIME
+BASIC_TRAIN_JOB_NAME = "test-job"
+
+
+def dummy_training_function():
+    """Dummy training function for testing."""
+    print("Training started")
+    return {"loss": 0.5, "accuracy": 0.95}
+
+
+@pytest.fixture
+def local_backend():
+    """Create LocalProcessBackend for testing."""
+    cfg = LocalProcessBackendConfig()
+    backend = LocalProcessBackend(cfg)
+    yield backend
+    # Cleanup: Clear jobs to prevent test pollution
+    backend._LocalProcessBackend__local_jobs.clear()
+
+
+@pytest.fixture
+def mock_train_environment():
+    """Mock the training environment to avoid actual subprocess execution."""
+    with (
+        patch("kubeflow.trainer.backends.localprocess.job.LocalJob.start") as mock_start,
+        patch(
+            "kubeflow.trainer.backends.localprocess.utils.get_local_runtime_trainer"
+        ) as mock_get_trainer,
+        patch(
+            "kubeflow.trainer.backends.localprocess.utils.get_local_train_job_script"
+        ) as mock_get_script,
+        patch("tempfile.mkdtemp") as mock_mkdtemp,
+    ):
+        # Setup mock return values
+        mock_mkdtemp.return_value = "/tmp/test-venv"
+        mock_get_script.return_value = ["/bin/bash", "-c", "echo 'training'"]
+
+        mock_trainer = LocalRuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="torch",
+            num_nodes=1,
+            device_count=1,
+            device="cpu",
+            packages=["torch"],
+        )
+        mock_trainer.set_command = Mock()
+        mock_get_trainer.return_value = mock_trainer
+
+        yield {
+            "start": mock_start,
+            "get_trainer": mock_get_trainer,
+            "get_script": mock_get_script,
+            "mkdtemp": mock_mkdtemp,
+        }
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="list_all_local_runtimes",
+            expected_status=SUCCESS,
+            config={},
+        ),
+    ],
+)
+def test_list_runtimes(local_backend, test_case):
+    """Test LocalProcessBackend.list_runtimes()."""
+    runtimes = local_backend.list_runtimes()
+    assert len(runtimes) > 0
+    assert all(isinstance(rt, types.Runtime) for rt in runtimes)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="get_existing_runtime",
+            expected_status=SUCCESS,
+            config={"runtime_name": TORCH_RUNTIME},
+        ),
+        TestCase(
+            name="get_nonexistent_runtime",
+            expected_status=FAILED,
+            config={"runtime_name": "nonexistent-runtime"},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_get_runtime(local_backend, test_case):
+    """Test LocalProcessBackend.get_runtime()."""
+    runtime_name = test_case.config.get("runtime_name")
+
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            local_backend.get_runtime(runtime_name)
+    else:
+        runtime = local_backend.get_runtime(runtime_name)
+        assert runtime is not None
+        assert runtime.name == runtime_name
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="get_packages_for_existing_runtime",
+            expected_status=SUCCESS,
+            config={
+                "runtime": types.Runtime(
+                    name=TORCH_RUNTIME,
+                    trainer=types.RuntimeTrainer(
+                        trainer_type=types.TrainerType.CUSTOM_TRAINER,
+                        framework="torch",
+                        num_nodes=1,
+                    ),
+                ),
+            },
+        ),
+        TestCase(
+            name="get_packages_for_nonexistent_runtime",
+            expected_status=FAILED,
+            config={
+                "runtime": types.Runtime(
+                    name="nonexistent-runtime",
+                    trainer=types.RuntimeTrainer(
+                        trainer_type=types.TrainerType.CUSTOM_TRAINER,
+                        framework="torch",
+                        num_nodes=1,
+                    ),
+                ),
+            },
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_get_runtime_packages(local_backend, test_case):
+    """Test LocalProcessBackend.get_runtime_packages()."""
+    runtime = test_case.config.get("runtime")
+
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            local_backend.get_runtime_packages(runtime)
+    else:
+        packages = local_backend.get_runtime_packages(runtime)
+        assert packages is not None
+        assert isinstance(packages, list)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="train with basic custom trainer - no options",
+            expected_status=SUCCESS,
+            config={
+                "runtime": types.Runtime(
+                    name=TORCH_RUNTIME,
+                    trainer=types.RuntimeTrainer(
+                        trainer_type=types.TrainerType.CUSTOM_TRAINER,
+                        framework="torch",
+                        num_nodes=1,
+                    ),
+                ),
+                "trainer": types.CustomTrainer(
+                    func=dummy_training_function,
+                    packages_to_install=["numpy", "torch"],
+                ),
+                "options": [],
+            },
+        ),
+        TestCase(
+            name="train with custom trainer and environment variables",
+            expected_status=SUCCESS,
+            config={
+                "runtime": types.Runtime(
+                    name=TORCH_RUNTIME,
+                    trainer=types.RuntimeTrainer(
+                        trainer_type=types.TrainerType.CUSTOM_TRAINER,
+                        framework="torch",
+                        num_nodes=1,
+                    ),
+                ),
+                "trainer": types.CustomTrainer(
+                    func=dummy_training_function,
+                    packages_to_install=["torch"],
+                    env={"CUDA_VISIBLE_DEVICES": "0", "OMP_NUM_THREADS": "4"},
+                ),
+                "options": [],
+            },
+        ),
+        TestCase(
+            name="train rejects kubernetes labels option",
+            expected_status=FAILED,
+            config={
+                "runtime": types.Runtime(
+                    name=TORCH_RUNTIME,
+                    trainer=types.RuntimeTrainer(
+                        trainer_type=types.TrainerType.CUSTOM_TRAINER,
+                        framework="torch",
+                        num_nodes=1,
+                    ),
+                ),
+                "trainer": types.CustomTrainer(
+                    func=dummy_training_function,
+                ),
+                "options": [Labels({"app": "test"})],
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="train rejects kubernetes annotations option",
+            expected_status=FAILED,
+            config={
+                "runtime": types.Runtime(
+                    name=TORCH_RUNTIME,
+                    trainer=types.RuntimeTrainer(
+                        trainer_type=types.TrainerType.CUSTOM_TRAINER,
+                        framework="torch",
+                        num_nodes=1,
+                    ),
+                ),
+                "trainer": types.CustomTrainer(
+                    func=dummy_training_function,
+                ),
+                "options": [Annotations({"description": "test"})],
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="train rejects pod template overrides option",
+            expected_status=FAILED,
+            config={
+                "runtime": types.Runtime(
+                    name=TORCH_RUNTIME,
+                    trainer=types.RuntimeTrainer(
+                        trainer_type=types.TrainerType.CUSTOM_TRAINER,
+                        framework="torch",
+                        num_nodes=1,
+                    ),
+                ),
+                "trainer": types.CustomTrainer(
+                    func=dummy_training_function,
+                ),
+                "options": [
+                    PodTemplateOverrides(
+                        PodTemplateOverride(
+                            target_jobs=["node"],
+                        )
+                    )
+                ],
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="train fails without runtime",
+            expected_status=FAILED,
+            config={
+                "runtime": None,
+                "trainer": types.CustomTrainer(
+                    func=dummy_training_function,
+                ),
+                "options": [],
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="train fails without custom trainer",
+            expected_status=FAILED,
+            config={
+                "runtime": types.Runtime(
+                    name=TORCH_RUNTIME,
+                    trainer=types.RuntimeTrainer(
+                        trainer_type=types.TrainerType.CUSTOM_TRAINER,
+                        framework="torch",
+                        num_nodes=1,
+                    ),
+                ),
+                "trainer": None,
+            },
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_train(local_backend, mock_train_environment, test_case):
+    """Test LocalProcessBackend.train() with success and failure cases."""
+    runtime = test_case.config.get("runtime")
+    trainer = test_case.config.get("trainer")
+    options = test_case.config.get("options", [])
+
+    mocks = mock_train_environment
+
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error) as exc_info:
+            local_backend.train(
+                runtime=runtime,
+                trainer=trainer,
+                options=options,
+            )
+
+        # Verify specific error messages
+        error_msg = str(exc_info.value)
+        if "rejects kubernetes" in test_case.name:
+            assert "not compatible with" in error_msg
+        elif "without runtime" in test_case.name:
+            assert "Runtime must be provided" in error_msg
+        elif "without custom trainer" in test_case.name:
+            assert "CustomTrainer must be set" in error_msg
+    else:
+        train_job_name = local_backend.train(
+            runtime=runtime,
+            trainer=trainer,
+            options=options,
+        )
+
+        assert train_job_name is not None
+        assert len(train_job_name) > 0
+        mocks["start"].assert_called_once()
+        mocks["get_trainer"].assert_called_once()
+        mocks["get_script"].assert_called_once()
+
+        # Verify job is tracked
+        jobs = local_backend.list_jobs(runtime=runtime)
+        assert any(job.name == train_job_name for job in jobs)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="get_nonexistent_job",
+            expected_status=FAILED,
+            config={"job_name": "nonexistent-job"},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_get_job(local_backend, test_case):
+    """Test LocalProcessBackend.get_job()."""
+    job_name = test_case.config.get("job_name")
+
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            local_backend.get_job(job_name)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="list_jobs_empty",
+            expected_status=SUCCESS,
+            config={"runtime": None},
+        ),
+    ],
+)
+def test_list_jobs(local_backend, test_case):
+    """Test LocalProcessBackend.list_jobs()."""
+    runtime = test_case.config.get("runtime")
+    jobs = local_backend.list_jobs(runtime=runtime)
+    assert isinstance(jobs, list)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="get_logs_nonexistent_job",
+            expected_status=FAILED,
+            config={"job_name": "nonexistent-job", "step": "train"},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_get_job_logs(local_backend, test_case):
+    """Test LocalProcessBackend.get_job_logs()."""
+    job_name = test_case.config.get("job_name")
+    step = test_case.config.get("step", "train")
+
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            list(local_backend.get_job_logs(job_name, step=step))
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="wait_for_nonexistent_job",
+            expected_status=FAILED,
+            config={"job_name": "nonexistent-job"},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_wait_for_job_status(local_backend, test_case):
+    """Test LocalProcessBackend.wait_for_job_status()."""
+    job_name = test_case.config.get("job_name")
+
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            local_backend.wait_for_job_status(job_name)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="delete_nonexistent_job",
+            expected_status=FAILED,
+            config={"job_name": "nonexistent-job"},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_delete_job(local_backend, test_case):
+    """Test LocalProcessBackend.delete_job()."""
+    job_name = test_case.config.get("job_name")
+
+    if test_case.expected_status == FAILED:
+        with pytest.raises(test_case.expected_error):
+            local_backend.delete_job(job_name)
+
+
+def test_name_option_sets_job_name(local_backend, mock_train_environment):
+    """Test that Name option sets the custom job name."""
+    custom_name = "my-custom-job-name"
+
+    def dummy_func():
+        pass
+
+    runtime = types.Runtime(
+        name=TORCH_RUNTIME,
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="torch",
+        ),
+    )
+
+    trainer = types.CustomTrainer(func=dummy_func)
+    options = [Name(name=custom_name)]
+
+    job_name = local_backend.train(
+        runtime=runtime,
+        trainer=trainer,
+        options=options,
+    )
+
+    assert job_name == custom_name

--- a/kubeflow/trainer/backends/localprocess/types.py
+++ b/kubeflow/trainer/backends/localprocess/types.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 from dataclasses import dataclass, field
 from datetime import datetime
 import typing

--- a/kubeflow/trainer/backends/localprocess/utils.py
+++ b/kubeflow/trainer/backends/localprocess/utils.py
@@ -122,7 +122,8 @@ def get_local_runtime_trainer(
     Get the LocalRuntimeTrainer object.
     """
     local_runtime = next(
-        (rt for rt in local_exec_constants.local_runtimes if rt.name == runtime_name), None
+        (rt for rt in local_exec_constants.local_runtimes if rt.name == runtime_name),
+        None,
     )
     if not local_runtime:
         raise ValueError(f"Runtime {runtime_name} not found")
@@ -267,9 +268,11 @@ def get_local_train_job_script(
     dependency_script = "\n"
     if trainer.packages_to_install:
         dependency_script = get_dependencies_command(
-            pip_index_urls=trainer.pip_index_urls
-            if trainer.pip_index_urls
-            else constants.DEFAULT_PIP_INDEX_URLS,
+            pip_index_urls=(
+                trainer.pip_index_urls
+                if trainer.pip_index_urls
+                else constants.DEFAULT_PIP_INDEX_URLS
+            ),
             runtime_packages=runtime_trainer.packages,
             trainer_packages=trainer.packages_to_install,
             quiet=False,

--- a/kubeflow/trainer/constants/constants.py
+++ b/kubeflow/trainer/constants/constants.py
@@ -167,3 +167,7 @@ TORCH_TUNE_INSTRUCT_DATASET = "torchtune.datasets.instruct_dataset"
 DEFAULT_FRAMEWORK_IMAGES = {
     "torch": "pytorch/pytorch:2.7.1-cuda12.8-cudnn9-runtime",
 }
+
+# The length of the UUID suffix for auto-generated job names.
+# Total name length = 1 (random letter) + 11 (UUID hex) = 12 characters
+JOB_NAME_UUID_LENGTH = 11

--- a/kubeflow/trainer/options/__init__.py
+++ b/kubeflow/trainer/options/__init__.py
@@ -1,0 +1,52 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Training options for the Kubeflow Trainer SDK.
+
+All options are available from this single import location:
+    from kubeflow.trainer.options import Name, Labels, PodTemplateOverrides, ...
+
+Options self-validate their backend compatibility at runtime.
+Check each option's docstring for supported backends.
+"""
+
+from kubeflow.trainer.options.common import Name
+from kubeflow.trainer.options.kubernetes import (
+    Annotations,
+    ContainerOverride,
+    Labels,
+    PodSpecOverride,
+    PodTemplateOverride,
+    PodTemplateOverrides,
+    SpecAnnotations,
+    SpecLabels,
+    TrainerArgs,
+    TrainerCommand,
+)
+
+__all__ = [
+    # Common options (all backends)
+    "Name",
+    # Kubernetes options
+    "Annotations",
+    "ContainerOverride",
+    "Labels",
+    "PodSpecOverride",
+    "PodTemplateOverride",
+    "PodTemplateOverrides",
+    "SpecAnnotations",
+    "SpecLabels",
+    "TrainerArgs",
+    "TrainerCommand",
+]

--- a/kubeflow/trainer/options/common.py
+++ b/kubeflow/trainer/options/common.py
@@ -1,0 +1,51 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common options and helper classes used across multiple backends."""
+
+from dataclasses import dataclass
+from typing import Any, Optional, Union
+
+from kubeflow.trainer.backends.base import RuntimeBackend
+from kubeflow.trainer.types.types import BuiltinTrainer, CustomTrainer, CustomTrainerContainer
+
+
+@dataclass
+class Name:
+    """Set a custom name for the TrainJob resource.
+
+    This option works with all backends.
+
+    Args:
+        name: Custom name for the job. Must be a valid identifier.
+    """
+
+    name: str
+
+    def __call__(
+        self,
+        job_spec: dict[str, Any],
+        trainer: Optional[Union[BuiltinTrainer, CustomTrainer, CustomTrainerContainer]],
+        backend: RuntimeBackend,
+    ) -> None:
+        """Apply custom name to the job specification.
+
+        Args:
+            job_spec: Job specification dictionary to modify.
+            trainer: Optional trainer instance for context.
+            backend: Backend instance for validation and context.
+        """
+        # Name option is generic - works with all backends
+        metadata = job_spec.setdefault("metadata", {})
+        metadata["name"] = self.name

--- a/kubeflow/trainer/options/kubernetes.py
+++ b/kubeflow/trainer/options/kubernetes.py
@@ -1,0 +1,498 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Kubernetes-specific training options for the Kubeflow Trainer SDK."""
+
+from dataclasses import dataclass
+from typing import Any, Optional, Union
+
+from kubeflow.trainer.backends.base import RuntimeBackend
+from kubeflow.trainer.types.types import BuiltinTrainer, CustomTrainer, CustomTrainerContainer
+
+
+@dataclass
+class ContainerOverride:
+    """Configuration for overriding a specific container in a pod.
+
+    Args:
+        name: Name of the container to override (must exist in TrainingRuntime).
+        env: Environment variables to add/merge with the container.
+             Each dict should have 'name' and 'value' or 'valueFrom' keys.
+        volume_mounts: Volume mounts to add/merge with the container.
+                      Each dict should have 'name' and 'mountPath' keys at minimum.
+    """
+
+    name: str
+    env: Optional[list[dict]] = None
+    volume_mounts: Optional[list[dict]] = None
+
+    def __post_init__(self):
+        """Validate the container override configuration."""
+        # Validate container name
+        if not self.name or not self.name.strip():
+            raise ValueError("Container name must be a non-empty string")
+
+        if self.env is not None:
+            if not isinstance(self.env, list):
+                raise ValueError("env must be a list of dictionaries")
+            for env_var in self.env:
+                if not isinstance(env_var, dict):
+                    raise ValueError("Each env entry must be a dictionary")
+                if "name" not in env_var:
+                    raise ValueError("Each env entry must have a 'name' key")
+                if not env_var.get("name"):
+                    raise ValueError("env 'name' must be a non-empty string")
+                if "value" not in env_var and "valueFrom" not in env_var:
+                    raise ValueError("Each env entry must have either 'value' or 'valueFrom' key")
+                # Validate valueFrom structure if present
+                if "valueFrom" in env_var:
+                    value_from = env_var["valueFrom"]
+                    if not isinstance(value_from, dict):
+                        raise ValueError("env 'valueFrom' must be a dictionary")
+                    # valueFrom must have one of these keys
+                    valid_keys = {"configMapKeyRef", "secretKeyRef", "fieldRef", "resourceFieldRef"}
+                    if not any(key in value_from for key in valid_keys):
+                        raise ValueError(
+                            f"env 'valueFrom' must contain one of: {', '.join(valid_keys)}"
+                        )
+
+        if self.volume_mounts is not None:
+            if not isinstance(self.volume_mounts, list):
+                raise ValueError("volume_mounts must be a list of dictionaries")
+            for mount in self.volume_mounts:
+                if not isinstance(mount, dict):
+                    raise ValueError("Each volume_mounts entry must be a dictionary")
+                if "name" not in mount:
+                    raise ValueError("Each volume_mounts entry must have a 'name' key")
+                if not mount.get("name"):
+                    raise ValueError("volume_mounts 'name' must be a non-empty string")
+                if "mountPath" not in mount:
+                    raise ValueError("Each volume_mounts entry must have a 'mountPath' key")
+                mount_path = mount.get("mountPath")
+                if not mount_path or not isinstance(mount_path, str):
+                    raise ValueError("volume_mounts 'mountPath' must be a non-empty string")
+                if not mount_path.startswith("/"):
+                    raise ValueError(
+                        f"volume_mounts 'mountPath' must be an absolute path "
+                        f"(start with /): {mount_path}"
+                    )
+
+
+@dataclass
+class PodSpecOverride:
+    """Configuration for overriding pod template specifications.
+
+    Args:
+        service_account_name: Service account to use for the pods.
+        node_selector: Node selector to place pods on specific nodes.
+        affinity: Affinity rules for pod scheduling.
+        tolerations: Tolerations for pod scheduling.
+        volumes: Volumes to add/merge with the pod.
+        init_containers: Init containers to add/merge with the pod.
+        containers: Containers to add/merge with the pod.
+        scheduling_gates: Scheduling gates for the pods.
+        image_pull_secrets: Image pull secrets for the pods.
+    """
+
+    service_account_name: Optional[str] = None
+    node_selector: Optional[dict[str, str]] = None
+    affinity: Optional[dict] = None
+    tolerations: Optional[list[dict]] = None
+    volumes: Optional[list[dict]] = None
+    init_containers: Optional[list[ContainerOverride]] = None
+    containers: Optional[list[ContainerOverride]] = None
+    scheduling_gates: Optional[list[dict]] = None
+    image_pull_secrets: Optional[list[dict]] = None
+
+
+@dataclass
+class PodTemplateOverride:
+    """Configuration for overriding pod templates for specific job types.
+
+    Args:
+        target_jobs: List of job names to apply the overrides to (e.g., ["node", "launcher"]).
+        metadata: Metadata overrides for the pod template (labels, annotations).
+        spec: Spec overrides for the pod template.
+    """
+
+    target_jobs: list[str]
+    metadata: Optional[dict] = None
+    spec: Optional[PodSpecOverride] = None
+
+
+@dataclass
+class Labels:
+    """Add labels to the TrainJob resource metadata (.metadata.labels).
+
+    Supported backends:
+        - Kubernetes
+
+    Args:
+        labels: Dictionary of label key-value pairs to add to TrainJob metadata.
+    """
+
+    labels: dict[str, str]
+
+    def __call__(
+        self,
+        job_spec: dict[str, Any],
+        trainer: Optional[Union[CustomTrainer, BuiltinTrainer]],
+        backend: RuntimeBackend,
+    ) -> None:
+        """Apply labels to the job specification.
+
+        Args:
+            job_spec: Job specification dictionary to modify.
+            trainer: Optional trainer instance for context.
+            backend: Backend instance for validation.
+
+        Raises:
+            ValueError: If backend does not support labels.
+        """
+        from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"Labels option is not compatible with {type(backend).__name__}. "
+                f"Supported backends: KubernetesBackend"
+            )
+
+        metadata = job_spec.setdefault("metadata", {})
+        metadata["labels"] = self.labels
+
+
+@dataclass
+class Annotations:
+    """Add annotations to the TrainJob resource metadata (.metadata.annotations).
+
+    Supported backends:
+        - Kubernetes
+
+    Args:
+        annotations: Dictionary of annotation key-value pairs to add to TrainJob metadata.
+    """
+
+    annotations: dict[str, str]
+
+    def __call__(
+        self,
+        job_spec: dict[str, Any],
+        trainer: Optional[Union[CustomTrainer, BuiltinTrainer]],
+        backend: RuntimeBackend,
+    ) -> None:
+        """Apply annotations to the job specification.
+
+        Args:
+            job_spec: Job specification dictionary to modify.
+            trainer: Optional trainer instance for context.
+            backend: Backend instance for validation.
+
+        Raises:
+            ValueError: If backend does not support annotations.
+        """
+        from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"Annotations option is not compatible with {type(backend).__name__}. "
+                f"Supported backends: KubernetesBackend"
+            )
+
+        metadata = job_spec.setdefault("metadata", {})
+        metadata["annotations"] = self.annotations
+
+
+@dataclass
+class SpecLabels:
+    """Add labels to derivative JobSet and Jobs (.spec.labels).
+
+    These labels will be merged with the TrainingRuntime values and applied to
+    the JobSet and Jobs created by the TrainJob.
+
+    Supported backends:
+        - Kubernetes
+
+    Args:
+        labels: Dictionary of label key-value pairs to add to JobSet and Jobs.
+    """
+
+    labels: dict[str, str]
+
+    def __call__(
+        self,
+        job_spec: dict[str, Any],
+        trainer: Optional[Union[CustomTrainer, BuiltinTrainer]],
+        backend: RuntimeBackend,
+    ) -> None:
+        """Apply spec-level labels to the job specification.
+
+        Args:
+            job_spec: Job specification dictionary to modify.
+            trainer: Optional trainer instance for context.
+            backend: Backend instance for validation.
+
+        Raises:
+            ValueError: If backend does not support spec labels.
+        """
+        from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"SpecLabels option is not compatible with {type(backend).__name__}. "
+                f"Supported backends: KubernetesBackend"
+            )
+
+        spec = job_spec.setdefault("spec", {})
+        spec["labels"] = self.labels
+
+
+@dataclass
+class SpecAnnotations:
+    """Add annotations to derivative JobSet and Jobs (.spec.annotations).
+
+    These annotations will be merged with the TrainingRuntime values and applied to
+    the JobSet and Jobs created by the TrainJob.
+
+    Supported backends:
+        - Kubernetes
+
+    Args:
+        annotations: Dictionary of annotation key-value pairs to add to JobSet and Jobs.
+    """
+
+    annotations: dict[str, str]
+
+    def __call__(
+        self,
+        job_spec: dict[str, Any],
+        trainer: Optional[Union[CustomTrainer, BuiltinTrainer]],
+        backend: RuntimeBackend,
+    ) -> None:
+        """Apply spec-level annotations to the job specification.
+
+        Args:
+            job_spec: Job specification dictionary to modify.
+            trainer: Optional trainer instance for context.
+            backend: Backend instance for validation.
+
+        Raises:
+            ValueError: If backend does not support spec annotations.
+        """
+        from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"SpecAnnotations option is not compatible with {type(backend).__name__}. "
+                f"Supported backends: KubernetesBackend"
+            )
+
+        spec = job_spec.setdefault("spec", {})
+        spec["annotations"] = self.annotations
+
+
+class PodTemplateOverrides:
+    """Add pod template overrides to the TrainJob (.spec.podTemplateOverrides).
+
+    Supported backends:
+        - Kubernetes
+
+    Args:
+        *overrides: One or more PodTemplateOverride objects.
+    """
+
+    def __init__(self, *overrides: PodTemplateOverride):
+        """Initialize with variable number of PodTemplateOverride objects."""
+        if not overrides:
+            raise ValueError("At least one PodTemplateOverride must be provided")
+        self.pod_overrides = list(overrides)
+
+    def __call__(
+        self,
+        job_spec: dict[str, Any],
+        trainer: Optional[Union[CustomTrainer, BuiltinTrainer]],
+        backend: RuntimeBackend,
+    ) -> None:
+        """Apply pod template overrides to the job specification.
+
+        Args:
+            job_spec: Job specification dictionary to modify.
+            trainer: Optional trainer instance for context.
+            backend: Backend instance for validation.
+
+        Raises:
+            ValueError: If backend does not support pod template overrides.
+        """
+        from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"PodTemplateOverrides option is not compatible with {type(backend).__name__}. "
+                f"Supported backends: KubernetesBackend"
+            )
+        spec = job_spec.setdefault("spec", {})
+        pod_overrides = spec.setdefault("podTemplateOverrides", [])
+
+        for override in self.pod_overrides:
+            api_override = {"targetJobs": [{"name": job} for job in override.target_jobs]}
+
+            if override.metadata:
+                api_override["metadata"] = override.metadata
+
+            if override.spec:
+                spec_dict = {}
+
+                if override.spec.service_account_name:
+                    spec_dict["serviceAccountName"] = override.spec.service_account_name
+                if override.spec.node_selector:
+                    spec_dict["nodeSelector"] = override.spec.node_selector
+                if override.spec.affinity:
+                    spec_dict["affinity"] = override.spec.affinity
+                if override.spec.tolerations:
+                    spec_dict["tolerations"] = override.spec.tolerations
+                if override.spec.volumes:
+                    spec_dict["volumes"] = override.spec.volumes
+                if override.spec.scheduling_gates:
+                    spec_dict["schedulingGates"] = override.spec.scheduling_gates
+                if override.spec.image_pull_secrets:
+                    spec_dict["imagePullSecrets"] = override.spec.image_pull_secrets
+
+                # Handle container overrides
+                if override.spec.init_containers:
+                    spec_dict["initContainers"] = []
+                    for container in override.spec.init_containers:
+                        container_dict = {"name": container.name}
+                        if container.env:
+                            container_dict["env"] = container.env
+                        if container.volume_mounts:
+                            container_dict["volumeMounts"] = container.volume_mounts
+                        spec_dict["initContainers"].append(container_dict)
+
+                if override.spec.containers:
+                    spec_dict["containers"] = []
+                    for container in override.spec.containers:
+                        container_dict = {"name": container.name}
+                        if container.env:
+                            container_dict["env"] = container.env
+                        if container.volume_mounts:
+                            container_dict["volumeMounts"] = container.volume_mounts
+                        spec_dict["containers"].append(container_dict)
+
+                if spec_dict:
+                    api_override["spec"] = spec_dict
+
+            pod_overrides.append(api_override)
+
+
+@dataclass
+class TrainerCommand:
+    """Override the trainer container command (.spec.trainer.command).
+
+    Can only be used with CustomTrainerContainer. CustomTrainer generates its own
+    command from the function, and BuiltinTrainer uses pre-configured commands.
+
+    Supported backends:
+        - Kubernetes
+
+    Args:
+        command: List of command strings to override the default trainer command.
+    """
+
+    command: list[str]
+
+    def __call__(
+        self,
+        job_spec: dict[str, Any],
+        trainer: Optional[Union[CustomTrainer, BuiltinTrainer, CustomTrainerContainer]],
+        backend: RuntimeBackend,
+    ) -> None:
+        """Apply trainer command override to the job specification.
+
+        Args:
+            job_spec: The job specification to modify.
+            trainer: Optional trainer context for validation.
+            backend: Backend instance for validation.
+
+        Raises:
+            ValueError: If backend doesn't support or trainer type conflicts.
+        """
+        from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"TrainerCommand option is not compatible with {type(backend).__name__}. "
+                f"Supported backends: KubernetesBackend"
+            )
+
+        if trainer is not None and not isinstance(trainer, CustomTrainerContainer):
+            raise ValueError(
+                "TrainerCommand can only be used with CustomTrainerContainer. "
+                "CustomTrainer generates its own command from the function, and "
+                "BuiltinTrainer uses pre-configured commands."
+            )
+
+        spec = job_spec.setdefault("spec", {})
+        trainer_spec = spec.setdefault("trainer", {})
+        trainer_spec["command"] = self.command
+
+
+@dataclass
+class TrainerArgs:
+    """Override the trainer container arguments (.spec.trainer.args).
+
+    Can only be used with CustomTrainerContainer. CustomTrainer generates its own
+    arguments from the function, and BuiltinTrainer uses pre-configured arguments.
+
+    Supported backends:
+        - Kubernetes
+
+    Args:
+        args: List of argument strings to override the default trainer arguments.
+    """
+
+    args: list[str]
+
+    def __call__(
+        self,
+        job_spec: dict[str, Any],
+        trainer: Optional[Union[CustomTrainer, BuiltinTrainer, CustomTrainerContainer]],
+        backend: RuntimeBackend,
+    ) -> None:
+        """Apply trainer args override to the job specification.
+
+        Args:
+            job_spec: The job specification to modify.
+            trainer: Optional trainer context for validation.
+            backend: Backend instance for validation.
+
+        Raises:
+            ValueError: If backend doesn't support or trainer type conflicts.
+        """
+        from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"TrainerArgs option is not compatible with {type(backend).__name__}. "
+                f"Supported backends: KubernetesBackend"
+            )
+
+        if trainer is not None and not isinstance(trainer, CustomTrainerContainer):
+            raise ValueError(
+                "TrainerArgs can only be used with CustomTrainerContainer. "
+                "CustomTrainer generates its own arguments from the function, and "
+                "BuiltinTrainer uses pre-configured arguments."
+            )
+
+        spec = job_spec.setdefault("spec", {})
+        trainer_spec = spec.setdefault("trainer", {})
+        trainer_spec["args"] = self.args

--- a/kubeflow/trainer/options/kubernetes_test.py
+++ b/kubeflow/trainer/options/kubernetes_test.py
@@ -1,0 +1,259 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Kubernetes options."""
+
+import pytest
+
+from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend
+from kubeflow.trainer.backends.localprocess.backend import LocalProcessBackend
+from kubeflow.trainer.options import (
+    Annotations,
+    ContainerOverride,
+    Labels,
+    Name,
+    PodTemplateOverride,
+    PodTemplateOverrides,
+    SpecAnnotations,
+    SpecLabels,
+    TrainerArgs,
+    TrainerCommand,
+)
+
+
+@pytest.fixture
+def mock_kubernetes_backend():
+    """Mock Kubernetes backend for testing."""
+    from unittest.mock import Mock
+
+    backend = Mock(spec=KubernetesBackend)
+    backend.__class__ = KubernetesBackend
+    return backend
+
+
+@pytest.fixture
+def mock_localprocess_backend():
+    """Mock LocalProcess backend for testing."""
+    from unittest.mock import MagicMock
+
+    # Create a proper mock that isinstance checks will work with
+    backend = MagicMock(spec=LocalProcessBackend)
+    # Make type(backend).__name__ return the correct class name
+    type(backend).__name__ = "LocalProcessBackend"
+    return backend
+
+
+class TestKubernetesOptionBackendValidation:
+    """Test that Kubernetes options validate backend compatibility."""
+
+    @pytest.mark.parametrize(
+        "option_class,option_args",
+        [
+            (Labels, {"app": "test", "version": "v1"}),
+            (Annotations, {"description": "test job"}),
+            (SpecLabels, {"app": "training"}),
+            (SpecAnnotations, {"prometheus.io/scrape": "true"}),
+            (TrainerCommand, ["python", "train.py"]),
+            (TrainerArgs, ["--epochs", "10"]),
+        ],
+    )
+    def test_kubernetes_options_reject_wrong_backend(
+        self, option_class, option_args, mock_localprocess_backend
+    ):
+        """Test Kubernetes-specific options reject non-Kubernetes backends."""
+        if option_class == TrainerCommand:
+            option = option_class(command=option_args)
+        elif option_class == TrainerArgs:
+            option = option_class(args=option_args)
+        else:
+            option = option_class(option_args)
+
+        job_spec = {}
+
+        with pytest.raises(ValueError) as exc_info:
+            option(job_spec, None, mock_localprocess_backend)
+
+        assert "not compatible with" in str(exc_info.value)
+        assert "LocalProcessBackend" in str(exc_info.value)
+
+    def test_pod_template_overrides_rejects_wrong_backend(self, mock_localprocess_backend):
+        """Test PodTemplateOverrides rejects non-Kubernetes backends."""
+        override = PodTemplateOverride(target_jobs=["node"])
+        option = PodTemplateOverrides(override)
+
+        job_spec = {}
+
+        with pytest.raises(ValueError) as exc_info:
+            option(job_spec, None, mock_localprocess_backend)
+
+        assert "not compatible with" in str(exc_info.value)
+
+
+class TestKubernetesOptionApplication:
+    """Test Kubernetes option application behavior."""
+
+    @pytest.mark.parametrize(
+        "option_class,option_args,expected_spec",
+        [
+            (
+                Labels,
+                {"app": "test", "version": "v1"},
+                {"metadata": {"labels": {"app": "test", "version": "v1"}}},
+            ),
+            (
+                Annotations,
+                {"description": "test job"},
+                {"metadata": {"annotations": {"description": "test job"}}},
+            ),
+            (
+                SpecLabels,
+                {"app": "training", "version": "v1.0"},
+                {"spec": {"labels": {"app": "training", "version": "v1.0"}}},
+            ),
+            (
+                SpecAnnotations,
+                {"prometheus.io/scrape": "true"},
+                {"spec": {"annotations": {"prometheus.io/scrape": "true"}}},
+            ),
+            (Name, "custom-job-name", {"metadata": {"name": "custom-job-name"}}),
+            (
+                TrainerCommand,
+                ["python", "train.py"],
+                {"spec": {"trainer": {"command": ["python", "train.py"]}}},
+            ),
+            (
+                TrainerArgs,
+                ["--epochs", "10"],
+                {"spec": {"trainer": {"args": ["--epochs", "10"]}}},
+            ),
+        ],
+    )
+    def test_option_application(
+        self, option_class, option_args, expected_spec, mock_kubernetes_backend
+    ):
+        """Test each option applies correctly to job spec with Kubernetes backend."""
+        if option_class == TrainerCommand:
+            option = option_class(command=option_args)
+        elif option_class == TrainerArgs:
+            option = option_class(args=option_args)
+        else:
+            option = option_class(option_args)
+
+        job_spec = {}
+        option(job_spec, None, mock_kubernetes_backend)
+
+        assert job_spec == expected_spec
+
+
+class TestTrainerOptionValidation:
+    """Test validation of trainer-specific options."""
+
+    @pytest.mark.parametrize(
+        "option_class,option_args,trainer_type,should_fail",
+        [
+            # Validation failures
+            (TrainerCommand, ["python", "train.py"], "CustomTrainer", True),
+            (TrainerArgs, ["--epochs", "10"], "CustomTrainer", True),
+            (TrainerCommand, ["python", "train.py"], "BuiltinTrainer", True),
+            (TrainerArgs, ["--epochs", "10"], "BuiltinTrainer", True),
+            # Successful applications
+            (TrainerCommand, ["python", "train.py"], "CustomTrainerContainer", False),
+            (TrainerArgs, ["--epochs", "10"], "CustomTrainerContainer", False),
+        ],
+    )
+    def test_trainer_option_validation(
+        self, option_class, option_args, trainer_type, should_fail, mock_kubernetes_backend
+    ):
+        """Test trainer option validation with different trainer types."""
+        from kubeflow.trainer.types.types import (
+            BuiltinTrainer,
+            CustomTrainer,
+            CustomTrainerContainer,
+            TorchTuneConfig,
+        )
+
+        # Create appropriate trainer instance
+        if trainer_type == "CustomTrainer":
+
+            def dummy_func():
+                pass
+
+            trainer = CustomTrainer(func=dummy_func)
+        elif trainer_type == "BuiltinTrainer":
+            trainer = BuiltinTrainer(config=TorchTuneConfig())
+        else:  # CustomTrainerContainer
+            trainer = CustomTrainerContainer(image="custom-image:latest")
+
+        # Create option
+        if option_class == TrainerCommand:
+            option = option_class(command=option_args)
+        else:  # TrainerArgs
+            option = option_class(args=option_args)
+
+        job_spec = {}
+
+        if should_fail:
+            with pytest.raises(ValueError) as exc_info:
+                option(job_spec, trainer, mock_kubernetes_backend)
+            assert "TrainerCommand can only be used with CustomTrainerContainer" in str(
+                exc_info.value
+            ) or "TrainerArgs can only be used with CustomTrainerContainer" in str(exc_info.value)
+        else:
+            option(job_spec, trainer, mock_kubernetes_backend)
+            if option_class == TrainerCommand:
+                assert job_spec["spec"]["trainer"]["command"] == option_args
+            else:
+                assert job_spec["spec"]["trainer"]["args"] == option_args
+
+
+class TestContainerOverride:
+    """Test ContainerOverride validation."""
+
+    @pytest.mark.parametrize(
+        "kwargs,expected_error",
+        [
+            ({"name": ""}, "Container name must be a non-empty string"),
+            (
+                {"name": "trainer", "env": [{"invalid": "structure"}]},
+                "Each env entry must have a 'name' key",
+            ),
+            (
+                {"name": "trainer", "volume_mounts": [{"name": "vol"}]},
+                "Each volume_mounts entry must have a 'mountPath' key",
+            ),
+        ],
+    )
+    def test_container_override_validation(self, kwargs, expected_error):
+        """Test ContainerOverride validates inputs correctly."""
+        with pytest.raises(ValueError) as exc_info:
+            ContainerOverride(**kwargs)
+        assert expected_error in str(exc_info.value)
+
+
+class TestPodTemplateOverrides:
+    """Test PodTemplateOverrides functionality."""
+
+    def test_pod_template_overrides_basic(self, mock_kubernetes_backend):
+        """Test basic PodTemplateOverrides application."""
+
+        override = PodTemplateOverride(target_jobs=["node"])
+        option = PodTemplateOverrides(override)
+
+        job_spec = {}
+        option(job_spec, None, mock_kubernetes_backend)
+
+        assert "spec" in job_spec
+        assert "podTemplateOverrides" in job_spec["spec"]
+        assert len(job_spec["spec"]["podTemplateOverrides"]) == 1
+        assert job_spec["spec"]["podTemplateOverrides"][0]["targetJobs"] == [{"name": "node"}]

--- a/kubeflow/trainer/options/localprocess.py
+++ b/kubeflow/trainer/options/localprocess.py
@@ -1,0 +1,20 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LocalProcess-specific training options for the Kubeflow Trainer SDK.
+
+TODO: Add LocalProcess options (ProcessTimeout, WorkingDirectory, etc.) in future iteration.
+"""
+
+# TODO: Implement LocalProcess options using LocalProcessCompatible base class


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes https://github.com/kubeflow/sdk/issues/87, https://github.com/kubeflow/sdk/issues/92, https://github.com/kubeflow/sdk/issues/116

QuickStart :
```
from kubeflow.trainer import TrainerClient, CustomTrainer
from kubeflow.trainer.options import Name, Labels

client = TrainerClient()
client.train(
    runtime=client.get_runtime("torch-distributed"),
    trainer=CustomTrainer(func=my_function),
    options=[
        Name(name="my-job"),
        Labels(labels={"team": "ml"})
    ]
)
``` 

Common Options:
```
from kubeflow.trainer.options import Name

```

Kubernetes Options
```
from kubeflow.trainer.options.kubernetes import (
    Name,        #JobName
    Labels,              # Job metadata labels
    Annotations,         # Job metadata annotations
    SpecLabels,          # Labels for pods/jobsets
    SpecAnnotations,     # Annotations for pods/jobsets
    PodTemplateOverrides,  # Pod customization
    TrainerCommand,      # Override container command (CustomTrainerContainer only)
    TrainerArgs,         # Override container args (CustomTrainerContainer only)
)
```

Basic config:
```
from kubeflow.trainer.options import Name, Labels

options=[
    Name(name="my-job"),
    Labels(labels={"team": "ml-team", "project": "nlp"})
]
```

Custom container specific options:
```
from kubeflow.trainer.options import TrainerCommand, TrainerArgs

options=[
    TrainerCommand(["python", "-m", "torch.distributed.run"]),
    TrainerArgs(["train.py", "--epochs=10"])
]
```

Pod customisation : 
```
from kubeflow.trainer.options import (
    PodTemplateOverride,
    PodTemplateOverrides,
    PodSpecOverride
)

options=[
    PodTemplateOverrides(
        PodTemplateOverride(
            target_jobs=["node"],
            spec=PodSpecOverride(
                node_selector={"gpu-type": "a100"},
                volumes=[{
                    "name": "data",
                    "persistentVolumeClaim": {"claimName": "my-data"}
                }]
            )
        )
    )
]
```

Creating custom options:
```
from dataclasses import dataclass
from typing import Any, Optional

@dataclass
class MyCustomOption:
    """My custom option for Kubernetes jobs."""
    
    timeout_seconds: int
    
    def __call__(self, job_spec: dict[str, Any], trainer, backend) -> None:
        # Validate backend compatibility
        from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend
        if not isinstance(backend, KubernetesBackend):
            raise ValueError("MyCustomOption only works with Kubernetes")
        
        # Apply your changes
        spec = job_spec.setdefault("spec", {})
        spec["activeDeadlineSeconds"] = self.timeout_seconds

client.train(
    trainer=my_trainer,
    options=[MyCustomOption(timeout_seconds=3600)]
)
```

Overrides: 

PodTemplateOverride Fields
```
PodTemplateOverride(
    target_jobs=["node", "launcher"],  # Which pods to apply to
    metadata={...},                     # Pod labels/annotations
    spec=PodSpecOverride(...)          # Pod spec customizations
)
```

PodSpecOverride Fields
```
PodSpecOverride(
    service_account_name="...",
    node_selector={...},
    tolerations=[...],
    affinity={...},
    volumes=[...],
    init_containers=[...],
    containers=[...],
    scheduling_gates=[...],
    image_pull_secrets=[...]
)
```

ContainerOverride Fields
```
ContainerOverride(
    name="trainer",
    env=[...],
    volume_mounts=[...]
)
```


**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
