### PR TITLE
chore: bump minimum model-registry version to 0.3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ podman = [
   "podman>=5.6.0"
 ]
 hub = [
-  "model-registry>=0.3.0",
+  "model-registry>=0.3.6",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -567,7 +567,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -838,7 +838,7 @@ requires-dist = [
     { name = "kubeflow-katib-api", specifier = ">=0.19.0" },
     { name = "kubeflow-trainer-api", specifier = ">=2.0.0" },
     { name = "kubernetes", specifier = ">=27.2.0" },
-    { name = "model-registry", marker = "extra == 'hub'", specifier = ">=0.3.0" },
+    { name = "model-registry", marker = "extra == 'hub'", specifier = ">=0.3.6" },
     { name = "podman", marker = "extra == 'podman'", specifier = ">=5.6.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
 ]
@@ -1023,7 +1023,7 @@ wheels = [
 
 [[package]]
 name = "model-registry"
-version = "0.3.5"
+version = "0.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1033,9 +1033,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/7c/957482253e6360238ae6a28a1f15a6390bf8210fcb68db57c47c8f48e7ae/model_registry-0.3.5.tar.gz", hash = "sha256:fb933aea7cb55693ee7b69d560a9e29ff1d924a2ac6940ceb24b8beeb68ea4de", size = 95789, upload-time = "2026-01-09T20:32:10.835Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/e8/790640c40b9c4a6ba792df97596d6989e4e2e52e3fba1c22f36369b2a73c/model_registry-0.3.6.tar.gz", hash = "sha256:79d3bf95a65a0b01d84e6ff5a9ba0d0920a69042bc2ea45cb573cdc7c571fcff", size = 105137, upload-time = "2026-02-10T10:37:16.487Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/4d/856972d0b2d0cd466868fcd88fe9b1f0c559c4e0d967247066e22ee3f48d/model_registry-0.3.5-py3-none-any.whl", hash = "sha256:5cf09c9012f860a5308008511ec9bc0cc1643f9038d62acf4ccdc3ff4f8f6eba", size = 204406, upload-time = "2026-01-09T20:32:09.389Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/49/f025399a9cff506ee7821f98e2fe7dc94ab475002493a16a82ecd7594f09/model_registry-0.3.6-py3-none-any.whl", hash = "sha256:b7b5ad080cb982db4442107d818cd47d50cea4361552cdd030b247bc039150b6", size = 216727, upload-time = "2026-02-10T10:37:14.536Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bump minimum `model-registry` version under `hub` extra to `0.3.6`.

**What this PR does / why we need it**:



**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
