### PR TITLE
fix(trainer): adapt SDK to removal of numProcPerNode from TorchMLPolicySource

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -58,8 +58,8 @@ FORBIDDEN = "forbidden"
 TORCH_RUNTIME = "torch"
 TORCH_TUNE_RUNTIME = "torchtune"
 
-# 2 nodes * 2 nproc
-RUNTIME_DEVICES = "4"
+# Device count = GPU resources per node (1) × num_nodes (2) = 2
+RUNTIME_DEVICES = "2"
 
 FAIL_LOGS = "fail_logs"
 LIST_RUNTIMES = "list_runtimes"
@@ -603,9 +603,7 @@ def create_cluster_training_runtime(
         ),
         spec=models.TrainerV1alpha1TrainingRuntimeSpec(
             mlPolicy=models.TrainerV1alpha1MLPolicy(
-                torch=models.TrainerV1alpha1TorchMLPolicySource(
-                    numProcPerNode=models.IoK8sApimachineryPkgUtilIntstrIntOrString(2)
-                ),
+                torch=models.TrainerV1alpha1TorchMLPolicySource(),
                 numNodes=2,
             ),
             template=models.TrainerV1alpha1JobSetTemplateSpec(
@@ -634,9 +632,7 @@ def create_training_runtime(
         ),
         spec=models.TrainerV1alpha1TrainingRuntimeSpec(
             mlPolicy=models.TrainerV1alpha1MLPolicy(
-                torch=models.TrainerV1alpha1TorchMLPolicySource(
-                    numProcPerNode=models.IoK8sApimachineryPkgUtilIntstrIntOrString(2)
-                ),
+                torch=models.TrainerV1alpha1TorchMLPolicySource(),
                 numNodes=2,
             ),
             template=models.TrainerV1alpha1JobSetTemplateSpec(

--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -119,12 +119,8 @@ def get_runtime_trainer(
     if devices := get_container_devices(trainer_container.resources):
         trainer.device, trainer.device_count = devices
 
-    # Torch and MPI plugins override accelerator count.
-    if ml_policy.torch and ml_policy.torch.num_proc_per_node:
-        num_proc = ml_policy.torch.num_proc_per_node.actual_instance
-        if isinstance(num_proc, int):
-            trainer.device_count = str(num_proc)
-    elif ml_policy.mpi and ml_policy.mpi.num_proc_per_node:
+    # MPI plugin overrides accelerator count.
+    if ml_policy.mpi and ml_policy.mpi.num_proc_per_node:
         trainer.device_count = str(ml_policy.mpi.num_proc_per_node)
 
     # Multiply accelerator_count by the number of nodes.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes `ml_policy.torch.num_proc_per_node` access and updates test fixtures to use empty `TorchMLPolicySource()` constructor.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #353 

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
