### PR TITLE
feat(ci): Switch to UV for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   # Python dependencies from pyproject.toml
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
It looks like Dependabot now supports uv, let's see if that is going to keep our deps updates.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference?utm_source=chatgpt.com#package-ecosystem-

/cc @Fiona-Waters @jaiakash @kubeflow/kubeflow-sdk-team 

