### PR TITLE
fix(ci): Move permissions to the workflow root

### DIFF
--- a/.github/workflows/welcome-new-contributors.yaml
+++ b/.github/workflows/welcome-new-contributors.yaml
@@ -8,12 +8,13 @@ on:
     types:
       - opened
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   welcome:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      issues: write
     steps:
       - uses: actions/first-interaction@v3
         with:


### PR DESCRIPTION
I moved permissions to the workflow root in welcome new contributors ci.
This should fix https://github.com/kubeflow/sdk/actions/runs/19663698755

/assign @kubeflow/kubeflow-sdk-team 