### PR TITLE
fix(trainer): replace os.chdir() with cwd= in subprocess.Popen to fix race condition

### DIFF
--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -563,10 +563,11 @@ def test_get_job_status(local_backend, test_case):
 
 def test_concurrent_localjobs_do_not_change_cwd():
     """Concurrent LocalJob threads must not mutate the parent process cwd."""
+    import os
     import threading
+
     from kubeflow.trainer.backends.localprocess.job import LocalJob
 
-    import os
     original_cwd = os.getcwd()
     errors = []
 
@@ -582,6 +583,7 @@ def test_concurrent_localjobs_do_not_change_cwd():
             errors.append(f"cwd changed to {os.getcwd()}")
 
     import tempfile
+
     dirs = [tempfile.mkdtemp() for _ in range(5)]
     threads = [threading.Thread(target=run_job, args=(d,)) for d in dirs]
     for t in threads:

--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -559,3 +559,35 @@ def test_get_job_status(local_backend, test_case):
 
     status = local_backend._LocalProcessBackend__get_job_status(job)
     assert status == test_case.expected_output
+
+
+def test_concurrent_localjobs_do_not_change_cwd():
+    """Concurrent LocalJob threads must not mutate the parent process cwd."""
+    import threading
+    from kubeflow.trainer.backends.localprocess.job import LocalJob
+
+    import os
+    original_cwd = os.getcwd()
+    errors = []
+
+    def run_job(tmp_dir):
+        job = LocalJob(
+            name=f"test-job-{tmp_dir}",
+            command=["echo", "hello"],
+            execution_dir=tmp_dir,
+        )
+        job.start()
+        job.join()
+        if os.getcwd() != original_cwd:
+            errors.append(f"cwd changed to {os.getcwd()}")
+
+    import tempfile
+    dirs = [tempfile.mkdtemp() for _ in range(5)]
+    threads = [threading.Thread(target=run_job, args=(d,)) for d in dirs]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert os.getcwd() == original_cwd, f"cwd was mutated: {os.getcwd()}"
+    assert not errors, f"cwd changed in threads: {errors}"

--- a/kubeflow/trainer/backends/localprocess/job.py
+++ b/kubeflow/trainer/backends/localprocess/job.py
@@ -72,7 +72,6 @@ class LocalJob(threading.Thread):
             _c = " ".join(self.command)
             logger.debug(f"[{self.name}] Started at {self._start_time} with command: \n {_c}")
 
-
             self._process = subprocess.Popen(
                 self.command,
                 cwd=self.execution_dir,

--- a/kubeflow/trainer/backends/localprocess/job.py
+++ b/kubeflow/trainer/backends/localprocess/job.py
@@ -67,17 +67,15 @@ class LocalJob(threading.Thread):
                     self._stdout = f"Dependency {dep.name} failed. Skipping"
                 return
 
-        current_dir = os.getcwd()
         try:
             self._start_time = datetime.now()
             _c = " ".join(self.command)
             logger.debug(f"[{self.name}] Started at {self._start_time} with command: \n {_c}")
 
-            # change working directory to venv before executing script
-            os.chdir(self.execution_dir)
 
             self._process = subprocess.Popen(
                 self.command,
+                cwd=self.execution_dir,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
@@ -126,8 +124,6 @@ class LocalJob(threading.Thread):
                 self._stdout += f"Exception: {e}\n"
                 self._success = False
                 self._status = constants.TRAINJOB_FAILED
-        finally:
-            os.chdir(current_dir)
 
     @property
     def stdout(self):


### PR DESCRIPTION
Description:
Summary
Fixes a race condition in LocalJob where concurrent threads could corrupt each other's working directory.
Problem
LocalJob inherits from threading.Thread. The run() method called os.chdir(self.execution_dir) before spawning the subprocess, then restored it in a finally block. Since os.chdir() mutates the working directory of the entire process (not just the thread), multiple concurrent LocalJob threads would overwrite each other's directory mid-execution, causing unpredictable path-resolution failures.
Fix
Removed os.chdir() and the finally cleanup entirely. Passed cwd=self.execution_dir directly to subprocess.Popen(), which scopes the directory change to the subprocess only — exactly as intended.
Changes

kubeflow/trainer/backends/localprocess/job.py — removed os.chdir() + finally block, added cwd= to Popen
kubeflow/trainer/backends/localprocess/backend_test.py — added test_concurrent_localjobs_do_not_change_cwd which spawns 5 concurrent jobs in different directories and verifies the parent process cwd is never mutated

Testing
24 passed in 0.85s
Fixes #356