### PR TITLE
chore(spark): replace manual type checks with validation.py

### DIFF
--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -42,6 +42,13 @@ from kubeflow.spark.backends.kubernetes.utils import (
 )
 from kubeflow.spark.types.options import Name
 from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo, SparkConnectState
+from kubeflow.spark.types.validation import (
+    validate_driver,
+    validate_executor,
+    validate_num_instances,
+    validate_resource_dict,
+    validate_spark_conf,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -121,19 +128,11 @@ class KubernetesBackend(RuntimeBackend):
         options: list | None = None,
     ) -> SparkConnectInfo:
         """Create a new SparkConnect session (INTERNAL USE ONLY)."""
-        # Validate input types
-        if resources_per_executor is not None and not isinstance(resources_per_executor, dict):
-            raise TypeError(
-                f"resources_per_executor must be a dict, got {type(resources_per_executor)}"
-            )
-        if spark_conf is not None and not isinstance(spark_conf, dict):
-            raise TypeError(f"spark_conf must be a dict, got {type(spark_conf)}")
-        if num_executors is not None and not isinstance(num_executors, int):
-            raise TypeError(f"num_executors must be an int, got {type(num_executors)}")
-        if driver is not None and not isinstance(driver, Driver):
-            raise TypeError(f"driver must be a Driver instance, got {type(driver)}")
-        if executor is not None and not isinstance(executor, Executor):
-            raise TypeError(f"executor must be an Executor instance, got {type(executor)}")
+        validate_resource_dict(resources_per_executor, param_name="resources_per_executor")
+        validate_spark_conf(spark_conf)
+        validate_num_instances(num_executors, param_name="num_executors")
+        validate_driver(driver)
+        validate_executor(executor)
 
         # Extract Name option if present, or auto-generate
         name, filtered_options = self._extract_name_option(options)

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -37,7 +37,8 @@ from kubeflow.spark.test.common import (
     TestCase,
 )
 from kubeflow.spark.types.options import Labels, Name
-from kubeflow.spark.types.types import SparkConnectInfo, SparkConnectState
+from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo, SparkConnectState
+from kubeflow.spark.types.validation import ValidationError
 
 # --------------------------
 # Fixtures
@@ -733,6 +734,118 @@ def test_extract_name_option(kubernetes_backend, test_case):
         assert len(filtered) == test_case.expected_output["remaining_count"]
         if "remaining_type" in test_case.expected_output:
             assert isinstance(filtered[0], test_case.expected_output["remaining_type"])
+
+    except Exception as e:
+        assert type(e) is test_case.expected_error
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        # Invalid types
+        TestCase(
+            name="invalid resources_per_executor type",
+            expected_status=FAILED,
+            config={"resources_per_executor": "not-a-dict"},
+            expected_error=ValidationError,
+        ),
+        TestCase(
+            name="invalid spark_conf type",
+            expected_status=FAILED,
+            config={"spark_conf": "not-a-dict"},
+            expected_error=ValidationError,
+        ),
+        TestCase(
+            name="invalid num_executors type",
+            expected_status=FAILED,
+            config={"num_executors": "3"},
+            expected_error=ValidationError,
+        ),
+        TestCase(
+            name="invalid driver type",
+            expected_status=FAILED,
+            config={"driver": {"image": "spark:3.4"}},
+            expected_error=ValidationError,
+        ),
+        TestCase(
+            name="invalid executor type",
+            expected_status=FAILED,
+            config={"executor": {"num_instances": 2}},
+            expected_error=ValidationError,
+        ),
+        # Invalid values
+        TestCase(
+            name="negative num_executors",
+            expected_status=FAILED,
+            config={"num_executors": -1},
+            expected_error=ValidationError,
+        ),
+        TestCase(
+            name="bad memory format in resources_per_executor",
+            expected_status=FAILED,
+            config={"resources_per_executor": {"memory": "lots"}},
+            expected_error=ValidationError,
+        ),
+        TestCase(
+            name="bad cpu format in resources_per_executor",
+            expected_status=FAILED,
+            config={"resources_per_executor": {"cpu": "fast"}},
+            expected_error=ValidationError,
+        ),
+        # Invalid nested fields in Driver/Executor
+        TestCase(
+            name="driver with invalid service account",
+            expected_status=FAILED,
+            config={"driver": Driver(service_account="INVALID ACCOUNT")},
+            expected_error=ValidationError,
+        ),
+        TestCase(
+            name="executor with negative num_instances",
+            expected_status=FAILED,
+            config={"executor": Executor(num_instances=-5)},
+            expected_error=ValidationError,
+        ),
+        # Valid inputs
+        TestCase(
+            name="all valid params",
+            expected_status=SUCCESS,
+            config={
+                "num_executors": 3,
+                "resources_per_executor": {"cpu": "4", "memory": "8Gi"},
+                "spark_conf": {"spark.sql.adaptive.enabled": "true"},
+                "driver": Driver(image="spark:3.4", service_account="spark-sa"),
+                "executor": Executor(
+                    num_instances=2, resources_per_executor={"cpu": "2"}
+                ),
+                "session_name": "valid-session",
+            },
+        ),
+        TestCase(
+            name="all none params",
+            expected_status=SUCCESS,
+            config={},
+        ),
+    ],
+)
+def test_create_session_validation(kubernetes_backend, test_case):
+    """Test _create_session input validation via validation.py functions."""
+    print("Executing test:", test_case.name)
+    try:
+        kubernetes_backend.namespace = test_case.config.get("namespace", DEFAULT_NAMESPACE)
+        session_name = test_case.config.get("session_name")
+        options = [Name(session_name)] if session_name else None
+
+        kubernetes_backend._create_session(
+            num_executors=test_case.config.get("num_executors"),
+            resources_per_executor=test_case.config.get("resources_per_executor"),
+            spark_conf=test_case.config.get("spark_conf"),
+            driver=test_case.config.get("driver"),
+            executor=test_case.config.get("executor"),
+            options=options,
+        )
+
+        assert test_case.expected_status == SUCCESS
 
     except Exception as e:
         assert type(e) is test_case.expected_error

--- a/kubeflow/spark/types/validation.py
+++ b/kubeflow/spark/types/validation.py
@@ -195,3 +195,50 @@ def validate_service_account(sa: str | None) -> None:
 
     if len(sa) > 253:
         raise ValidationError(f"service_account name too long ({len(sa)} chars, max 253)")
+
+
+def validate_driver(driver) -> None:
+    """Validate Driver configuration and its nested fields.
+
+    Args:
+        driver: Driver instance to validate.
+
+    Raises:
+        ValidationError: If validation fails.
+    """
+    if driver is None:
+        return
+
+    from kubeflow.spark.types.types import Driver
+
+    if not isinstance(driver, Driver):
+        raise ValidationError(f"driver must be a Driver instance, got {type(driver).__name__}")
+
+    validate_image_name(driver.image)
+    validate_resource_dict(driver.resources, param_name="driver.resources")
+    validate_service_account(driver.service_account)
+
+
+def validate_executor(executor) -> None:
+    """Validate Executor configuration and its nested fields.
+
+    Args:
+        executor: Executor instance to validate.
+
+    Raises:
+        ValidationError: If validation fails.
+    """
+    if executor is None:
+        return
+
+    from kubeflow.spark.types.types import Executor
+
+    if not isinstance(executor, Executor):
+        raise ValidationError(
+            f"executor must be an Executor instance, got {type(executor).__name__}"
+        )
+
+    validate_num_instances(executor.num_instances, param_name="executor.num_instances")
+    validate_resource_dict(
+        executor.resources_per_executor, param_name="executor.resources_per_executor"
+    )

--- a/kubeflow/spark/types/validation_test.py
+++ b/kubeflow/spark/types/validation_test.py
@@ -1,0 +1,226 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for validation utilities."""
+
+import pytest
+
+from kubeflow.spark.types.types import Driver, Executor
+from kubeflow.spark.types.validation import (
+    ValidationError,
+    validate_driver,
+    validate_executor,
+    validate_image_name,
+    validate_num_instances,
+    validate_resource_dict,
+    validate_service_account,
+    validate_spark_conf,
+)
+
+
+class TestValidateResourceDict:
+    """Tests for validate_resource_dict."""
+
+    def test_none_passes(self):
+        validate_resource_dict(None)
+
+    def test_valid_dict(self):
+        validate_resource_dict({"cpu": "4", "memory": "8Gi"})
+
+    def test_wrong_type(self):
+        with pytest.raises(ValidationError, match="must be a dict"):
+            validate_resource_dict("bad")
+
+    def test_empty_dict(self):
+        with pytest.raises(ValidationError, match="cannot be an empty dict"):
+            validate_resource_dict({})
+
+    def test_non_string_key(self):
+        with pytest.raises(ValidationError, match="keys must be strings"):
+            validate_resource_dict({123: "4"})
+
+    def test_non_string_value(self):
+        with pytest.raises(ValidationError, match="values must be strings"):
+            validate_resource_dict({"cpu": 4})
+
+    def test_invalid_memory_format(self):
+        with pytest.raises(ValidationError, match="Invalid memory format"):
+            validate_resource_dict({"memory": "lots"})
+
+    def test_valid_memory_formats(self):
+        for mem in ["512Mi", "4Gi", "1Ti", "100Ki", "8"]:
+            validate_resource_dict({"memory": mem})
+
+    def test_invalid_cpu_format(self):
+        with pytest.raises(ValidationError, match="Invalid CPU format"):
+            validate_resource_dict({"cpu": "fast"})
+
+    def test_valid_cpu_formats(self):
+        for cpu in ["4", "0.5", "500m", "1"]:
+            validate_resource_dict({"cpu": cpu})
+
+
+class TestValidateSparkConf:
+    """Tests for validate_spark_conf."""
+
+    def test_none_passes(self):
+        validate_spark_conf(None)
+
+    def test_valid_conf(self):
+        validate_spark_conf({"spark.sql.adaptive.enabled": "true"})
+
+    def test_wrong_type(self):
+        with pytest.raises(ValidationError, match="must be a dict"):
+            validate_spark_conf("bad")
+
+    def test_non_string_key(self):
+        with pytest.raises(ValidationError, match="keys must be strings"):
+            validate_spark_conf({42: "value"})
+
+    def test_non_string_value(self):
+        with pytest.raises(ValidationError, match="values must be strings"):
+            validate_spark_conf({"spark.key": 42})
+
+
+class TestValidateNumInstances:
+    """Tests for validate_num_instances."""
+
+    def test_none_passes(self):
+        validate_num_instances(None)
+
+    def test_valid_num(self):
+        validate_num_instances(5)
+
+    def test_wrong_type(self):
+        with pytest.raises(ValidationError, match="must be an integer"):
+            validate_num_instances("3")
+
+    def test_zero(self):
+        with pytest.raises(ValidationError, match="must be positive"):
+            validate_num_instances(0)
+
+    def test_negative(self):
+        with pytest.raises(ValidationError, match="must be positive"):
+            validate_num_instances(-1)
+
+    def test_very_large(self):
+        with pytest.raises(ValidationError, match="seems very large"):
+            validate_num_instances(20000)
+
+
+class TestValidateImageName:
+    """Tests for validate_image_name."""
+
+    def test_none_passes(self):
+        validate_image_name(None)
+
+    def test_valid_images(self):
+        for img in ["spark:3.4.1", "gcr.io/my-project/spark:latest", "my-repo/image"]:
+            validate_image_name(img)
+
+    def test_wrong_type(self):
+        with pytest.raises(ValidationError, match="must be a string"):
+            validate_image_name(123)
+
+    def test_empty(self):
+        with pytest.raises(ValidationError, match="cannot be empty"):
+            validate_image_name("")
+
+    def test_whitespace(self):
+        with pytest.raises(ValidationError, match="cannot be empty"):
+            validate_image_name("   ")
+
+    def test_invalid_format(self):
+        with pytest.raises(ValidationError, match="Invalid Docker image name"):
+            validate_image_name("image with spaces")
+
+
+class TestValidateServiceAccount:
+    """Tests for validate_service_account."""
+
+    def test_none_passes(self):
+        validate_service_account(None)
+
+    def test_valid_sa(self):
+        validate_service_account("spark-sa")
+
+    def test_wrong_type(self):
+        with pytest.raises(ValidationError, match="must be a string"):
+            validate_service_account(123)
+
+    def test_empty(self):
+        with pytest.raises(ValidationError, match="cannot be empty"):
+            validate_service_account("")
+
+    def test_invalid_format(self):
+        with pytest.raises(ValidationError, match="Invalid service account name"):
+            validate_service_account("UPPER_CASE")
+
+    def test_too_long(self):
+        with pytest.raises(ValidationError, match="too long"):
+            validate_service_account("a" * 254)
+
+
+class TestValidateDriver:
+    """Tests for validate_driver."""
+
+    def test_none_passes(self):
+        validate_driver(None)
+
+    def test_valid_driver(self):
+        validate_driver(Driver(image="spark:3.4", service_account="spark-sa"))
+
+    def test_valid_driver_all_none(self):
+        validate_driver(Driver())
+
+    def test_wrong_type(self):
+        with pytest.raises(ValidationError, match="must be a Driver instance"):
+            validate_driver({"image": "spark:3.4"})
+
+    def test_invalid_image(self):
+        with pytest.raises(ValidationError, match="Invalid Docker image name"):
+            validate_driver(Driver(image="image with spaces"))
+
+    def test_invalid_resources(self):
+        with pytest.raises(ValidationError, match="Invalid memory format"):
+            validate_driver(Driver(resources={"memory": "bad"}))
+
+    def test_invalid_service_account(self):
+        with pytest.raises(ValidationError, match="Invalid service account name"):
+            validate_driver(Driver(service_account="BAD ACCOUNT"))
+
+
+class TestValidateExecutor:
+    """Tests for validate_executor."""
+
+    def test_none_passes(self):
+        validate_executor(None)
+
+    def test_valid_executor(self):
+        validate_executor(Executor(num_instances=3, resources_per_executor={"cpu": "4"}))
+
+    def test_valid_executor_all_none(self):
+        validate_executor(Executor())
+
+    def test_wrong_type(self):
+        with pytest.raises(ValidationError, match="must be an Executor instance"):
+            validate_executor({"num_instances": 2})
+
+    def test_invalid_num_instances(self):
+        with pytest.raises(ValidationError, match="must be positive"):
+            validate_executor(Executor(num_instances=-1))
+
+    def test_invalid_resources(self):
+        with pytest.raises(ValidationError, match="Invalid CPU format"):
+            validate_executor(Executor(resources_per_executor={"cpu": "bad"}))


### PR DESCRIPTION
## Summary

- Wire existing validation functions (`validate_resource_dict`, `validate_spark_conf`, `validate_num_instances`) and new `validate_driver`/`validate_executor` into `KubernetesBackend._create_session()`, removing 5 inline `isinstance` blocks
- Add `validate_driver()` and `validate_executor()` to `validation.py` that check type + validate nested fields (image format, service account, resources, num_instances)
- Add `test_create_session_validation` parametrized test (12 cases) to `backend_test.py`
- Add `validation_test.py` (46 cases) covering all validation functions

## Behavioral changes (all improvements)

- Exception type: `TypeError` → `ValidationError(ValueError)` — `_create_session` is internal-only
- Empty dicts now rejected for `resources_per_executor`
- Invalid memory/CPU formats caught early with clear messages
- `num_executors <= 0` now caught (previously silently passed to K8s API)
- Driver/Executor nested fields validated (image format, service account format, etc.)

## Test plan

- [x] `uv run pytest kubeflow/spark/types/validation_test.py -v` — 46 passed
- [x] `uv run pytest kubeflow/spark/backends/kubernetes/backend_test.py -v` — 45 passed (including 12 new validation cases)
- [x] All existing tests unaffected

Closes #272