### PR TITLE
feat(ci): add workflow to approve GitHub actions with ok-to-test label

### DIFF
--- a/.github/workflows/gh-workflow-approve.yaml
+++ b/.github/workflows/gh-workflow-approve.yaml
@@ -1,0 +1,69 @@
+name: Approve Workflow Runs
+
+permissions:
+  actions: write
+  contents: read
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  ok-to-test:
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test') || github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Check if author is a Kubeflow GitHub member
+        id: membership-check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const username = context.payload.pull_request.user.login;
+            const org = context.repo.owner;
+            try {
+              const res = await github.rest.orgs.checkMembershipForUser({
+                org,
+                username
+              });
+              core.setOutput("is_member", true);
+            } catch (error) {
+              if (error.status === 404) {
+                // User is not a member
+                core.setOutput("is_member", false);
+              } else {
+                throw error;
+              }
+            }
+
+      - name: Approve Pending Workflow Runs
+        if: steps.membership-check.outputs.is_member == 'true' || contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+        uses: actions/github-script@v7
+        with:
+          retries: 3
+          script: |
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: "pull_request",
+              status: "action_required",
+              head_sha: context.payload.pull_request.head.sha,
+            }
+            core.info(`Getting workflow runs that need approval for commit ${request.head_sha}`)
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, request)
+            core.info(`Found ${runs.length} workflow runs that need approval`)
+            for (const run of runs) {
+              core.info(`Approving workflow run ${run.id}`)
+              const request = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              }
+              await github.rest.actions.approveWorkflowRun(request)
+            }


### PR DESCRIPTION
## Description

Adds a new GitHub workflow to automatically approve workflow runs for pull requests based on contributor membership and manual approval.

## Changes

- Created `.github/workflows/gh-workflow-approve.yaml` workflow
- Automatically approves workflow runs for Kubeflow organization members
- Requires `ok-to-test` label for external contributor PRs to run workflows

## How It Works

**For Kubeflow members:**
- Workflows run automatically without manual intervention
- Membership is checked via GitHub API

**For external contributors:**
- Workflows require manual approval via the `ok-to-test` label
- Maintainers add the label to approve and run pending workflows

## Security Benefits

- Prevents malicious code execution from untrusted sources
- Provides gating mechanism for external contributions
- Follows the same pattern as [kubeflow/trainer](https://github.com/kubeflow/trainer/blob/master/.github/workflows/gh-workflow-approve.yaml)

## Testing

- [ ] Verified YAML syntax is valid
- [ ] Confirmed permissions are correctly scoped (`actions: write`, `contents: read`)
- [ ] Tested with Kubeflow member PR (auto-approval)
- [ ] Tested with external contributor PR (manual approval via label)

Closes #137