### PR TITLE
fix(trainer): Remove --user flag from packages install in local subprocess

### DIFF
--- a/kubeflow/trainer/backends/localprocess/constants.py
+++ b/kubeflow/trainer/backends/localprocess/constants.py
@@ -47,7 +47,7 @@ local_runtimes = [
 # The exec script to embed training function into container command.
 DEPENDENCIES_SCRIPT = textwrap.dedent(
     """
-        PIP_DISABLE_PIP_VERSION_CHECK=1 pip install $QUIET --user \
+        PIP_DISABLE_PIP_VERSION_CHECK=1 pip install $QUIET \
     --no-warn-script-location $PIP_INDEX $PACKAGE_STR
     """
 )

--- a/kubeflow/trainer/backends/localprocess/utils.py
+++ b/kubeflow/trainer/backends/localprocess/utils.py
@@ -150,7 +150,7 @@ def get_local_runtime_trainer(
 
 def get_dependencies_command(
     runtime_packages: list[str],
-    pip_index_urls: str,
+    pip_index_urls: list[str],
     trainer_packages: list[str],
     quiet: bool = True,
 ) -> str:


### PR DESCRIPTION
As we discussed, local subprocess fails when packages install with `--user` flag.

cc @kubeflow/kubeflow-sdk-team 
