### PR TITLE
chore: Add make format target for Python code formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,12 @@ verify: install-dev  ## install all required tools
 	@uv run ruff format --check kubeflow
 	@uv run ty check kubeflow/hub
 
+.PHONY: format
+format:
+	@echo "Formatting code..."
+	@uv run ruff format .
+	@echo "Done."
+
 .PHONY: uv-venv
 uv-venv:  ## Create uv virtual environment
 	@if [ ! -d "$(VENV_DIR)" ]; then \


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a `make format` target to the Makefile to simplify Python code formatting
using Ruff.

Previously, you could only check if files were formatted or not, but now you can fix it using a make command.

Fixes NONE

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
