### PR TITLE
feat: add optional name parameter to training client's train() method…

### DIFF
--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -93,6 +93,7 @@ class TrainerClient:
         runtime: Optional[types.Runtime] = None,
         initializer: Optional[types.Initializer] = None,
         trainer: Optional[Union[types.CustomTrainer, types.BuiltinTrainer]] = None,
+        name: Optional[str] = None,
     ) -> str:
         """Create a TrainJob. You can configure the TrainJob using one of these trainers:
 
@@ -107,6 +108,7 @@ class TrainerClient:
             initializer: Optional configuration for the dataset and model initializers.
             trainer: Optional configuration for a CustomTrainer or BuiltinTrainer. If not specified,
                 the TrainJob will use the runtime's default values.
+            name: Optional name for the TrainJob. If not provided, a unique name will be generated.
 
         Returns:
             The unique name of the TrainJob that has been generated.
@@ -116,7 +118,9 @@ class TrainerClient:
             TimeoutError: Timeout to create TrainJobs.
             RuntimeError: Failed to create TrainJobs.
         """
-        return self.backend.train(runtime=runtime, initializer=initializer, trainer=trainer)
+        return self.backend.train(
+            runtime=runtime, initializer=initializer, trainer=trainer, name=name
+        )
 
     def list_jobs(self, runtime: Optional[types.Runtime] = None) -> list[types.TrainJob]:
         """List of the created TrainJobs. If a runtime is specified, only TrainJobs associated with

--- a/kubeflow/trainer/backends/base.py
+++ b/kubeflow/trainer/backends/base.py
@@ -34,6 +34,7 @@ class ExecutionBackend(abc.ABC):
         runtime: Optional[types.Runtime] = None,
         initializer: Optional[types.Initializer] = None,
         trainer: Optional[Union[types.CustomTrainer, types.BuiltinTrainer]] = None,
+        name: Optional[str] = None,
     ) -> str:
         raise NotImplementedError()
 

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -55,6 +55,28 @@ class KubernetesBackend(ExecutionBackend):
 
         self.namespace = cfg.namespace
 
+    def _validate_train_job_name(self, name: str) -> None:
+        """Validate train job name according to Kubernetes naming conventions.
+
+        Args:
+            name: The train job name to validate.
+
+        Raises:
+            ValueError: If the name doesn't meet Kubernetes naming requirements.
+        """
+        if not name:
+            raise ValueError("Train job name cannot be empty")
+
+        if len(name) > 63:
+            raise ValueError("Train job name must be 63 characters or less")
+
+        # Kubernetes DNS-1123 subdomain name validation
+        if not re.match(r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$', name):
+            raise ValueError(
+                "Train job name must consist of lower case alphanumeric characters "
+                "or '-', and must start and end with an alphanumeric character"
+            )
+
     def list_runtimes(self) -> list[types.Runtime]:
         result = []
         try:
@@ -181,13 +203,18 @@ class KubernetesBackend(ExecutionBackend):
         runtime: Optional[types.Runtime] = None,
         initializer: Optional[types.Initializer] = None,
         trainer: Optional[Union[types.CustomTrainer, types.BuiltinTrainer]] = None,
+        name: Optional[str] = None,
     ) -> str:
         if runtime is None:
             runtime = self.get_runtime(constants.TORCH_RUNTIME)
 
-        # Generate unique name for the TrainJob.
-        # TODO (andreyvelich): Discuss this TrainJob name generation.
-        train_job_name = random.choice(string.ascii_lowercase) + uuid.uuid4().hex[:11]
+        # Use provided name or generate unique name for the TrainJob.
+        if name is not None:
+            self._validate_train_job_name(name)
+            train_job_name = name
+        else:
+            # TODO (andreyvelich): Discuss this TrainJob name generation.
+            train_job_name = random.choice(string.ascii_lowercase) + uuid.uuid4().hex[:11]
 
         # Build the Trainer.
         trainer_crd = models.TrainerV1alpha1Trainer()

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -1079,3 +1079,84 @@ def test_delete_job(kubernetes_backend, test_case):
     except Exception as e:
         assert type(e) is test_case.expected_error
     print("test execution complete")
+
+
+def test_train_with_custom_name(kubernetes_backend):
+    """Test KubernetesBackend.train with custom name."""
+    kubernetes_backend.namespace = DEFAULT_NAMESPACE
+    runtime = kubernetes_backend.get_runtime(TORCH_RUNTIME)
+
+    custom_name = "my-custom-training-job"
+    trainer = types.CustomTrainer(func=lambda: print("training"))
+
+    train_job_name = kubernetes_backend.train(
+        runtime=runtime, trainer=trainer, name=custom_name
+    )
+
+    assert train_job_name == custom_name
+
+    # Verify the custom object was created with the custom name
+    kubernetes_backend.custom_api.create_namespaced_custom_object.assert_called_once()
+    call_args = kubernetes_backend.custom_api.create_namespaced_custom_object.call_args
+    # The object is passed as the last positional argument
+    created_object = call_args[0][-1]
+    assert created_object['metadata']['name'] == custom_name
+
+
+def test_train_with_auto_generated_name(kubernetes_backend):
+    """Test KubernetesBackend.train with auto-generated name."""
+    kubernetes_backend.namespace = DEFAULT_NAMESPACE
+    runtime = kubernetes_backend.get_runtime(TORCH_RUNTIME)
+
+    trainer = types.CustomTrainer(func=lambda: print("training"))
+
+    train_job_name = kubernetes_backend.train(runtime=runtime, trainer=trainer)
+
+    # Verify name was auto-generated (12 characters: 1 letter + 11 hex)
+    assert len(train_job_name) == 12
+    assert train_job_name[0].islower() and train_job_name[0].isalpha()
+
+    # Verify the custom object was created with the generated name
+    kubernetes_backend.custom_api.create_namespaced_custom_object.assert_called_once()
+    call_args = kubernetes_backend.custom_api.create_namespaced_custom_object.call_args
+    # The object is passed as the last positional argument
+    created_object = call_args[0][-1]
+    assert created_object['metadata']['name'] == train_job_name
+
+
+@pytest.mark.parametrize("invalid_name,expected_error", [
+    ("", "Train job name cannot be empty"),
+    ("My-Invalid-Name", "must consist of lower case alphanumeric characters"),
+    ("invalid_name", "must consist of lower case alphanumeric characters"),
+    ("invalid-name-", "must start and end with an alphanumeric character"),
+    ("-invalid-name", "must start and end with an alphanumeric character"),
+    ("a" * 64, "must be 63 characters or less"),
+    ("invalid.name", "must consist of lower case alphanumeric characters"),
+])
+def test_train_job_name_validation(kubernetes_backend, invalid_name, expected_error):
+    """Test train job name validation with various invalid names."""
+    kubernetes_backend.namespace = DEFAULT_NAMESPACE
+    runtime = kubernetes_backend.get_runtime(TORCH_RUNTIME)
+    trainer = types.CustomTrainer(func=lambda: print("training"))
+
+    with pytest.raises(ValueError, match=expected_error):
+        kubernetes_backend.train(runtime=runtime, trainer=trainer, name=invalid_name)
+
+
+@pytest.mark.parametrize("valid_name", [
+    "valid-name",
+    "valid123",
+    "123valid",
+    "a",
+    "valid-name-123",
+    "a" * 63,  # Maximum length
+])
+def test_train_job_name_validation_valid_names(kubernetes_backend, valid_name):
+    """Test train job name validation with valid names."""
+    kubernetes_backend.namespace = DEFAULT_NAMESPACE
+    runtime = kubernetes_backend.get_runtime(TORCH_RUNTIME)
+    trainer = types.CustomTrainer(func=lambda: print("training"))
+
+    # Should not raise any exception
+    train_job_name = kubernetes_backend.train(runtime=runtime, trainer=trainer, name=valid_name)
+    assert train_job_name == valid_name


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
- The Train backend API was intentionally designed to only support auto-generated names. 
- Custom names for trainjob improves job identification and management
- Meaningful names are useful for tracking and debugging

**Which issue(s) this PR fixes** 

Partially fixes https://github.com/kubeflow/sdk/issues/84
- Added the name parameter to train method to allow specifying name for a trainjob
- Added proper Kubernetes name validation
- Supporting both custom names AND auto-generation
- Added unit tests for the same

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
