### PR TITLE
feat: #195 Add callbacks to the wait_for_job_status() API

### DIFF
--- a/kubeflow/optimizer/api/optimizer_client.py
+++ b/kubeflow/optimizer/api/optimizer_client.py
@@ -14,7 +14,7 @@
 
 from collections.abc import Iterator
 import logging
-from typing import Any, Optional
+from typing import Any, Optional,Callable
 
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.optimizer.backends.kubernetes.backend import KubernetesBackend
@@ -183,6 +183,7 @@ class OptimizerClient:
         self,
         name: str,
         status: set[str] = {constants.OPTIMIZATION_JOB_COMPLETE},
+        callback: Optional[Callable] = None,
         timeout: int = 3600,
         polling_interval: int = 2,
     ) -> OptimizationJob:
@@ -192,6 +193,8 @@ class OptimizerClient:
             name: Name of the OptimizationJob.
             status: Expected statuses. Must be a subset of Created, Running, Complete, and
                 Failed statuses.
+            callback: Callback function that is invoked after Job status is polled. This 
+                function takes a single argument which is current Job object.    
             timeout: Maximum number of seconds to wait for the OptimizationJob to reach one of the
                 expected statuses.
             polling_interval: The polling interval in seconds to check OptimizationJob status.
@@ -209,6 +212,7 @@ class OptimizerClient:
             name=name,
             status=status,
             timeout=timeout,
+            callback=callback,
             polling_interval=polling_interval,
         )
 

--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -14,7 +14,7 @@
 
 from collections.abc import Iterator
 import logging
-from typing import Optional, Union
+from typing import Optional, Union,Callable
 
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.trainer.backends.container.backend import ContainerBackend
@@ -213,6 +213,7 @@ class TrainerClient:
         self,
         name: str,
         status: set[str] = {constants.TRAINJOB_COMPLETE},
+        callback: Optional[Callable] = None,
         timeout: int = 600,
         polling_interval: int = 2,
     ) -> types.TrainJob:
@@ -222,6 +223,8 @@ class TrainerClient:
             name: Name of the TrainJob.
             status: Expected statuses. Must be a subset of Created, Running, Complete, and
                 Failed statuses.
+            callback: Callback function that is invoked after Job status is polled. This 
+                 function takes a single argument which is current Job object.
             timeout: Maximum number of seconds to wait for the TrainJob to reach one of the
                 expected statuses.
             polling_interval: The polling interval in seconds to check TrainJob status.
@@ -238,6 +241,7 @@ class TrainerClient:
             name=name,
             status=status,
             timeout=timeout,
+            callback=callback,
             polling_interval=polling_interval,
         )
 

--- a/kubeflow/trainer/backends/base.py
+++ b/kubeflow/trainer/backends/base.py
@@ -14,7 +14,7 @@
 
 import abc
 from collections.abc import Iterator
-from typing import Optional, Union
+from typing import Optional, Union ,Callable
 
 from kubeflow.trainer.constants import constants
 from kubeflow.trainer.types import types
@@ -73,6 +73,7 @@ class RuntimeBackend(abc.ABC):
         name: str,
         status: set[str] = {constants.TRAINJOB_COMPLETE},
         timeout: int = 600,
+        callback: Optional[Callable] = None,
         polling_interval: int = 2,
     ) -> types.TrainJob:
         raise NotImplementedError()

--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -44,7 +44,7 @@ import os
 import random
 import shutil
 import string
-from typing import Optional, Union
+from typing import Optional, Union,Callable
 import uuid
 
 from kubeflow.trainer.backends.base import RuntimeBackend
@@ -612,6 +612,7 @@ class ContainerBackend(RuntimeBackend):
         name: str,
         status: set[str] = {constants.TRAINJOB_COMPLETE},
         timeout: int = 600,
+        callback: Optional[Callable] = None,
         polling_interval: int = 2,
     ) -> types.TrainJob:
         import time
@@ -620,6 +621,9 @@ class ContainerBackend(RuntimeBackend):
         while time.time() < end:
             tj = self.get_job(name)
             logger.debug(f"TrainJob {name}, status {tj.status}")
+            # Execute callback function is it is set.
+            if callback:
+                callback(tj)
             if tj.status in status:
                 return tj
             if constants.TRAINJOB_FAILED not in status and tj.status == constants.TRAINJOB_FAILED:

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -20,7 +20,7 @@ import random
 import re
 import string
 import time
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, Callable
 import uuid
 
 from kubeflow_trainer_api import models
@@ -352,6 +352,7 @@ class KubernetesBackend(RuntimeBackend):
         status: set[str] = {constants.TRAINJOB_COMPLETE},
         timeout: int = 600,
         polling_interval: int = 2,
+        callback: Callable = None,
     ) -> types.TrainJob:
         job_statuses = {
             constants.TRAINJOB_CREATED,
@@ -371,6 +372,10 @@ class KubernetesBackend(RuntimeBackend):
             # Check the status after event is generated for the TrainJob's Pods.
             trainjob = self.get_job(name)
             logger.debug(f"TrainJob {name}, status {trainjob.status}")
+
+            # Execute callback function is it is set.
+            if callback:
+                callback(trainjob)
 
             # Raise an error if TrainJob is Failed and it is not the expected status.
             if (

--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -213,6 +213,7 @@ class LocalProcessBackend(RuntimeBackend):
         name: str,
         status: set[str] = {constants.TRAINJOB_COMPLETE},
         timeout: int = 600,
+        callback: Optional[Callable] = None,
         polling_interval: int = 2,
     ) -> types.TrainJob:
         # find first match or fallback
@@ -226,7 +227,9 @@ class LocalProcessBackend(RuntimeBackend):
                 constants.TRAINJOB_RUNNING,
                 constants.TRAINJOB_CREATED,
             ]:
-                _step.job.join(timeout=timeout)
+             if callback is not None:
+                callback(_step.job)  
+            _step.job.join(timeout=timeout)
         return self.get_job(name)
 
     def delete_job(self, name: str):


### PR DESCRIPTION
#fix
This PR resolves #195 by adding callback support to the wait_for_job_status() API.
With this change, users can hook custom logic into the job status polling loop.

 ### **What’s changed**

* Added optional callback support to wait_for_job_status()
* Updated the following files:

                          1.optimizer_client.py
                          2.trainer_client.py
                          3.base.py
                          4.localprocess/backend.py
                          5.kubernetes/backend.py
                          6.adapters/backend.py

**Why This Change Is Needed**

In the Training Operator v1 SDK users have ability to create custom callback inwait_for_job_conditions() API: https://github.com/kubeflow/trainer/blob/release-1.9/sdk/python/kubeflow/training/api/training_client.py#L1000.

This is very useful when users want to periodically print logs or check status while TrainJob is running.

Fixes https://github.com/kubeflow/sdk/issues/195