### PR TITLE
fix(trainer): Fix parsing for TrainJob events

### DIFF
--- a/kubeflow/optimizer/backends/kubernetes/backend.py
+++ b/kubeflow/optimizer/backends/kubernetes/backend.py
@@ -346,18 +346,13 @@ class KubernetesBackend(RuntimeBackend):
         events = []
         try:
             # Retrieve events from the namespace
-            event_response = self.core_api.list_namespaced_event(
+            event_response: models.IoK8sApiCoreV1EventList = self.core_api.list_namespaced_event(
                 namespace=self.namespace,
                 async_req=True,
             ).get(common_constants.DEFAULT_TIMEOUT)
 
-            event_list = models.IoK8sApiCoreV1EventList.from_dict(event_response.to_dict())
-
-            if not event_list:
-                return events
-
             # Filter events related to OptimizationJob resources
-            for event in event_list.items:
+            for event in event_response.items:
                 if not (event.metadata and event.involved_object and event.first_timestamp):
                     continue
 

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -427,19 +427,13 @@ class KubernetesBackend(RuntimeBackend):
         events = []
         try:
             # Retrieve events from the namespace
-            event_response = self.core_api.list_namespaced_event(
+            event_response: models.IoK8sApiCoreV1EventList = self.core_api.list_namespaced_event(
                 namespace=self.namespace,
                 async_req=True,
             ).get(common_constants.DEFAULT_TIMEOUT)
 
-            # Convert to event list
-            event_list = models.IoK8sApiCoreV1EventList.from_dict(event_response.to_dict())
-
-            if not event_list:
-                return events
-
             # Filter events related to this TrainJob or its pods
-            for event in event_list.items:
+            for event in event_response.items:
                 if not (event.metadata and event.involved_object and event.first_timestamp):
                     continue
 
@@ -571,6 +565,7 @@ class KubernetesBackend(RuntimeBackend):
             ).get(common_constants.DEFAULT_TIMEOUT)
 
             # Convert Pod to the correct format.
+            # This is required to convert Pod's container resources into API object from str
             pod_list = models.IoK8sApiCoreV1PodList.from_dict(response.to_dict())
             if not pod_list:
                 return trainjob

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -428,28 +428,28 @@ def mock_list_namespaced_event(*args, **kwargs):
                     name="test-event-1",
                     namespace=DEFAULT_NAMESPACE,
                 ),
-                involved_object=models.IoK8sApiCoreV1ObjectReference(
+                involvedObject=models.IoK8sApiCoreV1ObjectReference(
                     kind=constants.TRAINJOB_KIND,
                     name=BASIC_TRAIN_JOB_NAME,
                     namespace=DEFAULT_NAMESPACE,
                 ),
                 message="TrainJob created successfully",
                 reason="Created",
-                first_timestamp=datetime.datetime(2025, 6, 1, 10, 30, 0),
+                firstTimestamp=datetime.datetime(2025, 6, 1, 10, 30, 0),
             ),
             models.IoK8sApiCoreV1Event(
                 metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
                     name="test-event-2",
                     namespace=DEFAULT_NAMESPACE,
                 ),
-                involved_object=models.IoK8sApiCoreV1ObjectReference(
+                involvedObject=models.IoK8sApiCoreV1ObjectReference(
                     kind="Pod",
                     name="node-0-pod",
                     namespace=DEFAULT_NAMESPACE,
                 ),
                 message="Pod scheduled successfully",
                 reason="Scheduled",
-                first_timestamp=datetime.datetime(2025, 6, 1, 10, 31, 0),
+                firstTimestamp=datetime.datetime(2025, 6, 1, 10, 31, 0),
             ),
         ]
     )


### PR DESCRIPTION
We should convert response from listing events via:
```py
models.IoK8sApiCoreV1EventList.from_dict(event_response.to_dict())
```

That will return an error as follows:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for IoK8sApiCoreV1Event
involvedObject
  Input should be a valid dictionary or instance of IoK8sApiCoreV1ObjectReference [type=model_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.12/v/model_type
```
Looking at v1 code, we also didn't do this: https://github.com/kubeflow/trainer/blob/release-1.9/sdk/python/kubeflow/training/api/training_client.py#L1387


We still need to do this for Pods, since container resources should be correctly parsed to the `IoK8sApiCoreV1ResourceRequirements`.


/assign @kubeflow/kubeflow-sdk-team @akshaychitneni @sksingh2005 