### PR TITLE
feat: Adds a GitHub Actions workflow to check kubeflow/hub/OWNERS.

### DIFF
--- a/.github/workflows/check-owners.yaml
+++ b/.github/workflows/check-owners.yaml
@@ -3,7 +3,7 @@ name: "Check OWNERS"
 on:
   pull_request:
     paths:
-      - 'OWNERS'
+      - 'kubeflow/hub/OWNERS'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This PR ensures that approvers for Kubeflow Hub are properly synchronized with the kubeflow-hub-team in kubeflow/internal-acls 
Fixes #275 
