### PR TITLE
fix(docs): Fix light mode text visibility in custom CSS

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -37,6 +37,7 @@
         --kf-text-light: #a0aec0;
         --kf-bg-subtle: #2d3748;
         --kf-border: #4a5568;
+        --kf-accent: #81e6d9;
         --kf-api-name: #63b3ed;
         --kf-api-param: #a0aec0;
         --kf-api-text: #e2e8f0;
@@ -53,6 +54,7 @@ body[data-theme="light"] {
     --kf-text-light: #718096;
     --kf-bg-subtle: #f7fafc;
     --kf-border: #e2e8f0;
+    --kf-accent: #81e6d9;
     --kf-api-name: #3182ce;
     --kf-api-param: #4a5568;
     --kf-api-text: #000;
@@ -67,6 +69,7 @@ body[data-theme="dark"] {
     --kf-text-light: #a0aec0;
     --kf-bg-subtle: #2d3748;
     --kf-border: #4a5568;
+    --kf-accent: #81e6d9;
     --kf-api-name: #63b3ed;
     --kf-api-param: #a0aec0;
     --kf-api-text: #e2e8f0;

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -26,9 +26,9 @@
     --kf-api-text: #000;
 }
 
-/* Dark mode overrides */
+/* Dark mode overrides - Furo sets data-theme on body, not :root */
 @media (prefers-color-scheme: dark) {
-    :root:not([data-theme="light"]) {
+    body:not([data-theme="light"]) {
         --kf-blue: #63b3ed;
         --kf-blue-light: #90cdf4;
         --kf-blue-dark: #4299e1;
@@ -43,7 +43,22 @@
     }
 }
 
-[data-theme="dark"] {
+/* Explicit light mode - ensure light vars when user selects Light */
+body[data-theme="light"] {
+    --kf-blue: #4299e1;
+    --kf-blue-light: #63b3ed;
+    --kf-blue-dark: #3182ce;
+    --kf-heading: #2d3748;
+    --kf-text: #4a5568;
+    --kf-text-light: #718096;
+    --kf-bg-subtle: #f7fafc;
+    --kf-border: #e2e8f0;
+    --kf-api-name: #3182ce;
+    --kf-api-param: #4a5568;
+    --kf-api-text: #000;
+}
+
+body[data-theme="dark"] {
     --kf-blue: #63b3ed;
     --kf-blue-light: #90cdf4;
     --kf-blue-dark: #4299e1;

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -26,7 +26,16 @@
     --kf-api-text: #000;
 }
 
-/* Dark mode overrides - Furo sets data-theme on body, not :root */
+/*
+ * Dark mode overrides — Furo sets data-theme on <body>, not :root.
+ *
+ * Two blocks are needed because they cover different scenarios:
+ *   @media block  → system prefers dark + user has not explicitly chosen Light (auto)
+ *   body[data-theme="dark"] → user explicitly selects Dark while system is light
+ *
+ * Light mode needs no explicit block: when Furo sets data-theme="light" on body,
+ * the media-query selector no longer matches and body inherits :root values.
+ */
 @media (prefers-color-scheme: dark) {
     body:not([data-theme="light"]) {
         --kf-blue: #63b3ed;
@@ -42,22 +51,6 @@
         --kf-api-param: #a0aec0;
         --kf-api-text: #e2e8f0;
     }
-}
-
-/* Explicit light mode - ensure light vars when user selects Light */
-body[data-theme="light"] {
-    --kf-blue: #4299e1;
-    --kf-blue-light: #63b3ed;
-    --kf-blue-dark: #3182ce;
-    --kf-heading: #2d3748;
-    --kf-text: #4a5568;
-    --kf-text-light: #718096;
-    --kf-bg-subtle: #f7fafc;
-    --kf-border: #e2e8f0;
-    --kf-accent: #81e6d9;
-    --kf-api-name: #3182ce;
-    --kf-api-param: #4a5568;
-    --kf-api-text: #000;
 }
 
 body[data-theme="dark"] {


### PR DESCRIPTION
## Summary

- Fixed light mode text being invisible (low contrast) when switching to Light in the Furo theme switcher
- Custom CSS was using `:root:not([data-theme="light"])` for dark overrides, but Furo sets `data-theme` on `body`, not `:root` — so dark variable overrides always applied even in Light mode
- Switched theme checks to `body`-based selectors and added explicit `body[data-theme="light"]` block for correct light-mode colors
Before 
<img width="1718" height="912" alt="image" src="https://github.com/user-attachments/assets/3acc37e8-cb2d-464f-bde1-798e348fd546" />

Fixes #331

After 

<img width="1712" height="968" alt="image" src="https://github.com/user-attachments/assets/1ad65b39-03f5-41d3-be83-0fadb9e3e868" />


## Test plan

- [x] Run `make docs` or `make docs-serve`
- [x] Open docs in browser with OS/browser set to dark mode
- [x] Click the Furo theme switcher and select **Light** — verify all text (sidebar, headings, body, TOC) is readable (dark on white)
- [x] Switch to **Dark** — verify dark theme still works correctly