### PR TITLE
feat(trainer): Support NPU labels in TrainJob device

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -41,7 +41,6 @@ def get_container_devices(
     # TODO (andreyvelich): We should discuss how to get container device type.
     # Potentially, we can use the trainer.kubeflow.org/device label from the runtime or
     # node types.
-    # TODO (andreyvelich): Support other resource labels (e.g. NPUs).
     if constants.GPU_LABEL in resources.limits:
         device = constants.GPU_LABEL.split("/")[1]
         device_count = resources.limits[constants.GPU_LABEL].actual_instance
@@ -55,6 +54,13 @@ def get_container_devices(
         mig_key = mig_keys[0]
         device = mig_key.split("/")[1]
         device_count = resources.limits[mig_key].actual_instance
+    elif constants.NPU_LABEL in resources.limits:
+        # huawei.com/Ascend910 is the K8s extended resource key for Huawei's Ascend 910 NPU.
+        # Unlike GPU/TPU, the suffix ("Ascend910") doesn't generically describe the device
+        # type, so we explicitly return "npu" as the device string instead of deriving it
+        # from the key.
+        device = "npu"
+        device_count = resources.limits[constants.NPU_LABEL].actual_instance
     elif constants.CPU_LABEL in resources.limits:
         device = constants.CPU_LABEL
         device_count = resources.limits[constants.CPU_LABEL].actual_instance

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -61,6 +61,18 @@ def _build_runtime() -> types.Runtime:
             },
             expected_error=ValueError,
         ),
+        TestCase(
+            name="single NPU limit returns device and count",
+            expected_status=SUCCESS,
+            config={
+                "resources": models.IoK8sApiCoreV1ResourceRequirements(
+                    limits={
+                        constants.NPU_LABEL: models.IoK8sApimachineryPkgApiResourceQuantity(2),
+                    }
+                )
+            },
+            expected_output=("npu", "2.0"),
+        ),
     ],
 )
 def test_get_container_devices(test_case: TestCase):

--- a/kubeflow/trainer/constants/constants.py
+++ b/kubeflow/trainer/constants/constants.py
@@ -104,6 +104,12 @@ GPU_MIG_PREFIX = "nvidia.com/mig-"
 # The label for TPU in the container resources.
 TPU_LABEL = "google.com/tpu"
 
+# The label for NPU in the container resources.
+# Unlike GPU (nvidia.com/gpu) and TPU (google.com/tpu), NPU vendors don't use
+# a consistent suffix that maps to device type, so we hardcode the full
+# Huawei Ascend 910 resource label until a general strategy is agreed upon.
+NPU_LABEL = "huawei.com/Ascend910"
+
 # The label key to identify the JobSet name of the Pod.
 JOBSET_NAME_LABEL = "jobset.sigs.k8s.io/jobset-name"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for NPU resource labels in container resource limits,
resolving the existing TODO to support additional accelerator types
(e.g., NPUs).


Fixes NONE

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
