### PR TITLE
feat: wait for pod to be running when follow=True in get_job_logs

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -352,8 +352,8 @@ class KubernetesBackend(RuntimeBackend):
         if pod_name is None and follow:
             import time
 
-            timeout = 120     # seconds
-            interval = 2      # seconds
+            timeout = 120  # seconds
+            interval = 2  # seconds
             waited = 0
 
             while waited < timeout:


### PR DESCRIPTION


This PR implements the behavior requested in issue #182.

Previously, trainer.get_job_logs(job_id, follow=True) exited immediately if the pod did not yet exist or was still pending. This made it difficult for users to follow logs immediately after submitting a job, because pods are usually created asynchronously.

What this PR adds

When follow=True, the backend now waits for the pod to be created and to leave the Pending state.
Added a simple polling loop with:
timeout: 120 seconds
poll interval: 2 seconds
Preserves old behavior for follow=False, returning immediately if no pod exists.
No API changes, fully backward compatible.

Why this is needed

Users commonly want to follow logs right after submitting a TrainingJob.
With the previous behavior, they needed to implement custom waiting logic.
This PR aligns the trainer experience with typical Kubernetes log-following behavior.

Testing

All existing tests pass (162 passed).
No breaking changes.
Local manual tests done.

Fixes #182.