### PR TITLE
chore: fix docstrings in TrainerClient

### DIFF
--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -76,11 +76,16 @@ class TrainerClient:
 
     def get_runtime(self, name: str) -> types.Runtime:
         """Get the runtime object
+
         Args:
             name: Name of the runtime.
 
         Returns:
             A runtime object.
+
+        Raises:
+            TimeoutError: Timeout to get a runtime.
+            RuntimeError: Failed to get a runtime.
         """
         return self.backend.get_runtime(name=name)
 


### PR DESCRIPTION
## What this PR does / why we need it

Fixes small docstring inconsistencies in `TrainerClient`:

* Print -> Get in `get_runtime_packages()`
* Added missing `Returns` section to `get_runtime_packages()`
* Added missing `Raises` section (`TimeoutError`, `RuntimeError`) to `get_runtime()`

Improves documentation consistency.

## Which issue(s) this PR fixes

General SDK maintenance (noticed while reviewing #164).

## Checklist

* Docs updated
* DCO signed
* Conventional commit format (`docs:`)
* No logic or API changes
