### PR TITLE
docs(sdk): add optimizerclient context to agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,13 @@ Before writing code, agents should:
 - Read docstrings and existing test cases for pattern alignment
 - Match import patterns from neighboring files
 - Preserve existing logging and error-handling conventionso
+### OptimizerClient (Hyperparameter Tuning)
+Agents generating hyperparameter optimization code must use the `OptimizerClient` from `kubeflow.optimizer`. 
 
+**Key rules for OptimizerClient:**
+- **Import path:** `from kubeflow.optimizer import OptimizerClient, Search, TrialConfig`
+- **Execution:** It supports both local execution (`ContainerBackend`, `LocalProcessBackend`) and remote Kubernetes cluster execution (`KubernetesBackend`).
+- **Search Space:** Parameters must be defined using the `Search` class (e.g., `Search.loguniform(0.001, 0.1)`, `Search.choice([5, 10, 15])`).
 ## Repository Map
 
 ```


### PR DESCRIPTION
Hi everyone! I'm a first-year student and this is my first contribution to the Kubeflow repo.

I saw Issue #189 and wanted to help out. I've updated the AGENTS.md file under the Context Awareness section to include the rules for the new OptimizerClient. I added the required import paths, the backend execution options, and the rules for defining the Search Space so AI agents will generate the correct hyperparameter tuning code.

Fixes #189

Please let me know if I need to adjust any of the formatting!