### PR TITLE
chore: add trivy cve scan and fix workflow

### DIFF
--- a/.github/workflows/trivy-cve-scan.yaml
+++ b/.github/workflows/trivy-cve-scan.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'
-
+          category: kubeflow-sdk-trivy-scanner
       - name: Process CVEs and Apply Fixes
         id: fixer
         run: |
@@ -97,4 +97,3 @@ jobs:
           delete-branch: true
           labels: |
             "area/security"
-            automated-fix


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR adds a workflow file that uses trivy for CVE scanning. The workflow will also open a PR on the repo with a fix for any CVEs with CVSS of 7.0 or higher that have fixes available. It runs nightly.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
