### PR TITLE
feat(trainer): implement get_gpu_status for Kubernetesbackend

### DIFF
--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -15,6 +15,7 @@
 from collections.abc import Callable, Iterator
 import logging
 from typing import Optional, Union
+import json
 
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.trainer.backends.container.backend import ContainerBackend
@@ -208,6 +209,15 @@ class TrainerClient:
             RuntimeError: Failed to get a TrainJob.
         """
         return self.backend.get_job_logs(name=name, follow=follow, step=step)
+
+    def get_gpu_status(self, name:str):
+        """Get GPU status for the training nodes of a TrainJob.
+        Args:
+            name: Name of the TrainJob.
+        Returns:
+            A list of dictionaries containing GPU metrics.
+        """
+        return self.backend.get_gpu_status(name=name)
 
     def get_job_events(self, name: str) -> list[types.Event]:
         """Get events for a TrainJob.

--- a/kubeflow/trainer/backends/base.py
+++ b/kubeflow/trainer/backends/base.py
@@ -92,3 +92,7 @@ class RuntimeBackend(abc.ABC):
     @abc.abstractmethod
     def delete_job(self, name: str):
         raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_gpu_status(self, name: str) -> list[dict[str, str]]:
+        raise NotImplementedError()

--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -44,7 +44,7 @@ import os
 import random
 import shutil
 import string
-from typing import Optional, Union
+from typing import Any, Optional, Union
 import uuid
 
 from kubeflow.trainer.backends.base import RuntimeBackend
@@ -666,3 +666,6 @@ class ContainerBackend(RuntimeBackend):
         # Remove working directory if configured
         if self.cfg.auto_remove and workdir_host and os.path.isdir(workdir_host):
             shutil.rmtree(workdir_host, ignore_errors=True)
+
+    def get_gpu_status(self, name: str) -> list[dict[str, Any]]:
+        return []

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -22,9 +22,9 @@ import string
 import time
 from typing import Any, Optional, Union
 import uuid
-
+import io,csv
 from kubeflow_trainer_api import models
-from kubernetes import client, config, watch
+from kubernetes import client, config, watch , stream
 
 import kubeflow.common.constants as common_constants
 from kubeflow.common.types import KubernetesBackendConfig
@@ -168,6 +168,51 @@ class KubernetesBackend(RuntimeBackend):
         self.wait_for_job_status(job_name)
         print("\n".join(self.get_job_logs(name=job_name)))
         self.delete_job(job_name)
+
+    def get_gpu_status(self , name: str) -> list[dict[str, str]]:
+        train_job = self.get_job(name=name)
+        gpu_status = []
+        
+        command = [
+            "nvidia-smi",
+            "--query-gpu=index,uuid,name,temperature.gpu,utilization.gpu,utilization.memory,memory.total,memory.used,power.draw,pstate",
+            "--format=csv,noheader,nounits"
+        ]
+
+        for step in train_job.steps:
+            if not step.name.startswith(constants.NODE) or not step.pod_name:
+                continue
+
+            try:
+                res = stream(
+                    self.core_api.connect_get_namespaced_pod_exec,
+                    step.pod_name,
+                    self.namespace,
+                    command=command,
+                    stderr=True,
+                    stdin=False,
+                    stdout=True,
+                    tty=False,
+                )
+                f = io.StringIO(res)
+                reader = csv.reader(f)
+                for row in reader:
+                    gpu_status.append({
+                        "node": step.name,
+                        "index": row[0].strip(),
+                        "uuid": row[1].strip(),
+                        "name": row[2].strip(),
+                        "temperature": f"{row[3].strip()}C",
+                        "utilization": f"{row[4].strip()}%",
+                        "memory_utilization": f"{row[5].strip()}%",
+                        "memory": f"{row[7].strip()}/{row[6].strip()} MiB",
+                        "power": f"{row[8].strip()}W",
+                        "pstate": row[9].strip(),
+                    })
+            except Exception as e:
+                logger.warning(f"Failed to get GPU status for pod {step.pod_name}: {e}")
+
+        return gpu_status
 
     def train(
         self,

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -1342,3 +1342,46 @@ def test_get_job_events(kubernetes_backend, test_case):
     except Exception as e:
         assert type(e) is test_case.expected_error
     print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid flow with gpu status",
+            expected_status=SUCCESS,
+            config={"name": BASIC_TRAIN_JOB_NAME},
+            expected_output=[
+                {
+                    "node": "node-0",
+                    "index": "0",
+                    "uuid": "GPU-12345",
+                    "name": "NVIDIA A100",
+                    "temperature": "40C",
+                    "utilization": "50%",
+                    "memory_utilization": "20%",
+                    "memory": "2000/40000 MiB",
+                    "power": "150W",
+                    "pstate": "P0",
+                }
+            ],
+        ),
+    ],
+)
+def test_get_gpu_status(kubernetes_backend, test_case):
+    """Test KubernetesBackend.get_gpu_status with success path."""
+    print("Executing test:", test_case.name)
+
+    # Mock stream response
+    mock_stream_res = "0, GPU-12345, NVIDIA A100, 40, 50, 20, 40000, 2000, 150, P0"
+
+    with patch(
+        "kubeflow.trainer.backends.kubernetes.backend.stream", return_value=mock_stream_res
+    ):
+        try:
+            status = kubernetes_backend.get_gpu_status(**test_case.config)
+            assert test_case.expected_status == SUCCESS
+            assert status == test_case.expected_output
+        except Exception as e:
+            assert type(e) is test_case.expected_error
+    print("test execution complete")

--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -18,7 +18,7 @@ import random
 import string
 import tempfile
 import time
-from typing import Optional, Union
+from typing import Any, Optional, Union
 import uuid
 
 from kubeflow.trainer.backends.base import RuntimeBackend
@@ -256,6 +256,9 @@ class LocalProcessBackend(RuntimeBackend):
         _ = [step.job.cancel() for step in _job.steps]
         # remove the job from the list of jobs
         self.__local_jobs.remove(_job)
+
+    def get_gpu_status(self, name: str) -> list[dict[str, Any]]:
+        return []
 
     def __get_job_status(self, job: LocalBackendJobs) -> str:
         statuses = [_step.job.status for _step in job.steps]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR implements the `get_gpu_status` method in the `KubernetesBackend`, allowing users to retrieve real-time GPU metrics from training pods. This feature enhances observability for AI workloads by providing structured data on GPU utilization, memory usage, temperature, power draw, and performance states.

Key technical changes:
- **Base Layer**: Added `get_gpu_status` as an abstract method in `RuntimeBackend`.
- **API Layer**: Exposed `get_gpu_status(job_name)` in `TrainerClient`.
- **Kubernetes Implementation**: Uses the Kubernetes `exec` API to run `nvidia-smi` inside training pods (`node-*`). It uses a structured CSV query format (`--query-gpu=...`) for reliable parsing.
- **Compatibility**: Added placeholder implementations for `LocalProcessBackend` and `ContainerBackend` to ensure all backends satisfy the revised interface.
- **Verification**: Added `test_get_gpu_status` to `kubeflow/trainer/backends/kubernetes/backend_test.py` which mocks the Kubernetes stream response.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #165 

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
- [x] Unit tests added/updated.
- [x] All 50 existing tests passed (Kubernetes, Local, Container backends).
