### PR TITLE
chore(ci): add 'docs' type to PR title check for documentation PRs

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -28,6 +28,7 @@ jobs:
             fix
             feat
             revert
+            docs
 
           scopes: |
             ci


### PR DESCRIPTION
This PR adds 'docs' type to the PR title semantic check workflow.
This ensures future documentation PRs will not fail due to title validation. 

fixes #192 
