### PR TITLE
chore(trainer): clarify namespace binding and CustomTrainer inputs (KEP-936)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,8 @@ pip install -U kubeflow
 ### Run your first PyTorch distributed job
 > Design notes (KEP-936 alignment)
 >
-> - **Why SDK-wrapping (vs direct API):** the SDK provides a single Pythonic surface for auth/config, local execution modes, and consistent orchestration across BuiltinTrainer/CustomTrainer workflows.
-> - **Namespace binding (SDK reality):** `TrainerClient` binds namespace via `KubernetesBackendConfig(namespace=...)` (not per-call).  
->   **MCP suggestion:** expose `namespace` as an explicit tool parameter, and internally create/cache a per-namespace `TrainerClient`.
-> - **CustomTrainer input (today):** pass a Python callable via `func=...` when constructing `CustomTrainer`. **Future/MCP-layer suggestion:** consider a `script_code: str` input (with `ast.parse` validation and denylisted imports) at the tooling layer, not as part of the current SDK.
-> - **Minimal toolset stance (MCP tools, not SDK methods):** start with orchestration tools (e.g. MCP `fine_tune` wrapping `TrainerClient.train`) + observability tools (e.g. MCP `get_training_logs` / `events` wrapping `TrainerClient.get_job_logs` / `TrainerClient.get_job_events`); gate fine-grained list/get tools via persona filtering.
+> - **Namespace binding:** `TrainerClient` binds namespace via `KubernetesBackendConfig(namespace=...)` (not per-call).
+> - **CustomTrainer inputs:** keep SDK API as-is (`func=...`). For MCP/tooling, prefer `script_code: str` to avoid callable serialization; treat it as **trusted-only** (validation is limited; `importlib`-style escapes exist). For untrusted code, route execution through a container/sandbox.
 ```python
 from kubeflow.trainer import TrainerClient, CustomTrainer, TrainJobTemplate
 


### PR DESCRIPTION
This PR adds a short "Design Notes (KEP-936 alignment)" block to the first Trainer quickstart example in the README.

It clarifies:
- **SDK vs direct API:** why an SDK wrapper helps (consistent config/auth surface + Pythonic orchestration).
- **Namespace handling:** `TrainerClient` binds namespace via `KubernetesBackendConfig(namespace=...)` (not per-call).
  - MCP suggestion: expose `namespace` as an explicit tool parameter and create/cache a per-namespace client internally.
- **CustomTrainer inputs:** recommend `script_code: str` over serializing Python callables (with a brief validation/security roadmap).
- **Tooling scope:** start with orchestration + observability; gate fine-grained tools via persona filtering.

Docs-only; no behavior changes.