### PR TITLE
chore(hub): add OWNERS file to kubeflow.hub

### DIFF
--- a/kubeflow/hub/OWNERS
+++ b/kubeflow/hub/OWNERS
@@ -1,0 +1,14 @@
+approvers:
+  - Al-Pragliola
+  - ederign
+  - pboyd
+  - rareddy
+  - tarilabs
+emeritus_approvers:
+  - andreyvelich
+  - ckadner
+  - Tomcli
+  - zijianjoy
+reviewers:
+  - fege
+  - jonburdo


### PR DESCRIPTION
This copies the OWNERS file from the root of the model-registry repo to kubeflow/hub/OWNERS since the kubeflow hub working group owns this particular sub-module.

The model-registry repo is: https://github.com/kubeflow/model-registry
This OWNERS file is specifically sourced from: https://github.com/kubeflow/model-registry/blob/c9222d84c04586c8d9fa95b6e5564f93869e6451/OWNERS

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

The kubeflow hub working group owns the code under `kubeflow/hub`. This was mentioned as a next step to adding this sub-module:
- https://github.com/kubeflow/sdk/pull/186#issuecomment-3775500991
- https://github.com/kubeflow/sdk/pull/186#issuecomment-3775649225

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
