### PR TITLE
feat: add structured and configurable logging support to Kubeflow SDK

### DIFF
--- a/kubeflow/common/logging.py
+++ b/kubeflow/common/logging.py
@@ -1,0 +1,51 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+
+_DEFAULT_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Get a configured logger for the given module name.
+
+    The log level can be configured via the KUBEFLOW_LOG_LEVEL environment
+    variable. Defaults to INFO if not set.
+
+    Example:
+```python
+        from kubeflow.common.logging import get_logger
+        logger = get_logger(__name__)
+        logger.info("Training started")
+```
+
+    Args:
+        name: The logger name, typically __name__ of the calling module.
+
+    Returns:
+        A configured logging.Logger instance.
+    """
+    logger = logging.getLogger(name)
+
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(_DEFAULT_FORMAT)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    log_level = os.environ.get("KUBEFLOW_LOG_LEVEL", "INFO").upper()
+    logger.setLevel(getattr(logging, log_level, logging.INFO))
+
+    return logger

--- a/kubeflow/common/logging.py
+++ b/kubeflow/common/logging.py
@@ -21,21 +21,21 @@ _DEFAULT_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 def get_logger(name: str) -> logging.Logger:
     """Get a configured logger for the given module name.
 
-    The log level can be configured via the KUBEFLOW_LOG_LEVEL environment
-    variable. Defaults to INFO if not set.
+        The log level can be configured via the KUBEFLOW_LOG_LEVEL environment
+        variable. Defaults to INFO if not set.
 
-    Example:
-```python
-        from kubeflow.common.logging import get_logger
-        logger = get_logger(__name__)
-        logger.info("Training started")
-```
+        Example:
+    ```python
+            from kubeflow.common.logging import get_logger
+            logger = get_logger(__name__)
+            logger.info("Training started")
+    ```
 
-    Args:
-        name: The logger name, typically __name__ of the calling module.
+        Args:
+            name: The logger name, typically __name__ of the calling module.
 
-    Returns:
-        A configured logging.Logger instance.
+        Returns:
+            A configured logging.Logger instance.
     """
     logger = logging.getLogger(name)
 

--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -39,13 +39,13 @@ Key behaviors:
 
 from collections.abc import Callable, Iterator
 from datetime import datetime
-from kubeflow.common.logging import get_logger
 import os
 import random
 import shutil
 import string
 import uuid
 
+from kubeflow.common.logging import get_logger
 from kubeflow.trainer.backends.base import RuntimeBackend
 from kubeflow.trainer.backends.container import utils as container_utils
 from kubeflow.trainer.backends.container.adapters.base import (

--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -39,7 +39,7 @@ Key behaviors:
 
 from collections.abc import Callable, Iterator
 from datetime import datetime
-import logging
+from kubeflow.common.logging import get_logger
 import os
 import random
 import shutil
@@ -61,7 +61,7 @@ from kubeflow.trainer.backends.container.types import ContainerBackendConfig
 from kubeflow.trainer.constants import constants
 from kubeflow.trainer.types import types
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class ContainerBackend(RuntimeBackend):

--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -250,7 +250,7 @@ class ContainerBackend(RuntimeBackend):
         ]
 
         logs = self._adapter.run_oneoff_container(image=runtime.trainer.image, command=command)
-        print(logs)
+        logger.info(logs)
 
     def train(
         self,

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -268,7 +268,7 @@ class KubernetesBackend(RuntimeBackend):
         )
 
         self.wait_for_job_status(job_name)
-        print("\n".join(self.get_job_logs(name=job_name)))
+        logger.info("\n".join(self.get_job_logs(name=job_name)))
         self.delete_job(job_name)
 
     def train(

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -14,7 +14,6 @@
 
 from collections.abc import Callable, Iterator
 import copy
-from kubeflow.common.logging import get_logger
 import multiprocessing
 import os
 import random
@@ -28,6 +27,7 @@ from kubeflow_trainer_api import models
 from kubernetes import client, config, watch
 
 import kubeflow.common.constants as common_constants
+from kubeflow.common.logging import get_logger
 from kubeflow.common.types import KubernetesBackendConfig
 import kubeflow.common.utils as common_utils
 from kubeflow.trainer.backends.base import RuntimeBackend

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -14,7 +14,7 @@
 
 from collections.abc import Callable, Iterator
 import copy
-import logging
+from kubeflow.common.logging import get_logger
 import multiprocessing
 import os
 import random
@@ -35,7 +35,7 @@ import kubeflow.trainer.backends.kubernetes.utils as utils
 from kubeflow.trainer.constants import constants
 from kubeflow.trainer.types import types
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class KubernetesBackend(RuntimeBackend):


### PR DESCRIPTION
## Summary
Fixes #85

## Changes
- Added `kubeflow/common/logging.py` with a `get_logger()` utility function
- Supports configurable log levels via `KUBEFLOW_LOG_LEVEL` environment variable (defaults to INFO)
- Replaced `print()` calls with `logger.info()` in production code:
  - `kubeflow/trainer/backends/kubernetes/backend.py`
  - `kubeflow/trainer/backends/container/backend.py`

## How to test
Set log level via environment variable:
```python
import os
os.environ["KUBEFLOW_LOG_LEVEL"] = "DEBUG"
from kubeflow.common.logging import get_logger
logger = get_logger(__name__)
logger.info("test")  # 2025-02-21 - __main__ - INFO - test
```

## Notes
- `print()` calls inside `print_packages()` were intentionally left as-is since they run inside the training container
- `print()` calls in docstring examples were also left unchanged