### PR TITLE
Kubeflow SDK Official Release 0.2.1

### DIFF
--- a/CHANGELOG/CHANGELOG-0.2.md
+++ b/CHANGELOG/CHANGELOG-0.2.md
@@ -1,3 +1,17 @@
+# [0.2.1](https://github.com/kubeflow/sdk/releases/tag/0.2.1) (2025-11-25)
+
+## New Features
+
+- feat(docs): Update README with announcement blog post ([#157](https://github.com/kubeflow/sdk/pull/157)) by @andreyvelich
+
+## Bug Fixes
+
+- fix(ci): Move permissions to the workflow root ([#177](https://github.com/kubeflow/sdk/pull/177)) by @kramaranya
+- fix: pip install with --user argument fails with image running in python virtual environment ([#162](https://github.com/kubeflow/sdk/pull/162)) by @briangallagher
+- fix(trainer): Remove namespace from ClusterTrainingRuntime exception messages ([#166](https://github.com/kubeflow/sdk/pull/166)) by @astefanutti
+- fix(trainer): Use PyTorch static rendezvous in container backend ([#168](https://github.com/kubeflow/sdk/pull/168)) by @astefanutti
+- fix(trainer): Fix listing containers with Podman backend ([#154](https://github.com/kubeflow/sdk/pull/154)) by @astefanutti
+
 # [0.2.0](https://github.com/kubeflow/sdk/releases/tag/0.2.0) (2025-11-06)
 
 ## New Features

--- a/kubeflow/__init__.py
+++ b/kubeflow/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
This is an Official Release of Kubeflow SDK 0.2.1
https://github.com/kubeflow/sdk/issues/120

/assign @kubeflow/kubeflow-sdk-team
/area release