### PR TITLE
fix(trainer): raise ValueError for missing containers instead of Stop…

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -155,13 +155,26 @@ def get_trainjob_initializer_step(
 ) -> types.Step:
     """
     Get the TrainJob initializer step from the given Pod name, spec, and status.
+
+    Raises:
+        ValueError: If the pod has no container named dataset-initializer or model-initializer.
     """
 
     container = next(
-        c
-        for c in pod_spec.containers
-        if c.name in {constants.DATASET_INITIALIZER, constants.MODEL_INITIALIZER}
+        (
+            c
+            for c in pod_spec.containers
+            if c.name in {constants.DATASET_INITIALIZER, constants.MODEL_INITIALIZER}
+        ),
+        None,
     )
+    if container is None:
+        raise ValueError(
+            f"Pod '{pod_name}' has no initializer container. "
+            f"Expected a container named '{constants.DATASET_INITIALIZER}' or "
+            f"'{constants.MODEL_INITIALIZER}', but found: "
+            f"{[c.name for c in pod_spec.containers]}"
+        )
 
     step = types.Step(
         name=container.name,
@@ -185,9 +198,21 @@ def get_trainjob_node_step(
 ) -> types.Step:
     """
     Get the TrainJob trainer node step from the given Pod name, spec, and status.
+
+    Raises:
+        ValueError: If the pod has no container named node.
     """
 
-    container = next(c for c in pod_spec.containers if c.name == constants.NODE)
+    container = next(
+        (c for c in pod_spec.containers if c.name == constants.NODE),
+        None,
+    )
+    if container is None:
+        raise ValueError(
+            f"Pod '{pod_name}' has no node container. "
+            f"Expected a container named '{constants.NODE}', but found: "
+            f"{[c.name for c in pod_spec.containers]}"
+        )
 
     step = types.Step(
         name=f"{constants.NODE}-{job_index}",

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -815,3 +815,172 @@ def test_get_args_from_dataset_preprocess_config(test_case: TestCase):
         assert test_case.expected_status == FAILED
         assert type(e) is test_case.expected_error
     print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="dataset-initializer container with Running status returns correct Step",
+            expected_status=SUCCESS,
+            config={
+                "pod_name": "test-pod",
+                "pod_spec": models.IoK8sApiCoreV1PodSpec(
+                    containers=[models.IoK8sApiCoreV1Container(name=constants.DATASET_INITIALIZER)]
+                ),
+                "pod_status": models.IoK8sApiCoreV1PodStatus(phase="Running"),
+            },
+            expected_output=types.Step(
+                name=constants.DATASET_INITIALIZER,
+                status="Running",
+                pod_name="test-pod",
+            ),
+        ),
+        TestCase(
+            name="model-initializer container with no status returns Step with None status",
+            expected_status=SUCCESS,
+            config={
+                "pod_name": "test-pod",
+                "pod_spec": models.IoK8sApiCoreV1PodSpec(
+                    containers=[models.IoK8sApiCoreV1Container(name=constants.MODEL_INITIALIZER)]
+                ),
+                "pod_status": None,
+            },
+            expected_output=types.Step(
+                name=constants.MODEL_INITIALIZER,
+                status=None,
+                pod_name="test-pod",
+            ),
+        ),
+        TestCase(
+            name="pod with no initializer container raises ValueError",
+            expected_status=FAILED,
+            config={
+                "pod_name": "test-pod",
+                "pod_spec": models.IoK8sApiCoreV1PodSpec(
+                    containers=[models.IoK8sApiCoreV1Container(name="unrelated-container")]
+                ),
+                "pod_status": None,
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="pod with empty container list raises ValueError",
+            expected_status=FAILED,
+            config={
+                "pod_name": "test-pod",
+                "pod_spec": models.IoK8sApiCoreV1PodSpec(containers=[]),
+                "pod_status": None,
+            },
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_get_trainjob_initializer_step(test_case: TestCase):
+    print("Executing test:", test_case.name)
+    try:
+        step = utils.get_trainjob_initializer_step(
+            pod_name=test_case.config["pod_name"],
+            pod_spec=test_case.config["pod_spec"],
+            pod_status=test_case.config["pod_status"],
+        )
+
+        assert test_case.expected_status == SUCCESS
+        assert step == test_case.expected_output
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert type(e) is test_case.expected_error
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="node container with Running status returns Step name node-0",
+            expected_status=SUCCESS,
+            config={
+                "pod_name": "test-pod",
+                "pod_spec": models.IoK8sApiCoreV1PodSpec(
+                    containers=[models.IoK8sApiCoreV1Container(name=constants.NODE)]
+                ),
+                "pod_status": models.IoK8sApiCoreV1PodStatus(phase="Running"),
+                "trainjob_runtime": _build_runtime(),
+                "replicated_job_name": constants.NODE,
+                "job_index": 0,
+            },
+            expected_output=types.Step(
+                name="node-0",
+                status="Running",
+                pod_name="test-pod",
+            ),
+        ),
+        TestCase(
+            name="node container with no status returns Step with None status",
+            expected_status=SUCCESS,
+            config={
+                "pod_name": "test-pod",
+                "pod_spec": models.IoK8sApiCoreV1PodSpec(
+                    containers=[models.IoK8sApiCoreV1Container(name=constants.NODE)]
+                ),
+                "pod_status": None,
+                "trainjob_runtime": _build_runtime(),
+                "replicated_job_name": constants.NODE,
+                "job_index": 0,
+            },
+            expected_output=types.Step(
+                name="node-0",
+                status=None,
+                pod_name="test-pod",
+            ),
+        ),
+        TestCase(
+            name="pod with no node container raises ValueError",
+            expected_status=FAILED,
+            config={
+                "pod_name": "test-pod",
+                "pod_spec": models.IoK8sApiCoreV1PodSpec(
+                    containers=[models.IoK8sApiCoreV1Container(name="unrelated-container")]
+                ),
+                "pod_status": None,
+                "trainjob_runtime": _build_runtime(),
+                "replicated_job_name": constants.NODE,
+                "job_index": 0,
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="pod with empty container list raises ValueError",
+            expected_status=FAILED,
+            config={
+                "pod_name": "test-pod",
+                "pod_spec": models.IoK8sApiCoreV1PodSpec(containers=[]),
+                "pod_status": None,
+                "trainjob_runtime": _build_runtime(),
+                "replicated_job_name": constants.NODE,
+                "job_index": 0,
+            },
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_get_trainjob_node_step(test_case: TestCase):
+    print("Executing test:", test_case.name)
+    try:
+        step = utils.get_trainjob_node_step(
+            pod_name=test_case.config["pod_name"],
+            pod_spec=test_case.config["pod_spec"],
+            pod_status=test_case.config["pod_status"],
+            trainjob_runtime=test_case.config["trainjob_runtime"],
+            replicated_job_name=test_case.config["replicated_job_name"],
+            job_index=test_case.config["job_index"],
+        )
+
+        assert test_case.expected_status == SUCCESS
+        assert step == test_case.expected_output
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert type(e) is test_case.expected_error
+    print("test execution complete")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
`next()` on a bare generator with no default raises `StopIteration`, which
  Python 3.7+ (PEP 479) promotes to a `RuntimeError` with no pod/container
  context. Hardens two functions in `utils.py`:

- `get_trainjob_initializer_step`: replaced bare `next(gen)` with  `next(..., None)` + explicit `ValueError` naming the pod and listingactual containers found
- `get_trainjob_node_step`: same pattern applied
- Added `Raises:` docstring section to both functions
- Added first unit test coverage for both functions (8 parametrized cases)

**Which issue(s) this PR fixes**

General SDK hardening (noticed while exploring the codebase for #164).

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
- DCO signed (`-s` flag on commit)
- Conventional commit format (`fix(trainer):`)
- No public API changes
