### PR TITLE
chore: Ignore PRs titles with area/release labels in CI

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -40,3 +40,4 @@ jobs:
           ignoreLabels: |
             do-not-merge/work-in-progress
             dependencies
+            area/release


### PR DESCRIPTION
We should ignore titles for PRs with `area/release` labels so that we can title release PRs as `Kubeflow SDK Official Release 0.1.0rc1 `

/assign @andreyvelich 