### PR TITLE
chore(hub): add kubeflow hub approver jonburdo

### DIFF
--- a/kubeflow/hub/OWNERS
+++ b/kubeflow/hub/OWNERS
@@ -1,6 +1,7 @@
 approvers:
   - Al-Pragliola
   - ederign
+  - jonburdo
   - pboyd
   - rareddy
   - tarilabs
@@ -11,4 +12,3 @@ emeritus_approvers:
   - zijianjoy
 reviewers:
   - fege
-  - jonburdo


### PR DESCRIPTION
The main kubeflow hub repo added jonburdo to the OWNERS file in this PR: https://github.com/kubeflow/model-registry/pull/2162

This makes the same change to kubeflow/hub/OWNERS

