### PR TITLE
feat(trainer): add ForwardKLLoss and ForwardKLWithChunkedOutputLoss to Loss enum

### DIFF
--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -90,12 +90,19 @@ class CustomTrainerContainer:
     env: dict[str, str] | None = None
 
 
-# TODO(Electronic-Waste): Add more loss functions.
 # Loss function for the TorchTune LLM Trainer.
 class Loss(Enum):
-    """Loss function for the TorchTune LLM Trainer."""
+    """Loss function for the TorchTune LLM Trainer.
+
+    Supported loss functions from torchtune.modules.loss:
+        - CEWithChunkedOutputLoss: Memory-efficient cross-entropy via chunked output.
+        - ForwardKLLoss: Forward KL divergence for knowledge distillation.
+        - ForwardKLWithChunkedOutputLoss: Memory-efficient forward KL via chunked output.
+    """
 
     CEWithChunkedOutputLoss = "torchtune.modules.loss.CEWithChunkedOutputLoss"
+    ForwardKLLoss = "torchtune.modules.loss.ForwardKLLoss"
+    ForwardKLWithChunkedOutputLoss = "torchtune.modules.loss.ForwardKLWithChunkedOutputLoss"
 
 
 # Data type for the TorchTune LLM Trainer.
@@ -201,8 +208,9 @@ class TorchTuneConfig:
             The number of samples processed before updating model weights.
         epochs (`Optional[int]`):
             The number of samples processed before updating model weights.
-        loss (`Optional[Loss]`): The loss algorithm we use to fine-tune the LLM,
-            e.g. `torchtune.modules.loss.CEWithChunkedOutputLoss`.
+        loss (`Optional[Loss]`): The loss algorithm we use to fine-tune the LLM.
+            Supported values: `Loss.CEWithChunkedOutputLoss`, `Loss.ForwardKLLoss`,
+            `Loss.ForwardKLWithChunkedOutputLoss`.
         num_nodes (`Optional[int]`): The number of nodes to use for training.
         peft_config (`Optional[LoraConfig]`):
             Configuration for the PEFT(Parameter-Efficient Fine-Tuning),

--- a/kubeflow/trainer/types/types_test.py
+++ b/kubeflow/trainer/types/types_test.py
@@ -113,3 +113,34 @@ def test_data_cache_initializer(test_case: TestCase):
         assert test_case.expected_status == FAILED
         assert type(e) is test_case.expected_error
     print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="CEWithChunkedOutputLoss has correct value",
+            expected_status=SUCCESS,
+            config={"loss": types.Loss.CEWithChunkedOutputLoss},
+            expected_output="torchtune.modules.loss.CEWithChunkedOutputLoss",
+        ),
+        TestCase(
+            name="ForwardKLLoss has correct value",
+            expected_status=SUCCESS,
+            config={"loss": types.Loss.ForwardKLLoss},
+            expected_output="torchtune.modules.loss.ForwardKLLoss",
+        ),
+        TestCase(
+            name="ForwardKLWithChunkedOutputLoss has correct value",
+            expected_status=SUCCESS,
+            config={"loss": types.Loss.ForwardKLWithChunkedOutputLoss},
+            expected_output="torchtune.modules.loss.ForwardKLWithChunkedOutputLoss",
+        ),
+    ],
+)
+def test_loss_enum(test_case: TestCase):
+    """Test Loss enum values match TorchTune module paths."""
+    print("Executing test:", test_case.name)
+    loss = test_case.config["loss"]
+    assert loss.value == test_case.expected_output
+    print("test execution complete")


### PR DESCRIPTION
## Summary

Completes the `Loss` enum by adding the two remaining loss functions from `torchtune.modules.loss`, resolving the TODO left by @Electronic-Waste.

## Changes

- `Loss.ForwardKLLoss`: forward KL divergence, used for knowledge distillation
- `Loss.ForwardKLWithChunkedOutputLoss`: memory-efficient variant via chunked output
- Tests verifying each enum value maps to the correct `torchtune.modules.loss` path

## Notes

`SimPOLoss` was intentionally excluded, it lives in `torchtune.rlhf.loss`
(not `torchtune.modules.loss`) and is marked deprecated upstream.

## References

- TorchTune loss API: https://pytorch.org/torchtune/main/api_ref_loss.html
- Tracking issue: kubeflow/trainer#2839