### PR TITLE
fix: add --user when install python packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Kubeflow Trainer client supports local development without needing a Kubernetes 
 ### Available Backends
 
 - **KubernetesBackend** (default) - Production training on Kubernetes
-- **ContainerBackend** - Local development with Docker/Podman isolation  
+- **ContainerBackend** - Local development with Docker/Podman isolation
 - **LocalProcessBackend** - Quick prototyping with Python subprocesses
 
 **Quick Start:**

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -217,6 +217,7 @@ def get_custom_trainer(
     """
     pip_command = [f"--index-url {pip_index_urls[0]}"]
     pip_command.extend([f"--extra-index-url {repo}" for repo in pip_index_urls[1:]])
+    pip_command.append("--user")
     pip_command = " ".join(pip_command)
 
     packages_command = " ".join(packages_to_install)

--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -247,9 +247,8 @@ def get_script_for_python_packages(
     # first url will be the index-url.
     options = [f"--index-url {pip_index_urls[0]}"]
     options.extend(f"--extra-index-url {extra_index_url}" for extra_index_url in pip_index_urls[1:])
-    # For the OpenMPI, the packages must be installed for the mpiuser.
-    if is_mpi:
-        options.append("--user")
+    # Always install for the user to avoid permission issues across environments.
+    options.append("--user")
 
     header_script = textwrap.dedent(
         """

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -54,7 +54,7 @@ def _build_runtime() -> types.Runtime:
                 "--no-warn-script-location --index-url https://pypi.org/simple "
                 "--extra-index-url https://private.repo.com/simple "
                 "--extra-index-url https://internal.company.com/simple "
-                "torch numpy custom-package\n"
+                "--user torch numpy custom-package\n"
             ),
         ),
         TestCase(
@@ -71,7 +71,7 @@ def _build_runtime() -> types.Runtime:
                 "fi\n\n"
                 "PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --quiet "
                 "--no-warn-script-location --index-url https://pypi.org/simple "
-                "torch numpy custom-package\n"
+                "--user torch numpy custom-package\n"
             ),
         ),
         TestCase(
@@ -111,7 +111,7 @@ def _build_runtime() -> types.Runtime:
                 "fi\n\n"
                 "PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --quiet "
                 f"--no-warn-script-location --index-url "
-                f"{constants.DEFAULT_PIP_INDEX_URLS[0]} torch numpy\n"
+                f"{constants.DEFAULT_PIP_INDEX_URLS[0]} --user torch numpy\n"
             ),
         ),
     ],

--- a/kubeflow/trainer/backends/localprocess/constants.py
+++ b/kubeflow/trainer/backends/localprocess/constants.py
@@ -43,7 +43,7 @@ local_runtimes = [
 # The exec script to embed training function into container command.
 DEPENDENCIES_SCRIPT = textwrap.dedent(
     """
-        PIP_DISABLE_PIP_VERSION_CHECK=1 pip install $QUIET \
+        PIP_DISABLE_PIP_VERSION_CHECK=1 pip install $QUIET --user \
     --no-warn-script-location $PIP_INDEX $PACKAGE_STR
     """
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Add --user argument when installing additional python packages to ensure avoid permissions errors when the container is running as non root

Fixes #135 

