### PR TITLE
feat(container): run dataset and model initializers in parallel

### DIFF
--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -596,10 +596,16 @@ class ContainerBackend(RuntimeBackend):
                     future.result()
                     logger.debug(f"{name.capitalize()} initializer completed")
                 except Exception as e:
-                    logger.error(f"{name.capitalize()} initializer failed: {e}")
+                    logger.exception(f"{name.capitalize()} initializer failed")
                     errors.append((name, e))
 
         if errors:
+            # If exactly one initializer failed, re-raise its original exception
+            # to match the behavior of the single-initializer path; aggregate
+            # into a RuntimeError only when multiple initializers fail.
+            if len(errors) == 1:
+                _, exc = errors[0]
+                raise exc
             error_details = "; ".join(f"{name}: {e}" for name, e in errors)
             raise RuntimeError(f"Initializer(s) failed: {error_details}") from errors[0][1]
 


### PR DESCRIPTION
## What this PR does

Refactors `_run_initializers()` in `ContainerBackend` to run dataset and model initializer containers **in parallel** using `concurrent.futures.ThreadPoolExecutor` when both are configured.

### Problem

Currently, the dataset initializer must complete before the model initializer starts. Since these containers download independent data to separate paths (`/workspace/dataset` and `/workspace/model`) and Docker/Podman support multiple containers mounting the same volume simultaneously, there's no reason to run them sequentially.

### Solution

| Scenario | Behavior |
|---|---|
| Single initializer (dataset **or** model) | Runs directly — no thread pool overhead |
| Both initializers | Runs in parallel via `ThreadPoolExecutor` |

Key design decisions:
- **Image pulls remain serialized** before thread submission to avoid potential race conditions in the Docker/Podman API
- **All errors are collected**: If both initializers fail, the error message includes details from both failures
- **Import moved to top-level**: `concurrent.futures` is imported at module level following the existing import style

### Changes

- `kubeflow/trainer/backends/container/backend.py`: Refactored `_run_initializers()` method

### Testing

The existing test suite covers this change:
- `test_train["train with both dataset and model initializers"]` — verifies both initializers run and produce the expected containers
- `test_train["initializer fails with non-zero exit code"]` — verifies error handling
- `test_train["initializer timeout"]` — verifies timeout handling

Fixes #290