### PR TITLE
feat: add train() and optimize() methods to TrainJobTemplate

### DIFF
--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -492,7 +492,6 @@ class Initializer:
     model: HuggingFaceModelInitializer | S3ModelInitializer | None = None
 
 
-# TODO (andreyvelich): Add train() and optimize() methods to this class.
 @dataclass
 class TrainJobTemplate:
     """TrainJob template configuration.
@@ -515,3 +514,61 @@ class TrainJobTemplate:
 
     def __getitem__(self, key):
         return getattr(self, key)
+
+    def train(self, options: list | None = None) -> str:
+        """Create a TrainJob using this template's configuration.
+
+        Args:
+            options: Optional list of configuration options to apply to the TrainJob.
+                Options can be imported from kubeflow.trainer.options.
+
+        Returns:
+            The unique name of the TrainJob that has been generated.
+
+        Raises:
+            ValueError: Input arguments are invalid.
+            TimeoutError: Timeout to create TrainJob.
+            RuntimeError: Failed to create TrainJob.
+        """
+        from kubeflow.trainer.api.trainer_client import TrainerClient
+
+        return TrainerClient().train(
+            runtime=self.runtime,
+            initializer=self.initializer,
+            trainer=self.trainer,
+            options=options,
+        )
+
+    def optimize(
+        self,
+        search_space: dict,
+        *,
+        trial_config=None,
+        objectives=None,
+        algorithm=None,
+    ) -> str:
+        """Create an Experiment using this template's configuration.
+
+        Args:
+            search_space: Dictionary mapping parameter names to Search specifications.
+            trial_config: Optional configuration to run Trials.
+            objectives: List of objectives to optimize.
+            algorithm: The optimization algorithm to use. Defaults to RandomSearch.
+
+        Returns:
+            The unique name of the Experiment that has been generated.
+
+        Raises:
+            ValueError: Input arguments are invalid.
+            TimeoutError: Timeout to create Experiment.
+            RuntimeError: Failed to create Experiment.
+        """
+        from kubeflow.optimizer.api.optimizer_client import OptimizerClient
+
+        return OptimizerClient().optimize(
+            trial_template=self,
+            trial_config=trial_config,
+            search_space=search_space,
+            objectives=objectives,
+            algorithm=algorithm,
+        )

--- a/kubeflow/trainer/types/types_test.py
+++ b/kubeflow/trainer/types/types_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
@@ -113,3 +115,53 @@ def test_data_cache_initializer(test_case: TestCase):
         assert test_case.expected_status == FAILED
         assert type(e) is test_case.expected_error
     print("test execution complete")
+
+
+def test_trainjob_template_train():
+    """Test TrainJobTemplate.train() delegates to TrainerClient."""
+    template = types.TrainJobTemplate(
+        trainer=types.CustomTrainer(func=lambda: None),
+        runtime="torch-distributed",
+        initializer=None,
+    )
+
+    with patch("kubeflow.trainer.api.trainer_client.TrainerClient") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.train.return_value = "test-job-name"
+        mock_client_cls.return_value = mock_client
+
+        result = template.train()
+
+        mock_client.train.assert_called_once_with(
+            runtime="torch-distributed",
+            initializer=None,
+            trainer=template.trainer,
+            options=None,
+        )
+        assert result == "test-job-name"
+
+
+def test_trainjob_template_optimize():
+    """Test TrainJobTemplate.optimize() delegates to OptimizerClient."""
+    template = types.TrainJobTemplate(
+        trainer=types.CustomTrainer(func=lambda: None),
+        runtime="torch-distributed",
+        initializer=None,
+    )
+    search_space = {"lr": 0.01}
+
+    with patch("kubeflow.optimizer.api.optimizer_client.OptimizerClient") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.optimize.return_value = "test-experiment-name"
+        mock_client_cls.return_value = mock_client
+
+        result = template.optimize(search_space=search_space)
+
+        mock_client.optimize.assert_called_once_with(
+            trial_template=template,
+            trial_config=None,
+            search_space=search_space,
+            objectives=None,
+            algorithm=None,
+        )
+        assert result == "test-experiment-name"


### PR DESCRIPTION
Resolves the TODO added by @andreyvelich in `kubeflow/trainer/types/types.py`.

Previously, `TrainJobTemplate` had a TODO to add `train()` and `optimize()` methods.
Users had to manually instantiate `TrainerClient` or `OptimizerClient` to submit jobs.

This PR adds:
- `train()`: delegates to `TrainerClient.train()` using the template's `runtime`, `initializer`, and `trainer` config.
- `optimize()`: delegates to `OptimizerClient.optimize()` using the template as the `trial_template`.

Lazy imports are used inside each method to avoid circular import issues between `types.py`, `trainer_client.py`, and `optimizer_client.py`.

**Changes:**
- `kubeflow/trainer/types/types.py`: Added `train()` and `optimize()` methods to `TrainJobTemplate`. Removed the TODO comment.
- `kubeflow/trainer/types/types_test.py`: Added unit tests for both methods using mocks.