### PR TITLE
fix: preserve case for extended resource keys

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -219,7 +219,6 @@ def get_trainjob_node_step(
     return step
 
 
-# TODO (andreyvelich): Discuss if we want to support V1ResourceRequirements resources as input.
 def get_resources_per_node(
     resources_per_node: dict,
 ) -> models.IoK8sApiCoreV1ResourceRequirements:
@@ -228,19 +227,15 @@ def get_resources_per_node(
     """
 
     # Convert only standard resource keys and aliases to lowercase.
+    # Extended resources (e.g., "example.com/Custom-NPU") preserve their original case.
+    standard_resources = {constants.CPU_LABEL, "memory", "gpu", "storage", "ephemeral-storage"}
+    resource_aliases = {"gpu": "nvidia.com/gpu", "storage": "ephemeral-storage"}
+
     resources = {}
     for k, v in resources_per_node.items():
-        if k.lower() in {
-            constants.CPU_LABEL,
-            "memory",
-            "ephemeral-storage",
-            "gpu",
-        } or k.lower().startswith("mig-"):
-            resources[k.lower()] = models.IoK8sApimachineryPkgApiResourceQuantity(v)
-        else:
-            resources[k] = models.IoK8sApimachineryPkgApiResourceQuantity(v)
-    if "gpu" in resources:
-        resources["nvidia.com/gpu"] = resources.pop("gpu")
+        key = k.lower() if k.lower() in standard_resources or k.lower().startswith("mig-") else k
+        key = resource_aliases.get(key, key)
+        resources[key] = models.IoK8sApimachineryPkgApiResourceQuantity(v)
 
     # Optional alias for MIG: "mig-<profile>" -> "nvidia.com/mig-<profile>"
     # Example: "mig-1g.5gb" -> "nvidia.com/mig-1g.5gb"
@@ -256,11 +251,10 @@ def get_resources_per_node(
             f"GPU (nvidia.com/gpu) and MIG ({mig_keys[0]}) cannot be requested together"
         )
 
-    resources = models.IoK8sApiCoreV1ResourceRequirements(
+    return models.IoK8sApiCoreV1ResourceRequirements(
         requests=resources,
         limits=resources,
     )
-    return resources
 
 
 def get_script_for_python_packages(

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -122,21 +122,24 @@ def test_get_container_devices(test_case: TestCase):
             expected_status=SUCCESS,
             config={
                 "resources_per_node": {
-                    "huawei.com/Ascend910": 1,
+                    "example.com/Capitalized": 1,
                     "CPU": 2,
                     "Memory": "16Gi",
+                    "EPHEMERAL-STORAGE": "100Gi",
                 }
             },
             expected_output=models.IoK8sApiCoreV1ResourceRequirements(
                 limits={
-                    "huawei.com/Ascend910": models.IoK8sApimachineryPkgApiResourceQuantity(1),
+                    "example.com/Capitalized": models.IoK8sApimachineryPkgApiResourceQuantity(1),
                     "cpu": models.IoK8sApimachineryPkgApiResourceQuantity(2),
                     "memory": models.IoK8sApimachineryPkgApiResourceQuantity("16Gi"),
+                    "ephemeral-storage": models.IoK8sApimachineryPkgApiResourceQuantity("100Gi"),
                 },
                 requests={
-                    "huawei.com/Ascend910": models.IoK8sApimachineryPkgApiResourceQuantity(1),
+                    "example.com/Capitalized": models.IoK8sApimachineryPkgApiResourceQuantity(1),
                     "cpu": models.IoK8sApimachineryPkgApiResourceQuantity(2),
                     "memory": models.IoK8sApimachineryPkgApiResourceQuantity("16Gi"),
+                    "ephemeral-storage": models.IoK8sApimachineryPkgApiResourceQuantity("100Gi"),
                 },
             ),
         ),
@@ -145,21 +148,21 @@ def test_get_container_devices(test_case: TestCase):
             expected_status=SUCCESS,
             config={
                 "resources_per_node": {
-                    "aws.amazon.com/neuron": 1,
+                    "example.com/test": 1,
                     "Example.com/Custom-NPU": 2,
                     "mEmOrY": "8Gi",
-                    "EPHEMERAL-STORAGE": "100Gi",
+                    "STORAGE": "100Gi",
                 }
             },
             expected_output=models.IoK8sApiCoreV1ResourceRequirements(
                 limits={
-                    "aws.amazon.com/neuron": models.IoK8sApimachineryPkgApiResourceQuantity(1),
+                    "example.com/test": models.IoK8sApimachineryPkgApiResourceQuantity(1),
                     "Example.com/Custom-NPU": models.IoK8sApimachineryPkgApiResourceQuantity(2),
                     "memory": models.IoK8sApimachineryPkgApiResourceQuantity("8Gi"),
                     "ephemeral-storage": models.IoK8sApimachineryPkgApiResourceQuantity("100Gi"),
                 },
                 requests={
-                    "aws.amazon.com/neuron": models.IoK8sApimachineryPkgApiResourceQuantity(1),
+                    "example.com/test": models.IoK8sApimachineryPkgApiResourceQuantity(1),
                     "Example.com/Custom-NPU": models.IoK8sApimachineryPkgApiResourceQuantity(2),
                     "memory": models.IoK8sApimachineryPkgApiResourceQuantity("8Gi"),
                     "ephemeral-storage": models.IoK8sApimachineryPkgApiResourceQuantity("100Gi"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
`fix: preserve case for extended resource keys` 
- fix https://github.com/kubeflow/sdk/issues/263

This PR fixes a bug in the Kubeflow Trainer SDK where resource keys were being unconditionally lowercased. While this is acceptable for standard Kubernetes resources (like `cpu` and `memory`), it causes resource allocation failures for **Extended Resources** (e.g., `huawei.com/Ascend910`) which are case-sensitive.

### The Problem
Device plugins (like the Huawei Ascend plugin) register resources with specific casing. When a user specifies `huawei.com/Ascend910` in their [resources_per_node](cci:1://file:///home/danish/opensource/kubeflow/sdk/kubeflow/trainer/backends/kubernetes/utils.py:222:0-260:20), the SDK previously converted this to `huawei.com/ascend910`. Since the Kubernetes control plane is looking for the exact string, it would fail to find the resource, leaving the `TrainJob` pods in a `Pending` state.

### Proposed Changes
Modified [sdk/kubeflow/trainer/backends/kubernetes/utils.py](cci:7://file:///home/danish/opensource/kubeflow/sdk/kubeflow/trainer/backends/kubernetes/utils.py:0:0-0:0) to implement a selective lowercasing strategy:
1.  **Whitelist normalization**: Only lowercase keys that are standard Kubernetes resources (`cpu`, `memory`, `ephemeral-storage`) or known aliases (`gpu`, `mig-*`).
2.  **Case preservation**: For all other keys (extended resources), maintain the original casing provided by the user.

### Resource Transformation Logic

```mermaid
graph TD
    User["User Input (Python dict)"] -->|"e.g., {'huawei.com/Ascend910': '1'}"| SDK["SDK Logic (get_resources_per_node)"]
    
    subgraph Buggy_Logic ["Before Fix (Indiscriminate Lowercasing)"]
    SDK -->|"k.lower()"| LowerCase["All keys lowercased"]
    LowerCase -->|Result| FailedYAML["TrainJob YAML: huawei.com/ascend910"]
    end
    
    subgraph Fixed_Logic ["After Fix (Selective Normalization)"]
    SDK -->|"Check if standard?"| Branch{Standard / Alias?}
    Branch -->|Yes| Lower["Lowercase (cpu, memory, etc.)"]
    Branch -->|No| Preserve["Preserve Case (huawei.com/Ascend910)"]
    Lower -->|Result| GoodYAML["TrainJob YAML: Correct keys"]
    Preserve -->|Result| GoodYAML
    end

    FailedYAML -->|"Scheduling Error"| Fail["NPU Not Allocated (Mismatch)"]
    GoodYAML -->|"Scheduling Success"| Success["NPU Allocated Successfully"]