### PR TITLE
feat: add MCP server foundation with discovery tools

### DIFF
--- a/kubeflow/mcp/__init__.py
+++ b/kubeflow/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""MCP server for Kubeflow Trainer SDK."""
+
+from .server import mcp
+
+__all__ = ["mcp"]

--- a/kubeflow/mcp/server.py
+++ b/kubeflow/mcp/server.py
@@ -1,0 +1,41 @@
+"""FastMCP server for Kubeflow Trainer.
+
+Wraps the Kubeflow Trainer SDK so AI agents can interact with training
+through natural language instead of writing Python code.
+"""
+
+from mcp.server.fastmcp import FastMCP
+
+from kubeflow.mcp.tools import discovery
+
+
+MCP_NAME = "kubeflow-mcp"
+
+MCP_INSTRUCTIONS = """
+Kubeflow MCP Server - AI Model Training on Kubernetes
+
+This server provides tools for discovering cluster resources and managing
+Kubeflow Training jobs.
+
+WORKFLOW: Discovery
+1. get_cluster_info() → Check cluster connectivity
+2. get_cluster_resources() → Check available GPUs and resources
+
+More tools (training, monitoring, lifecycle) will be added in follow-up PRs.
+"""
+
+
+def create_server() -> FastMCP:
+    """Creates the FastMCP server and registers all tools."""
+    server = FastMCP(MCP_NAME, instructions=MCP_INSTRUCTIONS)
+
+    # Only discovery tools for now, more coming later
+    discovery.register_tools(server)
+
+    return server
+
+
+# Main server instance that MCP clients will use
+mcp = create_server()
+
+__all__ = ["mcp", "create_server"]

--- a/kubeflow/mcp/server_test.py
+++ b/kubeflow/mcp/server_test.py
@@ -1,0 +1,59 @@
+"""Tests for MCP server setup and tool registration."""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from kubeflow.mcp import server
+from kubeflow.mcp.tools import discovery
+
+
+def test_server_creation() -> None:
+    """Server creation returns a FastMCP instance with the right name."""
+    mcp_server = server.create_server()
+    
+    assert isinstance(mcp_server, FastMCP)
+    assert mcp_server.name == "kubeflow-mcp"
+
+
+def test_server_has_instructions() -> None:
+    """Server gets created (instructions are stored internally by FastMCP)."""
+    mcp_server = server.create_server()
+    
+    # Can't easily check instructions directly, but if server was created
+    # then instructions were set
+    assert mcp_server is not None
+
+
+def test_server_registers_discovery_tools() -> None:
+    """register_tools() works without errors."""
+    test_server = FastMCP("test-mcp")
+    
+    # Should not raise
+    try:
+        discovery.register_tools(test_server)
+        registration_successful = True
+    except Exception as e:
+        registration_successful = False
+        raise AssertionError(f"register_tools() raised exception: {e}")
+    
+    assert registration_successful
+    assert test_server is not None
+
+
+def test_mcp_instance_exported() -> None:
+    """The mcp instance is exported and works."""
+    from kubeflow.mcp.server import mcp
+    
+    assert mcp is not None
+    assert isinstance(mcp, FastMCP)
+    assert mcp.name == "kubeflow-mcp"
+
+
+def test_register_tools_called() -> None:
+    """Can call register_tools without issues."""
+    test_server = FastMCP("test-mcp")
+    
+    discovery.register_tools(test_server)
+    
+    assert test_server is not None

--- a/kubeflow/mcp/tools/__init__.py
+++ b/kubeflow/mcp/tools/__init__.py
@@ -1,0 +1,5 @@
+"""MCP tools for Kubeflow Trainer."""
+
+from . import discovery
+
+__all__ = ["discovery"]

--- a/kubeflow/mcp/tools/discovery.py
+++ b/kubeflow/mcp/tools/discovery.py
@@ -1,0 +1,111 @@
+"""Discovery tools for checking cluster info and resources.
+
+These are read-only - they just look at stuff, never change anything.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from kubernetes import client as k8s_client
+from kubernetes import config as k8s_config
+from mcp.server.fastmcp import FastMCP
+
+
+def _load_kube_config() -> None:
+    """Loads kubeconfig. Helper function to make mocking easier in tests."""
+    k8s_config.load_kube_config()
+
+
+def get_cluster_info_impl() -> Dict[str, Any]:
+    """Checks if we can connect to the cluster and gets the K8s version.
+    
+    Returns a dict with 'connected' (bool) and 'kubernetes_version' (str),
+    or 'error' if something went wrong.
+    """
+    try:
+        _load_kube_config()
+        version_api = k8s_client.VersionApi()
+        version = version_api.get_code()
+
+        return {
+            "connected": True,
+            "kubernetes_version": getattr(version, "git_version", None),
+        }
+    except Exception as exc:
+        return {
+            "connected": False,
+            "error": str(exc),
+        }
+
+
+def get_cluster_resources_impl(namespace: str = "default") -> Dict[str, Any]:
+    """Gets GPU/CPU/memory info across all nodes in the cluster.
+    
+    The namespace param is just for context in the response, it doesn't
+    actually filter anything since we're looking at cluster-level resources.
+    
+    Returns a dict with 'namespace', 'total_gpus' (int), 'nodes' (list),
+    or 'error' if something failed.
+    """
+    try:
+        _load_kube_config()
+        core_api = k8s_client.CoreV1Api()
+        nodes = core_api.list_node().items
+
+        total_gpus = 0
+        node_info: List[Dict[str, Any]] = []
+
+        for node in nodes:
+            capacity = getattr(node.status, "capacity", {}) or {}
+            gpu_str = capacity.get("nvidia.com/gpu")
+            gpu_count = int(gpu_str) if gpu_str is not None else 0
+            total_gpus += gpu_count
+
+            node_info.append(
+                {
+                    "name": getattr(node.metadata, "name", None),
+                    "gpus": gpu_count,
+                    "cpu": capacity.get("cpu"),
+                    "memory": capacity.get("memory"),
+                }
+            )
+
+        return {
+            "namespace": namespace,
+            "total_gpus": total_gpus,
+            "nodes": node_info,
+        }
+    except Exception as exc:
+        return {
+            "namespace": namespace,
+            "error": str(exc),
+        }
+
+
+def register_tools(server: FastMCP) -> None:
+    """Registers the discovery tools with the MCP server."""
+    
+    @server.tool()
+    def get_cluster_info() -> Dict[str, Any]:
+        """Checks cluster connection and gets K8s version.
+        
+        Returns a dict with 'connected' (bool) and 'kubernetes_version' (str)
+        if connected, or 'error' (str) if connection failed.
+        """
+        return get_cluster_info_impl()
+
+    @server.tool()
+    def get_cluster_resources(namespace: str = "default") -> Dict[str, Any]:
+        """Gets available GPUs, CPU, and memory across all nodes.
+        
+        Args:
+            namespace: Just for context in the response, doesn't filter anything.
+        
+        Returns a dict with:
+        - 'namespace' (str): The namespace you passed in
+        - 'total_gpus' (int): Total GPUs across all nodes
+        - 'nodes' (list): List of node info with 'name', 'gpus', 'cpu', 'memory'
+        - 'error' (str): Present if the query failed
+        """
+        return get_cluster_resources_impl(namespace=namespace)

--- a/kubeflow/mcp/tools/discovery_test.py
+++ b/kubeflow/mcp/tools/discovery_test.py
@@ -1,0 +1,326 @@
+"""Tests for discovery tools - covers edge cases and error handling."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kubeflow.mcp.tools import discovery
+
+
+@pytest.fixture(autouse=True)
+def prevent_kubeconfig_load(monkeypatch):
+    """Stops tests from accidentally loading real kubeconfig.
+    
+    Patches load_kube_config to raise an error if called, so we're forced
+    to use mocks instead of connecting to real clusters.
+    """
+    def fail_load(*args, **kwargs):
+        raise RuntimeError(
+            "Tests should not load real kubeconfig. "
+            "Use mocks instead."
+        )
+    
+    monkeypatch.setattr(
+        "kubernetes.config.load_kube_config",
+        fail_load
+    )
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.VersionApi")
+def test_get_cluster_info_success(
+    mock_version_api: MagicMock, mock_load: MagicMock
+) -> None:
+    """Happy path - returns connected=True when everything works."""
+    version_obj = SimpleNamespace(git_version="v1.28.0")
+    mock_version_api.return_value.get_code.return_value = version_obj
+
+    result = discovery.get_cluster_info_impl()
+
+    assert result["connected"] is True
+    assert result["kubernetes_version"] == "v1.28.0"
+    assert "error" not in result
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.VersionApi")
+def test_get_cluster_info_version_missing(
+    mock_version_api: MagicMock, mock_load: MagicMock
+) -> None:
+    """Handles case where version object doesn't have git_version."""
+    version_obj = SimpleNamespace()  # No git_version
+    mock_version_api.return_value.get_code.return_value = version_obj
+
+    result = discovery.get_cluster_info_impl()
+
+    assert result["connected"] is True
+    assert result["kubernetes_version"] is None
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.VersionApi")
+def test_get_cluster_info_failure_api_error(
+    mock_version_api: MagicMock, mock_load: MagicMock
+) -> None:
+    """Returns connected=False when API call fails."""
+    mock_version_api.return_value.get_code.side_effect = RuntimeError("API connection failed")
+
+    result = discovery.get_cluster_info_impl()
+
+    assert result["connected"] is False
+    assert "error" in result
+    assert "API connection failed" in result["error"]
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+def test_get_cluster_info_failure_config_error(mock_load: MagicMock) -> None:
+    """Returns connected=False when kubeconfig can't be loaded."""
+    mock_load.side_effect = FileNotFoundError("kubeconfig not found")
+
+    result = discovery.get_cluster_info_impl()
+
+    assert result["connected"] is False
+    assert "error" in result
+    assert "kubeconfig not found" in result["error"]
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.CoreV1Api")
+def test_get_cluster_resources_with_gpus(
+    mock_core_api: MagicMock, mock_load: MagicMock
+) -> None:
+    """Counts GPUs correctly when nodes have them."""
+    node = SimpleNamespace(
+        metadata=SimpleNamespace(name="node-1"),
+        status=SimpleNamespace(
+            capacity={"nvidia.com/gpu": "4", "cpu": "16", "memory": "64Gi"}
+        ),
+    )
+    mock_core_api.return_value.list_node.return_value.items = [node]
+
+    result = discovery.get_cluster_resources_impl(namespace="test-ns")
+
+    assert result["namespace"] == "test-ns"
+    assert result["total_gpus"] == 4
+    assert len(result["nodes"]) == 1
+    assert result["nodes"][0]["name"] == "node-1"
+    assert result["nodes"][0]["gpus"] == 4
+    assert result["nodes"][0]["cpu"] == "16"
+    assert result["nodes"][0]["memory"] == "64Gi"
+    assert "error" not in result
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.CoreV1Api")
+def test_get_cluster_resources_multiple_nodes(
+    mock_core_api: MagicMock, mock_load: MagicMock
+) -> None:
+    """Sums GPUs correctly across multiple nodes."""
+    node1 = SimpleNamespace(
+        metadata=SimpleNamespace(name="gpu-node-1"),
+        status=SimpleNamespace(
+            capacity={"nvidia.com/gpu": "8", "cpu": "32", "memory": "128Gi"}
+        ),
+    )
+    node2 = SimpleNamespace(
+        metadata=SimpleNamespace(name="gpu-node-2"),
+        status=SimpleNamespace(
+            capacity={"nvidia.com/gpu": "4", "cpu": "16", "memory": "64Gi"}
+        ),
+    )
+    node3 = SimpleNamespace(
+        metadata=SimpleNamespace(name="cpu-node"),
+        status=SimpleNamespace(
+            capacity={"cpu": "8", "memory": "32Gi"}  # No GPUs
+        ),
+    )
+    mock_core_api.return_value.list_node.return_value.items = [node1, node2, node3]
+
+    result = discovery.get_cluster_resources_impl()
+
+    assert result["total_gpus"] == 12  # 8 + 4 + 0
+    assert len(result["nodes"]) == 3
+    assert result["nodes"][0]["gpus"] == 8
+    assert result["nodes"][1]["gpus"] == 4
+    assert result["nodes"][2]["gpus"] == 0
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.CoreV1Api")
+def test_get_cluster_resources_no_gpus(
+    mock_core_api: MagicMock, mock_load: MagicMock
+) -> None:
+    """Handles nodes that don't have GPUs."""
+    node = SimpleNamespace(
+        metadata=SimpleNamespace(name="cpu-only-node"),
+        status=SimpleNamespace(
+            capacity={"cpu": "8", "memory": "32Gi"}
+        ),
+    )
+    mock_core_api.return_value.list_node.return_value.items = [node]
+
+    result = discovery.get_cluster_resources_impl()
+
+    assert result["total_gpus"] == 0
+    assert result["nodes"][0]["gpus"] == 0
+    assert result["nodes"][0]["cpu"] == "8"
+    assert result["nodes"][0]["memory"] == "32Gi"
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.CoreV1Api")
+def test_get_cluster_resources_empty_cluster(
+    mock_core_api: MagicMock, mock_load: MagicMock
+) -> None:
+    """Works fine when cluster has no nodes."""
+    mock_core_api.return_value.list_node.return_value.items = []
+
+    result = discovery.get_cluster_resources_impl(namespace="empty-ns")
+
+    assert result["namespace"] == "empty-ns"
+    assert result["total_gpus"] == 0
+    assert result["nodes"] == []
+    assert "error" not in result
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.CoreV1Api")
+def test_get_cluster_resources_missing_capacity(
+    mock_core_api: MagicMock, mock_load: MagicMock
+) -> None:
+    """Handles weird nodes that don't have capacity info."""
+    node = SimpleNamespace(
+        metadata=SimpleNamespace(name="weird-node"),
+        status=SimpleNamespace(),  # No capacity
+    )
+    mock_core_api.return_value.list_node.return_value.items = [node]
+
+    result = discovery.get_cluster_resources_impl()
+
+    assert result["total_gpus"] == 0
+    assert len(result["nodes"]) == 1
+    assert result["nodes"][0]["name"] == "weird-node"
+    assert result["nodes"][0]["gpus"] == 0
+    assert result["nodes"][0]["cpu"] is None
+    assert result["nodes"][0]["memory"] is None
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.CoreV1Api")
+def test_get_cluster_resources_missing_node_name(
+    mock_core_api: MagicMock, mock_load: MagicMock
+) -> None:
+    """Handles nodes without names (shouldn't happen but you never know)."""
+    node = SimpleNamespace(
+        metadata=SimpleNamespace(),  # No name
+        status=SimpleNamespace(
+            capacity={"nvidia.com/gpu": "2", "cpu": "4"}
+        ),
+    )
+    mock_core_api.return_value.list_node.return_value.items = [node]
+
+    result = discovery.get_cluster_resources_impl()
+
+    assert result["total_gpus"] == 2
+    assert result["nodes"][0]["name"] is None
+    assert result["nodes"][0]["gpus"] == 2
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.CoreV1Api")
+def test_get_cluster_resources_failure_api_error(
+    mock_core_api: MagicMock, mock_load: MagicMock
+) -> None:
+    """Returns error dict when API call fails."""
+    mock_core_api.return_value.list_node.side_effect = RuntimeError("API connection failed")
+
+    result = discovery.get_cluster_resources_impl(namespace="test-ns")
+
+    assert "error" in result
+    assert result["namespace"] == "test-ns"
+    assert "API connection failed" in result["error"]
+    assert "total_gpus" not in result
+    assert "nodes" not in result
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+def test_get_cluster_resources_failure_config_error(mock_load: MagicMock) -> None:
+    """Returns error dict when kubeconfig can't be loaded."""
+    mock_load.side_effect = FileNotFoundError("kubeconfig not found")
+
+    result = discovery.get_cluster_resources_impl()
+
+    assert "error" in result
+    assert result["namespace"] == "default"
+    assert "kubeconfig not found" in result["error"]
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.CoreV1Api")
+def test_get_cluster_resources_different_namespaces(
+    mock_core_api: MagicMock, mock_load: MagicMock
+) -> None:
+    """Works with different namespace values (even though it doesn't filter)."""
+    node = SimpleNamespace(
+        metadata=SimpleNamespace(name="node-1"),
+        status=SimpleNamespace(capacity={"nvidia.com/gpu": "1"}),
+    )
+    mock_core_api.return_value.list_node.return_value.items = [node]
+
+    # Try a few different namespaces
+    for ns in ["default", "kubeflow", "ml-team", "production"]:
+        result = discovery.get_cluster_resources_impl(namespace=ns)
+        assert result["namespace"] == ns
+        assert result["total_gpus"] == 1
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.VersionApi")
+def test_get_cluster_info_json_serializable(
+    mock_version_api: MagicMock, mock_load: MagicMock
+) -> None:
+    """Makes sure the result can be converted to JSON (for LLM consumption)."""
+    import json
+    
+    version_obj = SimpleNamespace(git_version="v1.28.0")
+    mock_version_api.return_value.get_code.return_value = version_obj
+
+    result = discovery.get_cluster_info_impl()
+
+    # Should serialize to JSON without issues
+    json_str = json.dumps(result)
+    parsed = json.loads(json_str)
+    assert parsed["connected"] is True
+    assert parsed["kubernetes_version"] == "v1.28.0"
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.CoreV1Api")
+def test_get_cluster_resources_json_serializable(
+    mock_core_api: MagicMock, mock_load: MagicMock
+) -> None:
+    """Makes sure the result can be converted to JSON."""
+    import json
+    
+    node = SimpleNamespace(
+        metadata=SimpleNamespace(name="node-1"),
+        status=SimpleNamespace(
+            capacity={"nvidia.com/gpu": "4", "cpu": "16", "memory": "64Gi"}
+        ),
+    )
+    mock_core_api.return_value.list_node.return_value.items = [node]
+
+    result = discovery.get_cluster_resources_impl()
+
+    # Should serialize fine
+    json_str = json.dumps(result)
+    parsed = json.loads(json_str)
+    assert parsed["namespace"] == "default"
+    assert parsed["total_gpus"] == 4
+    assert isinstance(parsed["nodes"], list)
+    assert len(parsed["nodes"]) == 1

--- a/kubeflow/mcp/tools/integration_test.py
+++ b/kubeflow/mcp/tools/integration_test.py
@@ -1,0 +1,106 @@
+"""Basic integration tests - checks that tools work together.
+
+These are light integration tests using mocks. Real integration tests
+with actual TrainerClient will come later when we add training tools.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kubeflow.mcp import server
+from kubeflow.mcp.tools import discovery
+
+
+@pytest.fixture(autouse=True)
+def prevent_kubeconfig_load(monkeypatch):
+    """Stops tests from accidentally loading real kubeconfig."""
+    def fail_load(*args, **kwargs):
+        raise RuntimeError(
+            "Tests should not load real kubeconfig. "
+            "Use mocks instead."
+        )
+    
+    monkeypatch.setattr(
+        "kubernetes.config.load_kube_config",
+        fail_load
+    )
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.VersionApi")
+@patch("kubeflow.mcp.tools.discovery.k8s_client.CoreV1Api")
+def test_discovery_tools_workflow(
+    mock_core_api: MagicMock,
+    mock_version_api: MagicMock,
+    mock_load: MagicMock,
+) -> None:
+    """Typical workflow: check cluster, then check resources."""
+    # Mock cluster info
+    version_obj = SimpleNamespace(git_version="v1.28.0")
+    mock_version_api.return_value.get_code.return_value = version_obj
+    
+    # Mock cluster resources
+    node = SimpleNamespace(
+        metadata=SimpleNamespace(name="gpu-node"),
+        status=SimpleNamespace(
+            capacity={"nvidia.com/gpu": "8", "cpu": "32", "memory": "128Gi"}
+        ),
+    )
+    mock_core_api.return_value.list_node.return_value.items = [node]
+    
+    # Check cluster connectivity
+    cluster_info = discovery.get_cluster_info_impl()
+    assert cluster_info["connected"] is True
+    assert cluster_info["kubernetes_version"] == "v1.28.0"
+    
+    # Check available resources
+    resources = discovery.get_cluster_resources_impl(namespace="ml-team")
+    assert resources["namespace"] == "ml-team"
+    assert resources["total_gpus"] == 8
+    assert len(resources["nodes"]) == 1
+
+
+@patch("kubeflow.mcp.tools.discovery.k8s_config.load_kube_config")
+def test_tools_handle_connection_failure_gracefully(mock_load: MagicMock) -> None:
+    """Tools don't crash when connection fails, they return error dicts."""
+    mock_load.side_effect = FileNotFoundError("kubeconfig not found")
+    
+    # Both should return error dicts, not raise
+    cluster_info = discovery.get_cluster_info_impl()
+    assert cluster_info["connected"] is False
+    assert "error" in cluster_info
+    
+    resources = discovery.get_cluster_resources_impl()
+    assert "error" in resources
+    assert resources["namespace"] == "default"
+
+
+def test_server_can_be_imported() -> None:
+    """Can import and use the server module."""
+    from kubeflow.mcp import server
+    from kubeflow.mcp.server import mcp, create_server
+    
+    assert server is not None
+    assert mcp is not None
+    assert create_server is not None
+    
+    # Should be able to create a new server
+    new_server = create_server()
+    assert new_server is not None
+    assert isinstance(new_server, type(mcp))
+
+
+def test_tools_module_can_be_imported() -> None:
+    """Can import the tools module and access its functions."""
+    from kubeflow.mcp.tools import discovery
+    
+    assert discovery is not None
+    assert hasattr(discovery, "get_cluster_info_impl")
+    assert hasattr(discovery, "get_cluster_resources_impl")
+    assert hasattr(discovery, "register_tools")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "pydantic>=2.10.0",
   "kubeflow-trainer-api>=2.0.0",
   "kubeflow-katib-api>=0.19.0",
+  "mcp>=1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the foundation for the MCP server for Project 6 (MCP Server for Kubeflow SDK). This is the first step - just setting up the server structure and adding two discovery tools that let you check your cluster info and resources.

Right now it's pretty basic - just two tools that query the K8s API to see if you're connected and what GPUs you have. The actual training tools come later. We're not duplicating any SDK code - when we add training tools, we'll just wrap the existing `TrainerClient` and `BuiltinTrainer` classes.

**What's in this PR:**
- FastMCP server setup
- `get_cluster_info()` - checks cluster connectivity and K8s version
- `get_cluster_resources()` - shows GPU/CPU/memory across nodes
- 24 tests total (15 for the discovery tools, 5 for server setup, 4 integration tests)
- Added `mcp>=1.0.0` to dependencies

All tests pass. The tests use mocks so no real cluster needed. E2E tests will come when we add the training tools that actually create TrainJobs.

**Which issue(s) this PR fixes**:

Related to kubeflow/community#936 and kubeflow/sdk#238

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
  - No user-facing docs needed yet - this is just foundation code