### PR TITLE
feat: Ensure Control Plane Availability During Kubeflow SDK Client Creation 

### DIFF
--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -66,6 +66,8 @@ class TrainerClient:
         else:
             raise ValueError(f"Invalid backend config '{backend_config}'")
 
+        self.backend.verify_backend()
+
     def list_runtimes(self) -> list[types.Runtime]:
         """List of the available runtimes.
 

--- a/kubeflow/trainer/api/trainer_client_test.py
+++ b/kubeflow/trainer/api/trainer_client_test.py
@@ -70,3 +70,12 @@ def test_backend_selection(test_case):
         client = TrainerClient(backend_config=test_case["backend_config"])
         backend_name = client.backend.__class__.__name__
         assert backend_name == test_case["expected_backend"]
+
+
+def test_verify_backend_called():
+    with patch("kubeflow.trainer.api.trainer_client.KubernetesBackend") as MockBackend:
+        mock_instance = MockBackend.return_value
+        
+        TrainerClient()
+        
+        mock_instance.verify_backend.assert_called_once()

--- a/kubeflow/trainer/backends/base.py
+++ b/kubeflow/trainer/backends/base.py
@@ -30,6 +30,10 @@ class RuntimeBackend(abc.ABC):
     def list_runtimes(self) -> list[types.Runtime]:
         raise NotImplementedError()
 
+    def verify_backend(self) -> None:
+        """Verify that the backend is configured correctly and compatible."""
+        pass
+
     @abc.abstractmethod
     def get_runtime(self, name: str) -> types.Runtime:
         raise NotImplementedError()

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -23,6 +23,7 @@ import time
 from typing import Any, Optional, Union
 import uuid
 
+import kubeflow_trainer_api
 from kubeflow_trainer_api import models
 from kubernetes import client, config, watch
 
@@ -55,6 +56,34 @@ class KubernetesBackend(RuntimeBackend):
         self.core_api = client.CoreV1Api(k8s_client)
 
         self.namespace = cfg.namespace
+
+    def verify_backend(self) -> None:
+        try:
+            config_map = self.core_api.read_namespaced_config_map(
+                name=constants.TRAINER_VERSION_CONFIG_MAP,
+                namespace=constants.KUBEFLOW_NAMESPACE,
+            )
+        except client.ApiException as e:
+            if e.status == 404:
+                logger.warning(
+                    f"ConfigMap '{constants.TRAINER_VERSION_CONFIG_MAP}' not found "
+                    f"in namespace '{constants.KUBEFLOW_NAMESPACE}'. "
+                    "Cannot verify Kubeflow Trainer version compatibility."
+                )
+                return
+            else:
+                raise
+
+        server_version = (config_map.data or {}).get("version")
+        client_version = kubeflow_trainer_api.__version__
+
+        if server_version != client_version:
+            logger.warning(
+                f"Kubeflow Trainer version mismatch. "
+                f"Client version: {client_version}, "
+                f"Server version: {server_version}. "
+                "Some features might not work as expected."
+            )
 
     def list_runtimes(self) -> list[types.Runtime]:
         result = []

--- a/kubeflow/trainer/backends/kubernetes/backend_version_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_version_test.py
@@ -1,0 +1,89 @@
+
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from unittest.mock import MagicMock, patch
+from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend
+from kubeflow.common.types import KubernetesBackendConfig
+from kubeflow.trainer.constants import constants
+import kubeflow_trainer_api
+from kubernetes import client
+import logging
+
+@pytest.fixture
+def backend():
+    # Mock config loading and client creation
+    with patch("kubernetes.config.load_kube_config"), \
+         patch("kubernetes.config.load_incluster_config"), \
+         patch("kubeflow.common.utils.is_running_in_k8s", return_value=False), \
+         patch("kubernetes.client.ApiClient"), \
+         patch("kubernetes.client.CustomObjectsApi"), \
+         patch("kubernetes.client.CoreV1Api") as mock_core_cls:
+        
+        cfg = KubernetesBackendConfig()
+        bk = KubernetesBackend(cfg)
+        # Verify that bk.core_api is the return value of mock_core_cls()
+        # The constructor calls client.CoreV1Api(k8s_client), so the instance is mock_core_cls.return_value
+        yield bk
+
+def test_verify_backend_match(backend, caplog):
+    # Setup mock
+    mock_config_map = MagicMock()
+    mock_config_map.data = {"version": kubeflow_trainer_api.__version__}
+    backend.core_api.read_namespaced_config_map.return_value = mock_config_map
+
+    with caplog.at_level(logging.WARNING):
+        backend.verify_backend()
+    
+    # Assert no warning
+    assert "Kubeflow Trainer version mismatch" not in caplog.text
+    
+    # Verify call arguments
+    backend.core_api.read_namespaced_config_map.assert_called_with(
+        name=constants.TRAINER_VERSION_CONFIG_MAP,
+        namespace=constants.KUBEFLOW_NAMESPACE
+    )
+
+def test_verify_backend_mismatch(backend, caplog):
+    # Setup mock
+    mock_config_map = MagicMock()
+    mock_config_map.data = {"version": "0.0.0"} # Mismatch
+    backend.core_api.read_namespaced_config_map.return_value = mock_config_map
+
+    with caplog.at_level(logging.WARNING):
+        backend.verify_backend()
+
+    # Assert warning
+    assert "Kubeflow Trainer version mismatch" in caplog.text
+    assert "Server version: 0.0.0" in caplog.text
+
+def test_verify_backend_not_found(backend, caplog):
+    # Setup mock to raise 404
+    error = client.ApiException(status=404)
+    backend.core_api.read_namespaced_config_map.side_effect = error
+    
+    with caplog.at_level(logging.WARNING):
+        backend.verify_backend()
+    
+    # Assert warning about not found
+    assert f"ConfigMap '{constants.TRAINER_VERSION_CONFIG_MAP}' not found" in caplog.text
+
+def test_verify_backend_other_error(backend):
+    # Setup mock to raise 500
+    error = client.ApiException(status=500)
+    backend.core_api.read_namespaced_config_map.side_effect = error
+    
+    with pytest.raises(client.ApiException):
+        backend.verify_backend()

--- a/kubeflow/trainer/constants/constants.py
+++ b/kubeflow/trainer/constants/constants.py
@@ -29,6 +29,12 @@ CLUSTER_TRAINING_RUNTIME_PLURAL = "clustertrainingruntimes"
 # The Kind name for the TrainJob.
 TRAINJOB_KIND = "TrainJob"
 
+# The system namespace for the Kubeflow components.
+KUBEFLOW_NAMESPACE = "kubeflow"
+
+# The name of the ConfigMap that contains the Trainer version.
+TRAINER_VERSION_CONFIG_MAP = "kubeflow-trainer-public"
+
 # The plural for the TrainJob.
 TRAINJOB_PLURAL = "trainjobs"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR introduces a verification procedure to ensure that the appropriate version of the control plane is deployed for the corresponding SDK client

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #221 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
