### PR TITLE
chore(docs): Add Spark Operator to the future supported projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ print("\n".join(TrainerClient().get_job_logs(name=job_id)))
 | **Kubeflow Katib**          | 🚧 Planned       | TBD             | Hyperparameter optimization                                          |
 | **Kubeflow Pipelines**      | 🚧 Planned       | TBD             | Build, run, and track AI workflows                                   |
 | **Kubeflow Model Registry** | 🚧 Planned       | TBD             | Manage model artifacts, versions and ML artifacts metadata           |
-| **Kubeflow Spark Operator** | 🚧 Planned       | TBD             | Mange Spark applications for data processing and feature engineering |
+| **Kubeflow Spark Operator** | 🚧 Planned       | TBD             | Manage Spark applications for data processing and feature engineering |
 
 ## Community
 


### PR DESCRIPTION
Given our recent discussions to support SparkApplication within Kubeflow SDK, it would be nice to add it to the README.
And it looks like there is some interest: https://github.com/kubeflow/sdk/issues/107


/hold for review

/assign @kubeflow/kubeflow-sdk-team 

/cc @vara-bonthu @franciscojavierarceo @Shekharrajak @nabuskey @ChenYi015 @CrashCumber