### PR TITLE
fix: Remove uv from tools in readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.11"
-    uv: "latest"
   commands:
+    - pip install uv
     - uv sync --group docs
     - uv run sphinx-build -b html docs/source $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
 Removed uv: "latest" from tools section

/assign @andreyvelich 