### PR TITLE
feat(trainer): add s3 initializers, add `ignore_patterns` to hf initializers

### DIFF
--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -277,10 +277,40 @@ class TrainJob:
 # TODO (andreyvelich): Discuss how to keep these configurations is sync with pkg.initializers.types
 @dataclass
 class HuggingFaceDatasetInitializer:
-    """Configuration for downloading datasets from HuggingFace Hub."""
+    """Configuration for downloading datasets from HuggingFace Hub.
+
+    Args:
+        storage_uri (`str`): The HuggingFace Hub model identifier in the format 'hf://username/repo_name'.
+        ignore_patterns (`Optional[list[str]]`): List of file patterns to ignore during download.
+        access_token (`Optional[str]`): HuggingFace Hub access token for private datasets.
+    """
 
     storage_uri: str
+    ignore_patterns: Optional[list[str]] = None
     access_token: Optional[str] = None
+
+
+@dataclass
+class S3DatasetInitializer:
+    """Configuration for downloading datasets from S3-compatible storage.
+
+    Args:
+        storage_uri (`str`): The S3 URI for the model in the format 's3://bucket-name/path/to/model'.
+        ignore_patterns (`Optional[list[str]]`): List of file patterns to ignore during download.
+        endpoint (`Optional[str]`): Custom S3 endpoint URL.
+        access_key_id (`Optional[str]`): Access key for authentication.
+        secret_access_key (`Optional[str]`): Secret key for authentication.
+        region (`Optional[str]`): Region used in instantiating the client.
+        role_arn (`Optional[str]`): The ARN of the role you want to assume.
+    """
+
+    storage_uri: str
+    ignore_patterns: Optional[list[str]] = None
+    endpoint: Optional[str] = None
+    access_key_id: Optional[str] = None
+    secret_access_key: Optional[str] = None
+    region: Optional[str] = None
+    role_arn: Optional[str] = None
 
 
 @dataclass
@@ -332,8 +362,43 @@ class DataCacheInitializer:
 # Configuration for the HuggingFace model initializer.
 @dataclass
 class HuggingFaceModelInitializer:
+    """Configuration for downloading models from HuggingFace Hub.
+
+    Args:
+        storage_uri (`str`): The HuggingFace Hub model identifier in the format 'hf://username/repo_name'.
+        ignore_patterns (`Optional[list[str]]`): List of file patterns to ignore during download.
+        access_token (`Optional[str]`): HuggingFace Hub access token.
+    """
+
     storage_uri: str
+    ignore_patterns: Optional[list[str]] = None
     access_token: Optional[str] = None
+
+
+@dataclass
+class S3ModelInitializer:
+    """Configuration for downloading models from S3-compatible storage.
+
+    Args:
+        storage_uri (`str`): The S3 URI for the model in the format 's3://bucket-name/path/to/model'.
+        ignore_patterns (`Optional[list[str]]`): List of file patterns to ignore during download.
+            Defaults to `['*.msgpack', '*.h5', '*.bin', '.pt', '.pth']`.
+        endpoint (`Optional[str]`): Custom S3 endpoint URL.
+        access_key_id (`Optional[str]`): Access key for authentication.
+        secret_access_key (`Optional[str]`): Secret key for authentication.
+        region (`Optional[str]`): Region used in instantiating the client.
+        role_arn (`Optional[str]`): The ARN of the role you want to assume.
+    """
+
+    storage_uri: str
+    ignore_patterns: Optional[list[str]] = field(
+        default_factory=lambda: ["*.msgpack", "*.h5", "*.bin", ".pt", ".pth"]
+    )
+    endpoint: Optional[str] = None
+    access_key_id: Optional[str] = None
+    secret_access_key: Optional[str] = None
+    region: Optional[str] = None
+    role_arn: Optional[str] = None
 
 
 @dataclass
@@ -341,14 +406,16 @@ class Initializer:
     """Initializer defines configurations for dataset and pre-trained model initialization
 
     Args:
-        dataset (`Optional[Union[HuggingFaceDatasetInitializer, DataCacheInitializer]]`):
+        dataset (`Optional[Union[HuggingFaceDatasetInitializer, S3DatasetInitializer, DataCacheInitializer]]`):
             The configuration for one of the supported dataset initializers.
-        model (`Optional[HuggingFaceModelInitializer]`): The configuration for one of the
-            supported model initializers.
-    """
+        model (`Optional[Union[HuggingFaceModelInitializer, S3ModelInitializer]]`):
+            The configuration for one of the supported model initializers.
+    """  # noqa: E501
 
-    dataset: Optional[Union[HuggingFaceDatasetInitializer, DataCacheInitializer]] = None
-    model: Optional[HuggingFaceModelInitializer] = None
+    dataset: Optional[
+        Union[HuggingFaceDatasetInitializer, S3DatasetInitializer, DataCacheInitializer]
+    ] = None
+    model: Optional[Union[HuggingFaceModelInitializer, S3ModelInitializer]] = None
 
 
 # TODO (andreyvelich): Add train() and optimize() methods to this class.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR is a follow-up to kubeflow/trainer#2728.

It adds type definitions for the S3 model and dataset initializers. Additionally, it adds `ignore_patterns` to HF initializers and complements the docstrings of types.

/cc @andreyvelich @astefanutti @Electronic-Waste @kramaranya @szaher @kubeflow/kubeflow-sdk-team

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Crossref kubeflow/trainer#2728

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
