### PR TITLE
fix: Support custom images in ClusterTrainingRuntime for container backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Kubeflow Trainer client supports local development without needing a Kubernetes 
 ### Available Backends
 
 - **KubernetesBackend** (default) - Production training on Kubernetes
-- **ContainerBackend** - Local development with Docker/Podman isolation  
+- **ContainerBackend** - Local development with Docker/Podman isolation
 - **LocalProcessBackend** - Quick prototyping with Python subprocesses
 
 **Quick Start:**

--- a/kubeflow/trainer/backends/container/utils.py
+++ b/kubeflow/trainer/backends/container/utils.py
@@ -152,7 +152,11 @@ def aggregate_status_from_containers(container_statuses: list[str]) -> str:
 
 def resolve_image(runtime: types.Runtime) -> str:
     """
-    Resolve the container image for a runtime from DEFAULT_FRAMEWORK_IMAGES.
+    Resolve the container image for a runtime.
+
+    Priority:
+    1. Use runtime.image if specified in the ClusterTrainingRuntime
+    2. Fall back to DEFAULT_FRAMEWORK_IMAGES based on framework
 
     Args:
         runtime: Runtime object.
@@ -163,6 +167,11 @@ def resolve_image(runtime: types.Runtime) -> str:
     Raises:
         ValueError: If no image is found for the runtime's framework.
     """
+    # Use image from runtime if specified
+    if runtime.image:
+        return runtime.image
+
+    # Fall back to default framework images
     framework = runtime.trainer.framework
     if framework in constants.DEFAULT_FRAMEWORK_IMAGES:
         return constants.DEFAULT_FRAMEWORK_IMAGES[framework]

--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -250,6 +250,7 @@ class Runtime:
     name: str
     trainer: RuntimeTrainer
     pretrained_model: Optional[str] = None
+    image: Optional[str] = None
 
 
 # Representation for the TrainJob steps.


### PR DESCRIPTION

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
While testing use of a custom image in the container backend I noticed that the image was not being used and instead the default one was being picked up. This PR will fix this and ensure that the TrainingRuntimeSource will correctly use the image specified in the users ClusterTrainingRuntime yaml.

cc @andreyvelich @astefanutti @kramaranya 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
