### PR TITLE
Kubeflow SDK Official Release 0.1.0rc1

### DIFF
--- a/kubeflow/__init__.py
+++ b/kubeflow/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.0"
+__version__ = "0.1.0rc1"


### PR DESCRIPTION
Cutting Kubeflow SDK `0.1.0rc1` release. This will trigger automatic release workflow

cc @andreyvelich @astefanutti @briangallagher @szaher @Electronic-Waste 
/hold for review and https://github.com/kubeflow/sdk/pull/65
