### PR TITLE
fix(trainer): Use PyTorch static rendezvous in container backend

### DIFF
--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -356,7 +356,7 @@ class ContainerBackend(RuntimeBackend):
                     f"TRAINING_SCRIPT_EOF\n"
                     "if command -v torchrun >/dev/null 2>&1; then "
                     f"  torchrun --nproc_per_node={nproc_per_node} --nnodes={num_nodes} "
-                    f"  --node-rank={rank} --rdzv-backend=c10d "
+                    f"  --node-rank={rank} --rdzv-backend=static "
                     f"  --rdzv-endpoint={master_addr}:{master_port} "
                     f"  /tmp/train.py; "
                     "else "


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes the container backend to use PyTorch distributed static rendezvous otherwise `--node-rank` is not taken into account by torchrun:  

https://github.com/pytorch/pytorch/blob/1df723e6f5a09b2be2f3d69add2800280daad0aa/torch/distributed/run.py#L869

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #167 

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
