### PR TITLE
feat(trainer): Add GPU passthrough support for container backend

### DIFF
--- a/kubeflow/trainer/backends/container/adapters/base.py
+++ b/kubeflow/trainer/backends/container/adapters/base.py
@@ -74,6 +74,7 @@ class BaseContainerClientAdapter(abc.ABC):
         labels: dict[str, str],
         volumes: dict[str, dict[str, str]],
         working_dir: str,
+        gpu_count: Optional[int] = None,
     ) -> str:
         """
         Create and start a container.
@@ -87,6 +88,7 @@ class BaseContainerClientAdapter(abc.ABC):
             labels: Container labels
             volumes: Volume mounts
             working_dir: Working directory
+            gpu_count: Number of GPUs to allocate to the container, or None for no GPU access.
 
         Returns:
             Container ID

--- a/kubeflow/trainer/backends/container/adapters/docker.py
+++ b/kubeflow/trainer/backends/container/adapters/docker.py
@@ -87,8 +87,16 @@ class DockerClientAdapter(BaseContainerClientAdapter):
         labels: dict[str, str],
         volumes: dict[str, dict[str, str]],
         working_dir: str,
+        gpu_count: Optional[int] = None,
     ) -> str:
         """Create and start a Docker container."""
+        import docker.types
+
+        # Configure GPU access via NVIDIA Container Toolkit
+        device_requests = None
+        if gpu_count is not None and gpu_count > 0:
+            device_requests = [docker.types.DeviceRequest(count=gpu_count, capabilities=[["gpu"]])]
+
         container = self.client.containers.run(
             image=image,
             command=tuple(command),
@@ -100,6 +108,7 @@ class DockerClientAdapter(BaseContainerClientAdapter):
             labels=labels,
             volumes=volumes,
             auto_remove=False,
+            device_requests=device_requests,
         )
         return container.id
 

--- a/kubeflow/trainer/backends/container/adapters/podman.py
+++ b/kubeflow/trainer/backends/container/adapters/podman.py
@@ -93,8 +93,15 @@ class PodmanClientAdapter(BaseContainerClientAdapter):
         labels: dict[str, str],
         volumes: dict[str, dict[str, str]],
         working_dir: str,
+        gpu_count: Optional[int] = None,
     ) -> str:
         """Create and start a Podman container."""
+        # Configure GPU access via CDI (Container Device Interface)
+        devices = None
+        if gpu_count is not None and gpu_count > 0:
+            # Request specific number of GPUs by index
+            devices = [f"nvidia.com/gpu={i}" for i in range(gpu_count)]
+
         container = self.client.containers.run(
             image=image,
             command=command,
@@ -106,6 +113,7 @@ class PodmanClientAdapter(BaseContainerClientAdapter):
             volumes=volumes,
             detach=True,
             remove=False,
+            devices=devices,
         )
         return container.id
 

--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -41,6 +41,7 @@ from collections.abc import Callable, Iterator
 from datetime import datetime
 import logging
 import os
+import platform
 import random
 import shutil
 import string
@@ -284,10 +285,22 @@ class ContainerBackend(RuntimeBackend):
             # For GPU training: spawn one process per GPU for optimal utilization
             # For CPU training: use single process (PyTorch parallelizes internally via threads)
             nproc_per_node = 1  # Default for CPU training
+            gpu_count = None  # GPU count for container device passthrough
             if trainer.resources_per_node and "gpu" in trainer.resources_per_node:
                 try:
-                    nproc_per_node = int(trainer.resources_per_node["gpu"])
+                    gpu_count = int(trainer.resources_per_node["gpu"])
+                    nproc_per_node = gpu_count
                     logger.debug(f"Using {nproc_per_node} processes per node (1 per GPU)")
+
+                    # Check for macOS - GPU passthrough is not supported
+                    if platform.system() == "Darwin":
+                        logger.warning(
+                            "GPU passthrough is not supported on macOS. "
+                            "Containers will run without GPU access. "
+                            "To use GPUs, run on a Linux machine with NVIDIA drivers "
+                            "and the NVIDIA Container Toolkit installed."
+                        )
+                        gpu_count = None  # Don't attempt GPU passthrough on macOS
                 except (ValueError, TypeError):
                     logger.warning(
                         f"Invalid GPU count in resources_per_node: "
@@ -391,6 +404,7 @@ class ContainerBackend(RuntimeBackend):
                     labels=labels,
                     volumes=volumes,
                     working_dir=constants.WORKSPACE_PATH,
+                    gpu_count=gpu_count,
                 )
 
                 logger.debug(f"Started container {container_name} (ID: {container_id[:12]})")

--- a/kubeflow/trainer/backends/container/backend_test.py
+++ b/kubeflow/trainer/backends/container/backend_test.py
@@ -74,6 +74,7 @@ class MockContainerAdapter(BaseContainerClientAdapter):
         labels: dict[str, str],
         volumes: dict[str, dict[str, str]],
         working_dir: str,
+        gpu_count: Optional[int] = None,
     ) -> str:
         container_id = f"container-{len(self.containers_created)}"
         self.containers_created.append(
@@ -89,6 +90,7 @@ class MockContainerAdapter(BaseContainerClientAdapter):
                 "working_dir": working_dir,
                 "status": "running",
                 "exit_code": None,
+                "gpu_count": gpu_count,
             }
         )
         return container_id
@@ -861,3 +863,94 @@ def test_create_adapter_error_message_format():
         error_msg = str(exc_info.value)
         assert "Could not connect" in error_msg
         assert "tried:" in error_msg
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="gpu passthrough on linux",
+            expected_status=SUCCESS,
+            config={
+                "platform": "Linux",
+                "resources_per_node": {"gpu": "2"},
+                "expected_gpu_count": 2,
+            },
+        ),
+        TestCase(
+            name="gpu passthrough disabled on macos",
+            expected_status=SUCCESS,
+            config={
+                "platform": "Darwin",
+                "resources_per_node": {"gpu": "2"},
+                "expected_gpu_count": None,  # Should be None on macOS
+            },
+        ),
+        TestCase(
+            name="no gpu specified",
+            expected_status=SUCCESS,
+            config={
+                "platform": "Linux",
+                "resources_per_node": {"cpu": "4"},
+                "expected_gpu_count": None,
+            },
+        ),
+        TestCase(
+            name="gpu passthrough on windows wsl",
+            expected_status=SUCCESS,
+            config={
+                "platform": "Linux",  # WSL2 reports as Linux
+                "resources_per_node": {"gpu": "1"},
+                "expected_gpu_count": 1,
+            },
+        ),
+    ],
+)
+def test_gpu_passthrough(container_backend, test_case):
+    """Test GPU passthrough configuration for containers."""
+    print("Executing test:", test_case.name)
+    try:
+        with patch("platform.system", return_value=test_case.config["platform"]):
+            trainer = types.CustomTrainer(
+                func=simple_train_func,
+                num_nodes=1,
+                resources_per_node=test_case.config.get("resources_per_node"),
+            )
+            runtime = container_backend.get_runtime(constants.DEFAULT_TRAINING_RUNTIME)
+
+            container_backend.train(runtime=runtime, trainer=trainer)
+
+            assert test_case.expected_status == SUCCESS
+            container = container_backend._adapter.containers_created[0]
+            assert container["gpu_count"] == test_case.config["expected_gpu_count"], (
+                f"Expected gpu_count={test_case.config['expected_gpu_count']}, "
+                f"got gpu_count={container['gpu_count']}"
+            )
+
+    except Exception as e:
+        assert type(e) is test_case.expected_error
+    print("test execution complete")
+
+
+def test_gpu_multi_node_passthrough(container_backend):
+    """Test GPU passthrough for multi-node training."""
+    print("Executing test: gpu_multi_node_passthrough")
+
+    with patch("platform.system", return_value="Linux"):
+        trainer = types.CustomTrainer(
+            func=simple_train_func,
+            num_nodes=3,
+            resources_per_node={"gpu": "4"},
+        )
+        runtime = container_backend.get_runtime(constants.DEFAULT_TRAINING_RUNTIME)
+
+        container_backend.train(runtime=runtime, trainer=trainer)
+
+        # All 3 nodes should have GPU passthrough configured
+        assert len(container_backend._adapter.containers_created) == 3
+        for container in container_backend._adapter.containers_created:
+            assert container["gpu_count"] == 4, (
+                f"Expected gpu_count=4 for all nodes, got {container['gpu_count']}"
+            )
+
+    print("test execution complete")


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #159

## Changes

- BaseContainerClientAdapter: Added `gpu_count` parameter to `create_and_start_container`
- DockerClientAdapter: Configures GPU access via `device_requests`
- PodmanClientAdapter: Configures GPU access via `devices` parameter
- ContainerBackend: Extracts GPU count from `resources_per_node`, handles macOS warning
- Tests: Added 5 test cases covering GPU passthrough scenarios

**Checklist:**

- [x] All  pass (make test-python)
- [x] Linting passes (make verify)
- [x] Documentation added (docstrings for new parameters)
- [x] Tests cover new functionality
- [x] No breaking changes to public APIs (backward compatible - gpu_count is optional)
- [x] Tested locally with both runtimes (docker, podman) on NVIDIA GPU (Turning arch)


Things to mention in docs relating to gpu compatability in containers: 
  - Docker: Install NVIDIA Container Toolkit (nvidia-ctk runtime configure --runtime=docker)
  - Podman: CDI  (configured by default with NVIDIA Container Toolkit v1.12.0+)
  - Linux and Windows via wsl2 only: macOS users will see a warning that GPU passthrough is unavailable
  - RHEL/Fedora users with SELinux enforcing may need to run with --security-opt=label=disable if they encounter NVML: Insufficient Permissions errors. according [to](RHEL/Fedora users with SELinux enforcing may need to run with --security-opt=label=disable if they encounter NVML: Insufficient Permissions errors.)

**Relevant sources:**
https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/index.html
https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html
https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/cdi-support.html
https://podman-desktop.io/docs/podman/gpu
