### PR TITLE
feat(spark): add validate_resource_string utility function

### DIFF
--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -73,7 +73,7 @@ def validate_resource_string(value: str) -> None:
     match = re.fullmatch(r"([0-9]+)([A-Za-z]*)", value)
     if not match or match.group(2) not in _VALID_UNITS:
         raise ValueError(
-            f"Invalid Kubernetes resource string: {value!r}Valid units are: {sorted(_VALID_UNITS)}"
+            f"Invalid Kubernetes resource string: {value!r} Valid units are: {sorted(u for u in _VALID_UNITS if u)}"
         )
 
 
@@ -184,8 +184,10 @@ def get_executor_spec_from_executor(
 
     if resource_dict:
         if "cpu" in resource_dict:
+            validate_resource_string(resource_dict["cpu"])
             cores = int(resource_dict["cpu"])
         if "memory" in resource_dict:
+            validate_resource_string([resource_dict["memory"]])
             memory = _memory_kubernetes_to_spark(resource_dict["memory"])
 
     return models.SparkV1alpha1ExecutorSpec(

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -125,6 +125,10 @@ class TestValidateResourceString:
         with pytest.raises(ValueError, match="Invalid Kubernetes resource string"):
             validate_resource_string("256 Mi")
 
+    def test_decimal_rejected(self):
+        with pytest.raises(ValueError, match="Invalid Kubernetes resource string"):
+            validate_resource_string("1.5Gi")
+
 
 class TestBuildServiceUrl:
     """Tests for build_service_url function."""


### PR DESCRIPTION
Closes #359

## What this PR does
Adds a `validate_resource_string()` function to `utils.py` 
that validates Kubernetes resource strings (e.g. "256Mi", "2Gi") 
before they reach the cluster.

## Why
Currently invalid strings like "256GB" get sent directly to 
Kubernetes which fails with a cryptic error. This catches it 
early with a helpful message.

## Note
Only integer quantities are supported (e.g. "256Mi"). 
Decimal quantities (e.g. "1.5Gi") are not currently supported.

## Testing
Added 10 unit tests covering valid inputs, invalid units, 
missing numbers, empty strings, and non-string inputs.

Assisted-by: Claude (Anthropic)
