### PR TITLE
fix: pip install with --user argument fails with image running in python virtual environment

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -22,7 +22,6 @@ It tests KubernetesBackend's behavior across job listing, resource creation etc
 from dataclasses import asdict
 import datetime
 import multiprocessing
-import os
 import random
 import string
 from typing import Optional
@@ -218,15 +217,12 @@ def get_custom_trainer(
     env: Optional[list[models.IoK8sApiCoreV1EnvVar]] = None,
     pip_index_urls: Optional[list[str]] = constants.DEFAULT_PIP_INDEX_URLS,
     packages_to_install: list[str] = ["torch", "numpy"],
-    add_user: bool = False,
 ) -> models.TrainerV1alpha1Trainer:
     """
     Get the custom trainer for the TrainJob.
     """
     pip_command = [f"--index-url {pip_index_urls[0]}"]
     pip_command.extend([f"--extra-index-url {repo}" for repo in pip_index_urls[1:]])
-    if add_user:
-        pip_command.append("--user")
     pip_command = " ".join(pip_command)
 
     packages_command = " ".join(packages_to_install)
@@ -236,7 +232,10 @@ def get_custom_trainer(
             "-c",
             '\nif ! [ -x "$(command -v pip)" ]; then\n    python -m ensurepip '
             "|| python -m ensurepip --user || apt-get install python-pip"
-            "\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --quiet"
+            "\nfi\n\n"
+            "PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --quiet"
+            f" --no-warn-script-location {pip_command} --user {packages_command}"
+            " ||\nPIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --quiet"
             f" --no-warn-script-location {pip_command} {packages_command}"
             "\n\nread -r -d '' SCRIPT << EOM\n\nfunc=lambda: "
             'print("Hello World"),\n\n<lambda>(**'
@@ -802,31 +801,6 @@ def test_get_runtime_packages(kubernetes_backend, test_case):
                 train_job_trainer=get_custom_trainer(
                     pip_index_urls=constants.DEFAULT_PIP_INDEX_URLS,
                     packages_to_install=["torch", "numpy"],
-                    add_user=False,
-                ),
-            ),
-        ),
-        TestCase(
-            name="valid flow with custom trainer (append --user)",
-            expected_status=SUCCESS,
-            config={
-                "trainer": types.CustomTrainer(
-                    func=lambda: print("Hello World"),
-                    func_args={"learning_rate": 0.001, "batch_size": 32},
-                    packages_to_install=["torch", "numpy"],
-                    pip_index_urls=constants.DEFAULT_PIP_INDEX_URLS,
-                    num_nodes=2,
-                ),
-                "virt_env": False,
-                "euid": 1000,
-            },
-            expected_output=get_train_job(
-                runtime_name=TORCH_RUNTIME,
-                train_job_name=TRAIN_JOB_WITH_CUSTOM_TRAINER,
-                train_job_trainer=get_custom_trainer(
-                    pip_index_urls=constants.DEFAULT_PIP_INDEX_URLS,
-                    packages_to_install=["torch", "numpy"],
-                    add_user=True,
                 ),
             ),
         ),
@@ -856,7 +830,6 @@ def test_get_runtime_packages(kubernetes_backend, test_case):
                     ],
                     pip_index_urls=constants.DEFAULT_PIP_INDEX_URLS,
                     packages_to_install=["torch", "numpy"],
-                    add_user=False,
                 ),
             ),
         ),
@@ -988,39 +961,11 @@ def test_train(kubernetes_backend, test_case):
 
         options = test_case.config.get("options", [])
 
-        # Exercise real logic: control VIRTUAL_ENV and euid to trigger append_user behavior
-        virt_env = test_case.config.get("virt_env", None)
-        euid = test_case.config.get("euid", None)
-        if virt_env is not None or euid is not None:
-            if virt_env:
-                with (
-                    patch.dict(os.environ, {"VIRTUAL_ENV": "1"}, clear=False),
-                    patch("os.geteuid", return_value=(euid if euid is not None else 0)),
-                ):
-                    train_job_name = kubernetes_backend.train(
-                        runtime=runtime,
-                        trainer=test_case.config.get("trainer", None),
-                        options=options,
-                    )
-            else:
-                with (
-                    patch.dict(os.environ, {}, clear=False),
-                    patch("os.geteuid", return_value=(euid if euid is not None else 0)),
-                    patch("kubeflow.trainer.backends.kubernetes.utils.sys.prefix", "base"),
-                    patch("kubeflow.trainer.backends.kubernetes.utils.sys.base_prefix", "base"),
-                ):
-                    os.environ.pop("VIRTUAL_ENV", None)
-                    train_job_name = kubernetes_backend.train(
-                        runtime=runtime,
-                        trainer=test_case.config.get("trainer", None),
-                        options=options,
-                    )
-        else:
-            train_job_name = kubernetes_backend.train(
-                runtime=runtime,
-                trainer=test_case.config.get("trainer", None),
-                options=options,
-            )
+        train_job_name = kubernetes_backend.train(
+            runtime=runtime,
+            trainer=test_case.config.get("trainer", None),
+            options=options,
+        )
 
         assert test_case.expected_status == SUCCESS
 

--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -15,7 +15,6 @@
 from dataclasses import fields
 import inspect
 import os
-import sys
 import textwrap
 from typing import Any, Callable, Optional, Union
 from urllib.parse import urlparse
@@ -239,7 +238,6 @@ def get_resources_per_node(
 def get_script_for_python_packages(
     packages_to_install: list[str],
     pip_index_urls: list[str],
-    is_mpi: bool,
 ) -> str:
     """
     Get init script to install Python packages from the given pip index URLs.
@@ -249,9 +247,6 @@ def get_script_for_python_packages(
     # first url will be the index-url.
     options = [f"--index-url {pip_index_urls[0]}"]
     options.extend(f"--extra-index-url {extra_index_url}" for extra_index_url in pip_index_urls[1:])
-    # Add --user when appropriate.
-    if append_user(is_mpi):
-        options.append("--user")
 
     header_script = textwrap.dedent(
         """
@@ -265,6 +260,11 @@ def get_script_for_python_packages(
     script_for_python_packages = (
         header_script
         + "PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --quiet "
+        + "--no-warn-script-location {} --user {}".format(
+            " ".join(options),
+            packages_str,
+        )
+        + " ||\nPIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --quiet "
         + "--no-warn-script-location {} {}\n".format(
             " ".join(options),
             packages_str,
@@ -272,37 +272,6 @@ def get_script_for_python_packages(
     )
 
     return script_for_python_packages
-
-
-def append_user(is_mpi: bool) -> bool:
-    """
-    Decide whether to append '--user' to pip install options.
-    - Always true for MPI (containers often run as non-root users like 'mpiuser').
-    - Also true when running as non-root AND not inside a virtual environment.
-    """
-    return is_mpi or (not is_root_user() and not is_running_in_venv())
-
-
-def is_root_user() -> bool:
-    try:
-        return os.geteuid() == 0  # type: ignore[attr-defined]
-    except AttributeError:
-        # Platforms without geteuid (e.g., Windows). Treat as non-root.
-        return False
-
-
-def is_running_in_venv() -> bool:
-    return (
-        # In a venv, sys.prefix points to the venv path and differs from the interpreter's
-        # installation prefix (sys.base_prefix). This is the canonical CPython signal.
-        sys.prefix != sys.base_prefix
-        # Older virtualenvs (and some tooling) set sys.real_prefix to the original
-        # interpreter prefix; its presence implies we're inside a virtual environment.
-        or hasattr(sys, "real_prefix")
-        # Activation scripts commonly export the VIRTUAL_ENV environment variable.
-        # If present, it's a strong indicator that a venv/virtualenv is active.
-        or ("VIRTUAL_ENV" in os.environ)
-    )
 
 
 def get_command_using_train_func(
@@ -360,7 +329,6 @@ def get_command_using_train_func(
         install_packages = get_script_for_python_packages(
             packages_to_install,
             pip_index_urls,
-            is_mpi,
         )
 
     # Add function code to the Trainer command.

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-from unittest.mock import patch
-
 import pytest
 
 import kubeflow.trainer.backends.kubernetes.utils as utils
@@ -58,7 +55,12 @@ def _build_runtime() -> types.Runtime:
                 "--no-warn-script-location --index-url https://pypi.org/simple "
                 "--extra-index-url https://private.repo.com/simple "
                 "--extra-index-url https://internal.company.com/simple "
-                "--user torch numpy custom-package\n"
+                "--user torch numpy custom-package ||\n"
+                "PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --quiet "
+                "--no-warn-script-location --index-url https://pypi.org/simple "
+                "--extra-index-url https://private.repo.com/simple "
+                "--extra-index-url https://internal.company.com/simple "
+                "torch numpy custom-package\n"
             ),
         ),
         TestCase(
@@ -75,7 +77,10 @@ def _build_runtime() -> types.Runtime:
                 "fi\n\n"
                 "PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --quiet "
                 "--no-warn-script-location --index-url https://pypi.org/simple "
-                "--user torch numpy custom-package\n"
+                "--user torch numpy custom-package ||\n"
+                "PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --quiet "
+                "--no-warn-script-location --index-url https://pypi.org/simple "
+                "torch numpy custom-package\n"
             ),
         ),
         TestCase(
@@ -98,7 +103,12 @@ def _build_runtime() -> types.Runtime:
                 "--no-warn-script-location --index-url https://pypi.org/simple "
                 "--extra-index-url https://private.repo.com/simple "
                 "--extra-index-url https://internal.company.com/simple "
-                "--user torch numpy custom-package\n"
+                "--user torch numpy custom-package ||\n"
+                "PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --quiet "
+                "--no-warn-script-location --index-url https://pypi.org/simple "
+                "--extra-index-url https://private.repo.com/simple "
+                "--extra-index-url https://internal.company.com/simple "
+                "torch numpy custom-package\n"
             ),
         ),
         TestCase(
@@ -115,26 +125,20 @@ def _build_runtime() -> types.Runtime:
                 "fi\n\n"
                 "PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --quiet "
                 f"--no-warn-script-location --index-url "
-                f"{constants.DEFAULT_PIP_INDEX_URLS[0]} --user torch numpy\n"
+                f"{constants.DEFAULT_PIP_INDEX_URLS[0]} --user torch numpy ||\n"
+                "PIP_DISABLE_PIP_VERSION_CHECK=1 python -m pip install --quiet "
+                f"--no-warn-script-location --index-url "
+                f"{constants.DEFAULT_PIP_INDEX_URLS[0]} torch numpy\n"
             ),
         ),
     ],
 )
 def test_get_script_for_python_packages(test_case):
     """Test get_script_for_python_packages with various configurations."""
-    # Simulate a non-virtualenv, non-root environment so append_user returns True for non-MPI.
-    with (
-        patch.dict(os.environ, {}, clear=False),
-        patch("os.geteuid", return_value=1000),
-        patch("kubeflow.trainer.backends.kubernetes.utils.sys.prefix", "base"),
-        patch("kubeflow.trainer.backends.kubernetes.utils.sys.base_prefix", "base"),
-    ):
-        os.environ.pop("VIRTUAL_ENV", None)
-        script = utils.get_script_for_python_packages(
-            packages_to_install=test_case.config["packages_to_install"],
-            pip_index_urls=test_case.config["pip_index_urls"],
-            is_mpi=test_case.config["is_mpi"],
-        )
+    script = utils.get_script_for_python_packages(
+        packages_to_install=test_case.config["packages_to_install"],
+        pip_index_urls=test_case.config["pip_index_urls"],
+    )
 
     assert test_case.expected_output == script
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
pip install with --user argument fails with image running in python virtual environment

I've added some conditions to adding the **--user** argument on pip install 
Currently we add **--user** for all pip installs
I've reverted the previous condition that was in place i.e. an mpi job
And I've added 2 additional conditions:
1. **Not** in a virtual environment **and**
2. **Not** root user

**Which issue(s) this PR fixes**
Fixes # 161

