### PR TITLE
feat(trainer): Add local notebook examples to E2E

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -41,6 +41,9 @@ jobs:
 
           echo "Installing Kubeflow SDK locally"
           pip install .
+
+          echo "Installing Kubeflow SDK with Docker support for local notebooks"
+          pip install '.[docker]'
         working-directory: . # Ensure pip runs from the SDK repo root
 
       - name: Setup cluster
@@ -62,6 +65,14 @@ jobs:
           make test-e2e-notebook \
             NOTEBOOK_INPUT=./examples/pytorch/question-answering/fine-tune-distilbert.ipynb \
             NOTEBOOK_OUTPUT=../artifacts/notebooks/${{ matrix.kubernetes-version }}_fine-tune-distilbert.ipynb \
+            PAPERMILL_TIMEOUT=900
+          make test-e2e-notebook \
+            NOTEBOOK_INPUT=./examples/local/local-container-mnist.ipynb \
+            NOTEBOOK_OUTPUT=../artifacts/notebooks/${{ matrix.kubernetes-version }}_local-container-mnist.ipynb \
+            PAPERMILL_TIMEOUT=900
+          make test-e2e-notebook \
+            NOTEBOOK_INPUT=./examples/local/local-training-mnist.ipynb \
+            NOTEBOOK_OUTPUT=../artifacts/notebooks/${{ matrix.kubernetes-version }}_local-training-mnist.ipynb \
             PAPERMILL_TIMEOUT=900
         working-directory: . # Execute make from the root of the SDK repo
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Following on from https://github.com/kubeflow/trainer/pull/2907 I am adding the new notebooks to the E2Es here on the SDK as per this [comment](https://github.com/kubeflow/trainer/pull/2907#pullrequestreview-3424732377). 

@andreyvelich 

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
