### PR TITLE
chore: improve trainer docstrings and contributing guide formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@ This guide explains how to contribute to the Kubeflow SDK project.
 For the Kubeflow SDK documentation, please check [the official Kubeflow documentation](https://www.kubeflow.org/docs/components/).
 
 ## Requirements
+
 - [Supported Python version](./pyproject.toml#L4)
 - [pre-commit](https://pre-commit.com/)
 - [uv](https://docs.astral.sh/uv/getting-started/installation/)
-
 
 ## Development
 
@@ -20,6 +20,7 @@ make install-dev
 ```
 
 ### Coding Style
+
 Make sure to install [pre-commit](https://pre-commit.com/) (`uv pip install pre-commit`) and run `pre-commit install` from the root of the repository at least once before creating git commits.
 
 The pre-commit hooks ensure code quality and consistency. They are executed in CI. PRs that fail to comply with the hooks will not be able to pass the corresponding CI gate. The hooks are only executed against staged files unless you run `pre-commit run --all`, in which case, they'll be executed against every file in the repository.
@@ -37,6 +38,7 @@ make verify
 The Kubeflow SDK project includes several types of tests to ensure code quality and functionality.
 
 ### Unit Testing
+
 To run unit tests locally use the following make command:
 
 ```shell
@@ -44,10 +46,10 @@ make test-python
 ```
 
 ### E2E Tests
+
 E2E test run in CI on a kind cluster using [Kubeflow Trainer E2E Scripts](https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md#e2e-tests).
 Clone the `Kubeflow Trainer` repo and run the provided commands against `Trainer` Makefile.
 For more details check [the Kubeflow Trainer Contributing Guide](https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md#e2e-tests).
-
 
 ## Best Practices
 

--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -75,7 +75,7 @@ class TrainerClient:
         return self.backend.list_runtimes()
 
     def get_runtime(self, name: str) -> types.Runtime:
-        """Get the runtime object
+        """Get the runtime object.
 
         Args:
             name: Name of the runtime.
@@ -203,7 +203,6 @@ class TrainerClient:
 
         Returns:
             Iterator of log lines.
-
 
         Raises:
             TimeoutError: Timeout to get a TrainJob.

--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -152,7 +152,7 @@ class TorchTuneInstructDataset:
 @dataclass
 class LoraConfig:
     """Configuration for the LoRA/QLoRA/DoRA.
-    REF: https://meta-pytorch.org/torchtune/main/tutorials/memory_optimizations.html
+    REF: https://pytorch.org/torchtune/main/tutorials/lora_finetune.html
 
     Args:
         apply_lora_to_mlp (`Optional[bool]`):


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves documentation clarity and consistency in the Kubeflow Trainer SDK.

Changes include:
- Fix docstring punctuation inconsistencies in `TrainerClient`.
- Improve wording in trainer types documentation.
- Add a blank line after the "Requirements" header in `CONTRIBUTING.md` for better Markdown readability.

These changes improve documentation quality and follow standard Python docstring conventions (PEP 257). No functional changes were made.

**Which issue(s) this PR fixes**:

N/A

**Checklist:**

- [x] Docs included if any changes are user-facing