### PR TITLE
fix: Improve CVE workflow

### DIFF
--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,3 @@
+# GitHub Actions Python Scripts
+
+This directory contains Python scripts used by GitHub Actions workflows for dependency management and security updates.

--- a/.github/scripts/compare_versions.py
+++ b/.github/scripts/compare_versions.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+Compare PEP 440 versions.
+
+Usage:
+    python compare_versions.py <current_version> <target_version>
+
+Exit codes:
+    0 - current_version < target_version (upgrade needed)
+    1 - current_version >= target_version (no upgrade needed)
+    2 - error parsing versions
+"""
+
+import sys
+
+from packaging.version import InvalidVersion, Version
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: compare_versions.py <current_version> <target_version>", file=sys.stderr)
+        sys.exit(2)
+
+    current_str = sys.argv[1]
+    target_str = sys.argv[2]
+
+    try:
+        current = Version(current_str)
+        target = Version(target_str)
+
+        # Exit 0 if current < target (upgrade needed)
+        # Exit 1 if current >= target (no upgrade needed)
+        sys.exit(0 if current < target else 1)
+    except InvalidVersion as e:
+        print(f"Error: Invalid version format - {e}", file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/extract_version.py
+++ b/.github/scripts/extract_version.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+Extract package version from uv tree output.
+
+This script parses uv tree output to extract the full version
+(including pre-release, post-release, dev versions) of a package.
+
+Usage:
+    uv tree --package <package> | python extract_version.py <package>
+
+Exit codes:
+    0 - version found and printed to stdout
+    1 - version not found or error
+"""
+
+import re
+import sys
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: uv tree --package <pkg> | extract_version.py <pkg>", file=sys.stderr)
+        sys.exit(1)
+
+    package_name = sys.argv[1]
+
+    # Read from stdin (piped from uv tree)
+    tree_output = sys.stdin.read()
+
+    # Look for pattern: "package_name vX.Y.Z"
+    # Using non-greedy match to get version until whitespace
+    pattern = rf"{re.escape(package_name)}\s+v([^\s]+)"
+    match = re.search(pattern, tree_output)
+
+    if match:
+        version = match.group(1)
+        print(version)
+        sys.exit(0)
+    else:
+        print(f"Error: Could not find version for {package_name}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+Unit tests for GitHub Actions scripts.
+
+Run with: uv run pytest .github/scripts/test_scripts.py -v
+"""
+
+from pathlib import Path
+import subprocess
+import sys
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).parent
+
+
+class TestCompareVersions:
+    """Tests for compare_versions.py"""
+
+    def run_compare(self, current: str, target: str) -> int:
+        """Helper to run compare_versions.py and return exit code"""
+        result = subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "compare_versions.py", current, target],
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode
+
+    def test_upgrade_needed(self):
+        """Current version is less than target - should return 0 (upgrade needed)"""
+        assert self.run_compare("2.0.0", "2.1.0") == 0
+        assert self.run_compare("1.0.0", "2.0.0") == 0
+        assert self.run_compare("2.0.0", "2.0.1") == 0
+
+    def test_no_upgrade_needed(self):
+        """Current version equals or exceeds target - should return 1 (no upgrade)"""
+        assert self.run_compare("2.1.0", "2.0.0") == 1
+        assert self.run_compare("2.0.0", "2.0.0") == 1
+        assert self.run_compare("3.0.0", "2.9.9") == 1
+
+    def test_pre_release_versions(self):
+        """Test PEP 440 pre-release versions"""
+        # Pre-release is less than final release
+        assert self.run_compare("2.0.0rc1", "2.0.0") == 0
+        assert self.run_compare("2.0.0a1", "2.0.0") == 0
+        assert self.run_compare("2.0.0b1", "2.0.0") == 0
+
+        # Final release is greater than pre-release
+        assert self.run_compare("2.0.0", "2.0.0rc1") == 1
+
+    def test_post_release_versions(self):
+        """Test PEP 440 post-release versions"""
+        # Post-release is greater than base release
+        assert self.run_compare("2.0.0", "2.0.0.post1") == 0
+        assert self.run_compare("2.0.0.post1", "2.0.0") == 1
+
+    def test_dev_versions(self):
+        """Test PEP 440 dev versions"""
+        # Dev versions are less than base release
+        assert self.run_compare("2.0.0.dev1", "2.0.0") == 0
+        assert self.run_compare("2.0.0", "2.0.0.dev1") == 1
+
+    def test_complex_version_comparison(self):
+        """Test complex multi-part version numbers"""
+        assert self.run_compare("2.0.0.1", "2.0.0.2") == 0
+        assert self.run_compare("2.10.0", "2.9.0") == 1  # 10 > 9, not string comparison
+        assert self.run_compare("1.0.0rc1", "1.0.0rc2") == 0
+
+    def test_invalid_version_error(self):
+        """Invalid version should return error code 2"""
+        result = subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "compare_versions.py", "invalid", "2.0.0"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+        assert "Error" in result.stderr
+
+    def test_missing_arguments(self):
+        """Missing arguments should return error code 2"""
+        result = subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "compare_versions.py", "2.0.0"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 2
+
+
+class TestExtractVersion:
+    """Tests for extract_version.py"""
+
+    def run_extract(self, tree_output: str, package: str) -> tuple[int, str, str]:
+        """Helper to run extract_version.py and return (exit_code, stdout, stderr)"""
+        result = subprocess.run(
+            [sys.executable, SCRIPTS_DIR / "extract_version.py", package],
+            input=tree_output,
+            capture_output=True,
+            text=True,
+        )
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+    def test_simple_version_extraction(self):
+        """Extract version from simple uv tree output"""
+        tree_output = "requests v2.31.0"
+        exit_code, version, _ = self.run_extract(tree_output, "requests")
+        assert exit_code == 0
+        assert version == "2.31.0"
+
+    def test_version_with_metadata(self):
+        """Extract version from tree output with metadata"""
+        tree_output = "├── requests v2.31.0 (transitive)"
+        exit_code, version, _ = self.run_extract(tree_output, "requests")
+        assert exit_code == 0
+        assert version == "2.31.0"
+
+    def test_pre_release_version(self):
+        """Extract pre-release version"""
+        tree_output = "package v1.0.0rc1"
+        exit_code, version, _ = self.run_extract(tree_output, "package")
+        assert exit_code == 0
+        assert version == "1.0.0rc1"
+
+    def test_post_release_version(self):
+        """Extract post-release version"""
+        tree_output = "package v1.0.0.post1"
+        exit_code, version, _ = self.run_extract(tree_output, "package")
+        assert exit_code == 0
+        assert version == "1.0.0.post1"
+
+    def test_dev_version(self):
+        """Extract dev version"""
+        tree_output = "package v1.0.0.dev1"
+        exit_code, version, _ = self.run_extract(tree_output, "package")
+        assert exit_code == 0
+        assert version == "1.0.0.dev1"
+
+    def test_package_not_found(self):
+        """Package not in tree output should return error"""
+        tree_output = "other-package v1.0.0"
+        exit_code, _, stderr = self.run_extract(tree_output, "requests")
+        assert exit_code == 1
+        assert "Could not find version" in stderr
+
+    def test_multiline_tree_output(self):
+        """Extract from realistic multi-line uv tree output"""
+        tree_output = """
+        project v1.0.0
+        ├── requests v2.31.0
+        │   ├── certifi v2023.7.22
+        │   └── urllib3 v2.0.4
+        └── pytest v7.4.0
+        """
+        exit_code, version, _ = self.run_extract(tree_output, "requests")
+        assert exit_code == 0
+        assert version == "2.31.0"
+
+
+class TestUpdateOverrides:
+    """Tests for update_overrides.py"""
+
+    def run_update(
+        self, pyproject_content: str, package: str, target: str, date: str, advisory: str
+    ) -> tuple[int, str]:
+        """Helper to run update_overrides.py with temp file"""
+        with NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+            f.write(pyproject_content)
+            temp_path = Path(f.name)
+
+        try:
+            # Change to temp directory so script finds pyproject.toml
+            import os
+
+            original_dir = os.getcwd()
+            os.chdir(temp_path.parent)
+
+            # Create pyproject.toml in current directory
+            Path("pyproject.toml").write_text(pyproject_content)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    SCRIPTS_DIR / "update_overrides.py",
+                    package,
+                    target,
+                    date,
+                    advisory,
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            updated_content = Path("pyproject.toml").read_text()
+
+            # Cleanup
+            Path("pyproject.toml").unlink()
+            os.chdir(original_dir)
+
+            return result.returncode, updated_content
+        finally:
+            temp_path.unlink(missing_ok=True)
+
+    def test_create_tool_uv_section(self):
+        """Create [tool.uv] section if it doesn't exist"""
+        pyproject = "[project]\nname = 'test'\n"
+        exit_code, updated = self.run_update(
+            pyproject, "requests", "requests==2.31.0", "2025-01-15", "https://advisory.com"
+        )
+
+        assert exit_code == 0
+        assert "[tool.uv]" in updated
+        assert "override-dependencies = [" in updated
+        assert '"requests==2.31.0",' in updated
+        assert "# requests==2.31.0 - Added 2025-01-15" in updated
+
+    def test_add_to_existing_tool_uv(self):
+        """Add override-dependencies to existing [tool.uv]"""
+        pyproject = "[project]\nname = 'test'\n\n[tool.uv]\n"
+        exit_code, updated = self.run_update(
+            pyproject, "requests", "requests==2.31.0", "2025-01-15", "https://advisory.com"
+        )
+
+        assert exit_code == 0
+        assert "override-dependencies = [" in updated
+        assert '"requests==2.31.0",' in updated
+
+    def test_update_existing_override(self):
+        """Update existing package override to new version"""
+        pyproject = """[project]
+name = 'test'
+
+[tool.uv]
+# Security overrides - Review periodically and remove if parent constraints allow natural upgrade
+override-dependencies = [
+    # requests==2.30.0 - Added 2025-01-01 for security fix - https://old.com
+    "requests==2.30.0",
+]
+"""
+        exit_code, updated = self.run_update(
+            pyproject, "requests", "requests==2.31.0", "2025-01-15", "https://new.com"
+        )
+
+        assert exit_code == 0
+        assert '"requests==2.31.0",' in updated
+        assert "2.30.0" not in updated  # Old version removed
+        assert "2025-01-15" in updated  # New date
+        assert "https://new.com" in updated  # New advisory
+
+    def test_add_second_override(self):
+        """Add second package to existing overrides"""
+        pyproject = """[project]
+name = 'test'
+
+[tool.uv]
+override-dependencies = [
+    # requests==2.31.0 - Added 2025-01-15 for security fix - https://advisory.com
+    "requests==2.31.0",
+]
+"""
+        exit_code, updated = self.run_update(
+            pyproject, "urllib3", "urllib3==2.0.5", "2025-01-16", "https://urllib-advisory.com"
+        )
+
+        assert exit_code == 0
+        assert '"requests==2.31.0",' in updated
+        assert '"urllib3==2.0.5",' in updated
+        # Should be alphabetically sorted
+        lines = updated.split("\n")
+        requests_line = next(i for i, line in enumerate(lines) if "requests==" in line)
+        urllib_line = next(i for i, line in enumerate(lines) if "urllib3==" in line)
+        assert requests_line < urllib_line  # requests comes before urllib3
+
+    def test_multiline_array_preserved(self):
+        """Ensure output is always multi-line array format"""
+        pyproject = "[project]\nname = 'test'\n"
+        exit_code, updated = self.run_update(
+            pyproject, "pkg", "pkg==1.0.0", "2025-01-15", "https://advisory.com"
+        )
+
+        assert exit_code == 0
+        # Check multi-line format
+        assert "override-dependencies = [\n" in updated
+        assert '    "pkg==1.0.0",\n' in updated
+        assert "]\n" in updated
+
+    def test_single_line_array_converted(self):
+        """Single-line array should be parsed and converted to multi-line"""
+        pyproject = """[project]
+name = 'test'
+
+[tool.uv]
+override-dependencies = ["pkg1==1.0.0", "pkg2==2.0.0"]
+"""
+        exit_code, updated = self.run_update(
+            pyproject, "pkg3", "pkg3==3.0.0", "2025-01-15", "https://advisory.com"
+        )
+
+        assert exit_code == 0
+        # Should preserve existing packages
+        assert '"pkg1==1.0.0",' in updated
+        assert '"pkg2==2.0.0",' in updated
+        assert '"pkg3==3.0.0",' in updated
+        # Should be in multi-line format
+        assert "override-dependencies = [\n" in updated
+        # Should not have duplicate override-dependencies
+        assert updated.count("override-dependencies") == 1
+
+
+if __name__ == "__main__":
+    # Allow running with: python test_scripts.py
+    pytest.main([__file__, "-v"])

--- a/.github/scripts/update_overrides.py
+++ b/.github/scripts/update_overrides.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Update override-dependencies in pyproject.toml.
+
+This script manages the [tool.uv] override-dependencies section by:
+1. Reading existing overrides
+2. Adding or updating a package override
+3. Rewriting the entire section in consistent multi-line format
+
+Usage:
+    python update_overrides.py <package> <target> <date> <advisory_url>
+
+Example:
+    python update_overrides.py requests "requests==2.31.0" "2025-01-15" "https://..."
+"""
+
+from pathlib import Path
+import re
+import sys
+
+
+def main():
+    if len(sys.argv) != 5:
+        print(
+            "Usage: update_overrides.py <package> <target> <date> <advisory_url>", file=sys.stderr
+        )
+        sys.exit(1)
+
+    package = sys.argv[1]
+    target = sys.argv[2]
+    current_date = sys.argv[3]
+    advisory_url = sys.argv[4]
+
+    pyproject_path = Path("pyproject.toml")
+    if not pyproject_path.exists():
+        print(f"Error: {pyproject_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    # Read current pyproject.toml
+    content = pyproject_path.read_text()
+
+    comment = f"# {target} - Added {current_date} for security fix - {advisory_url}"
+
+    # Extract existing override-dependencies
+    overrides = {}  # pkg_name -> (full_spec, comment)
+    has_tool_uv = "[tool.uv]" in content
+    has_overrides = "override-dependencies" in content
+
+    if has_overrides:
+        # Parse existing override-dependencies (handles both single-line and multi-line)
+        in_override = False
+        last_comment = None
+        for line in content.split("\n"):
+            if "override-dependencies" in line and "=" in line:
+                in_override = True
+                # Check if it's a single-line array: override-dependencies = ["pkg1", "pkg2"]
+                single_line_match = re.search(r"override-dependencies\s*=\s*\[(.*?)\]", line)
+                if single_line_match:
+                    # Parse all packages from single line
+                    for pkg_match in re.finditer(r'"([^"]+)"', single_line_match.group(1)):
+                        spec = pkg_match.group(1)
+                        pkg_name = spec.split("==")[0] if "==" in spec else spec.split("[")[0]
+                        overrides[pkg_name] = (spec, None)
+                    break  # Single-line format, done parsing
+                continue
+            if in_override:
+                if line.strip() == "]":
+                    break
+                # Check for comment lines
+                if line.strip().startswith("#"):
+                    last_comment = line.strip()
+                    continue
+                # Extract package spec
+                match = re.search(r'"([^"]+)"', line)
+                if match:
+                    spec = match.group(1)
+                    pkg_name = spec.split("==")[0] if "==" in spec else spec.split("[")[0]
+                    overrides[pkg_name] = (spec, last_comment)
+                    last_comment = None
+
+    # Add or update the current package
+    overrides[package] = (target, comment)
+
+    # Rebuild pyproject.toml
+    if not has_tool_uv:
+        # Add [tool.uv] section at the end
+        content += "\n[tool.uv]\n"
+        content += "# Security overrides - Review periodically and remove if parent constraints allow natural upgrade\n"
+        has_tool_uv = True
+
+    if has_overrides:
+        # Remove old override-dependencies section (handles both single-line and multi-line)
+        # Single-line: override-dependencies = ["pkg==1.0"]
+        # Multi-line: override-dependencies = [\n    "pkg",\n]
+        content = re.sub(
+            r"^override-dependencies\s*=\s*\[.*?\]", "", content, flags=re.MULTILINE | re.DOTALL
+        )
+        # Also remove any orphaned comments before override-dependencies
+        content = re.sub(r"^# Security overrides.*?\n", "", content, flags=re.MULTILINE)
+
+    # Find [tool.uv] and insert override-dependencies
+    if not has_overrides and has_tool_uv:
+        # Insert after [tool.uv]
+        content = re.sub(
+            r"(\[tool\.uv\]\n)",
+            r"\1# Security overrides - Review periodically and remove if parent constraints allow natural upgrade\n",
+            content,
+        )
+
+    # Build override-dependencies array
+    override_lines = ["override-dependencies = ["]
+    for _pkg_name, (spec, pkg_comment) in sorted(overrides.items()):
+        if pkg_comment:
+            override_lines.append(f"    {pkg_comment}")
+        override_lines.append(f'    "{spec}",')
+    override_lines.append("]")
+    override_block = "\n".join(override_lines)
+
+    # Insert after [tool.uv] or the header comment
+    if "# Security overrides" in content:
+        content = re.sub(r"(# Security overrides.*?\n)", r"\1" + override_block + "\n", content)
+    else:
+        content = re.sub(r"(\[tool\.uv\]\n)", r"\1" + override_block + "\n", content)
+
+    # Write back
+    pyproject_path.write_text(content)
+    print(f"Updated override-dependencies with {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/cleanup-overrides.yaml
+++ b/.github/workflows/cleanup-overrides.yaml
@@ -84,7 +84,7 @@ jobs:
             fi
 
             # Check the resulting version
-            NATURAL_VER=$(uv tree --package "$PACKAGE" | grep -F "$PACKAGE v" | grep -oP 'v\K[0-9.]+' | head -n 1)
+            NATURAL_VER=$(uv tree --package "$PACKAGE" | uv run python3 .github/scripts/extract_version.py "$PACKAGE")
 
             if [ -z "$NATURAL_VER" ]; then
               echo "Warning: Could not determine natural version, keeping override"
@@ -97,19 +97,21 @@ jobs:
             echo "Natural upgrade resulted in version: $NATURAL_VER"
 
             # Compare versions: if natural version >= override version, we can remove override
-            if [ "$NATURAL_VER" = "$OVERRIDE_VER" ] || \
-               [ "$(printf '%s\n' "$NATURAL_VER" "$OVERRIDE_VER" | sort -V | tail -n1)" = "$NATURAL_VER" ]; then
-              echo "SUCCESS: Natural upgrade now works! Version $NATURAL_VER >= $OVERRIDE_VER"
-              echo "  Removing override for $TARGET"
-              echo "- $TARGET (upgraded to $NATURAL_VER)" >> removed.txt
-              # Keep the modified files (override removed)
-              rm -f pyproject.toml.backup uv.lock.backup
-            else
+            # compare_versions.py exits 0 if first arg < second arg, so we need to check if NATURAL_VER < OVERRIDE_VER
+            if uv run python3 .github/scripts/compare_versions.py "$NATURAL_VER" "$OVERRIDE_VER"; then
+              # NATURAL_VER < OVERRIDE_VER, so we need to keep the override
               echo "SKIP: Natural upgrade insufficient. Version $NATURAL_VER < $OVERRIDE_VER"
               echo "  Keeping override for $TARGET"
               mv pyproject.toml.backup pyproject.toml
               mv uv.lock.backup uv.lock
               echo "- $TARGET (natural upgrade only reached $NATURAL_VER, need $OVERRIDE_VER)" >> kept.txt
+            else
+              # NATURAL_VER >= OVERRIDE_VER, we can remove the override
+              echo "SUCCESS: Natural upgrade now works! Version $NATURAL_VER >= $OVERRIDE_VER"
+              echo "  Removing override for $TARGET"
+              echo "- $TARGET (upgraded to $NATURAL_VER)" >> removed.txt
+              # Keep the modified files (override removed)
+              rm -f pyproject.toml.backup uv.lock.backup
             fi
           done <<< "$OVERRIDES"
 
@@ -182,4 +184,4 @@ jobs:
           branch: cleanup-overrides-${{ github.run_id }}
           delete-branch: true
           labels: |
-            "area/dependencies"
+            "area/security"

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -42,6 +42,9 @@ jobs:
       - name: Verify
         run: make verify
 
+      - name: Test GitHub Actions Scripts
+        run: make test-scripts
+
       - name: Run Tests
         run: |
           make test-python report=xml

--- a/.github/workflows/trivy-cve-scan.yaml
+++ b/.github/workflows/trivy-cve-scan.yaml
@@ -81,7 +81,7 @@ jobs:
 
             # Verify if the upgrade actually worked in the lockfile
             # Extract full version including pre-release, post-release, dev, etc.
-            CURRENT_VER=$(uv tree --package "$PACKAGE" | grep -F "$PACKAGE v" | sed -n 's/.*v\([^ ]*\).*/\1/p' | head -n 1)
+            CURRENT_VER=$(uv tree --package "$PACKAGE" | uv run python3 .github/scripts/extract_version.py "$PACKAGE")
 
             if [ -z "$CURRENT_VER" ]; then
               echo "Warning: Could not determine current version for $PACKAGE. Skipping..."
@@ -89,7 +89,7 @@ jobs:
             fi
 
             # Use Python packaging.version for proper PEP 440 version comparison
-            if python3 -c "from packaging.version import Version; import sys; current = Version('$CURRENT_VER'); target = Version('$VERSION'); sys.exit(0 if current < target else 1)"; then
+            if uv run python3 .github/scripts/compare_versions.py "$CURRENT_VER" "$VERSION"; then
               NEEDS_OVERRIDE="true"
             else
               NEEDS_OVERRIDE="false"
@@ -99,116 +99,7 @@ jobs:
               echo "Natural upgrade blocked by parents (current: $CURRENT_VER, target: $VERSION). Adding Hard Pin to pyproject.toml overrides..."
 
               # Extract existing override-dependencies, add/update package, rewrite entire section
-              python3 <<'EOF'
-              import re
-              import sys
-
-              pyproject_path = "pyproject.toml"
-
-              # Read current pyproject.toml
-              with open(pyproject_path, 'r') as f:
-                  content = f.read()
-
-              # Package info from shell variables
-              package = "$PACKAGE"
-              target = "$TARGET"
-              current_date = "$CURRENT_DATE"
-              advisory_url = "$ADVISORY_URL"
-              comment = f"# {target} - Added {current_date} for security fix - {advisory_url}"
-
-              # Extract existing override-dependencies
-              overrides = {}  # pkg_name -> (full_spec, comment)
-              has_tool_uv = "[tool.uv]" in content
-              has_overrides = "override-dependencies" in content
-
-              if has_overrides:
-                  # Parse existing override-dependencies
-                  in_override = False
-                  last_comment = None
-                  for line in content.split('\n'):
-                      if 'override-dependencies' in line and '=' in line:
-                          in_override = True
-                          continue
-                      if in_override:
-                          if line.strip() == ']':
-                              break
-                          # Check for comment lines
-                          if line.strip().startswith('#'):
-                              last_comment = line.strip()
-                              continue
-                          # Extract package spec
-                          match = re.search(r'"([^"]+)"', line)
-                          if match:
-                              spec = match.group(1)
-                              pkg_name = spec.split('==')[0] if '==' in spec else spec.split('[')[0]
-                              overrides[pkg_name] = (spec, last_comment)
-                              last_comment = None
-
-              # Add or update the current package
-              overrides[package] = (target, comment)
-
-              # Rebuild pyproject.toml
-              if not has_tool_uv:
-                  # Add [tool.uv] section at the end
-                  content += "\n[tool.uv]\n"
-                  content += "# Security overrides - Review periodically and remove if parent constraints allow natural upgrade\n"
-                  has_tool_uv = True
-
-              if has_overrides:
-                  # Remove old override-dependencies section
-                  # Match from override-dependencies line through the closing ]
-                  content = re.sub(
-                      r'^override-dependencies\s*=\s*\[.*?\n^\]$',
-                      '',
-                      content,
-                      flags=re.MULTILINE | re.DOTALL
-                  )
-                  # Also remove any orphaned comments before override-dependencies
-                  content = re.sub(
-                      r'^# Security overrides.*?\n',
-                      '',
-                      content,
-                      flags=re.MULTILINE
-                  )
-
-              # Find [tool.uv] and insert override-dependencies
-              if not has_overrides and has_tool_uv:
-                  # Insert after [tool.uv]
-                  content = re.sub(
-                      r'(\[tool\.uv\]\n)',
-                      r'\1# Security overrides - Review periodically and remove if parent constraints allow natural upgrade\n',
-                      content
-                  )
-
-              # Build override-dependencies array
-              override_lines = ["override-dependencies = ["]
-              for pkg_name, (spec, pkg_comment) in sorted(overrides.items()):
-                  if pkg_comment:
-                      override_lines.append(f"    {pkg_comment}")
-                  override_lines.append(f'    "{spec}",')
-              override_lines.append("]")
-              override_block = '\n'.join(override_lines)
-
-              # Insert after [tool.uv] or the header comment
-              if "# Security overrides" in content:
-                  content = re.sub(
-                      r'(# Security overrides.*?\n)',
-                      r'\1' + override_block + '\n',
-                      content
-                  )
-              else:
-                  content = re.sub(
-                      r'(\[tool\.uv\]\n)',
-                      r'\1' + override_block + '\n',
-                      content
-                  )
-
-              # Write back
-              with open(pyproject_path, 'w') as f:
-                  f.write(content)
-
-              print(f"Updated override-dependencies with {target}")
-              EOF
+              uv run python3 .github/scripts/update_overrides.py "$PACKAGE" "$TARGET" "$CURRENT_DATE" "$ADVISORY_URL"
 
               uv lock
             else

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,11 @@ test-e2e-setup-cluster:  ## Setup Kind cluster for Spark E2E tests
 	 SPARK_OPERATOR_VERSION=$(SPARK_OPERATOR_VERSION) \
 	 KIND=$(KIND) \
 	 ./hack/e2e-setup-cluster.sh
+.PHONY: test-scripts
+test-scripts: uv-venv  ## Run GitHub Actions script tests
+	@uv sync
+	@uv run pytest .github/scripts/test_scripts.py -v
+
 
 .PHONY: install-dev
 install-dev: uv uv-venv ruff  ## Install uv, create .venv, sync deps.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Following on from the trivy-cve-scan workflow that was added yesterday I have updated it with the following:

 - It has come to my attention that purely updating the uv.lock is not sufficient as anyone updating the file in another PR can revert this change. In order to counter that I have added a verification step that checks if a "natural" lockfile upgrade is blocked by parent dependencies. If blocked, the bot now automatically injects a tool.uv.override-dependencies into pyproject.toml to ensure the fix cannot be accidentally reverted by manual uv lock commands.

Last nights run found the urllib CVE, which I had already fixed - but another PR had reverted the change.

 - Implemented add-paths filtering in the PR creation step. This ensures only uv.lock and pyproject.toml are committed and nothing else. This was previously missing causing the workflow to fail.

Please review @andreyvelich @kramaranya 


**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
