### PR TITLE
fix: include full pr name for change log

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -14,7 +14,7 @@ body = """
 ## [Unreleased]
 {%- endif %}
 
-{%- set group_order = ["🚀 Features", "🐛 Bug Fixes", "⚙️ Miscellaneous Tasks"] -%}
+{%- set group_order = ["🚀 Features", "🐛 Bug Fixes", "⚙️ Miscellaneous Tasks", "⏪ Reverts"] -%}
 
 {%- for group_name in group_order %}
 {%- set group_commits = commits | filter(attribute="group", value=group_name) -%}
@@ -69,6 +69,6 @@ commit_parsers = [
     { message = "^feat(\\(.*\\))?:", group = "🚀 Features" },
     { message = "^fix(\\(.*\\))?:", group = "🐛 Bug Fixes" },
     { message = "^chore(\\(.*\\))?:", group = "⚙️ Miscellaneous Tasks" },
-    { message = "^revert(\\(.*\\))?:", group = "⚙️ Miscellaneous Tasks" },
+    { message = "^revert(\\(.*\\))?:", group = "⏪ Reverts" },
     { message = ".*", skip = true },
 ]


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the `git-cliff` config to include full title for PR.

**Which issue(s) this PR fixes** 

Related: https://github.com/kubeflow/sdk/issues/99

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
