### PR TITLE
feat(spark): implement batch job support via SparkApplication CRD (KEP-107 Phase 1)

### DIFF
--- a/.github/workflows/test-spark-examples.yaml
+++ b/.github/workflows/test-spark-examples.yaml
@@ -39,7 +39,7 @@ jobs:
           enable-cache: true
       - name: Install project and test deps
         run: |
-          uv sync --extra spark
+          uv sync --extra spark --extra docker
           uv pip install pytest pytest-timeout
 
       - name: Install Kind, kubectl, and Helm

--- a/examples/spark/spark_job_simple.py
+++ b/examples/spark/spark_job_simple.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+SparkClient Batch Job Examples
+
+Demonstrates submitting batch Spark jobs via the SparkApplication CRD.
+The SDK auto-builds a Docker image from the local script and loads it
+into the Kind cluster before submitting.
+
+Usage:
+    python examples/spark/spark_job_simple.py
+
+    # Run a specific example:
+    SPARK_TEST_NAMESPACE=spark-test python examples/spark/spark_job_simple.py
+"""
+
+import os
+from pathlib import Path
+import uuid
+
+from kubeflow.common.types import KubernetesBackendConfig
+from kubeflow.spark import SparkClient
+from kubeflow.spark.types.types import SparkJobStatus
+
+EXAMPLES_DIR = Path(__file__).parent
+WORDCOUNT_SCRIPT = str(EXAMPLES_DIR / "wordcount.py")
+
+
+def _e2e_job_name(base: str) -> str:
+    """In E2E in-cluster runs use a unique name to avoid conflicts."""
+    if os.environ.get("SPARK_E2E_RUN_IN_CLUSTER") == "1":
+        return f"{base}-{uuid.uuid4().hex[:8]}"
+    return base
+
+
+def _backend_config(namespace_default: str = "spark-test"):
+    """Backend config; uses SPARK_TEST_NAMESPACE in CI."""
+    return KubernetesBackendConfig(
+        namespace=os.environ.get("SPARK_TEST_NAMESPACE", namespace_default)
+    )
+
+
+def example_level1_minimal():
+    """
+    Level 1: Minimal Usage
+
+    Submit a local Python script with all defaults:
+    - Auto-generated job name
+    - Default namespace (spark-test or SPARK_TEST_NAMESPACE)
+    - SDK builds Docker image and loads it into Kind automatically
+    """
+    print("=" * 70)
+    print("LEVEL 1: MINIMAL USAGE (Auto-generated name)")
+    print("=" * 70)
+
+    client = SparkClient(backend_config=_backend_config())
+    job_name = client.submit_job(main_file=WORDCOUNT_SCRIPT)
+    print(f"\nSubmitted job: {job_name}")
+
+    job = client.wait_for_job_status(job_name, status={SparkJobStatus.COMPLETED, SparkJobStatus.FAILED}, timeout=300)
+    print(f"Job status: {job.status}")
+    print(f"Driver pod: {job.driver_pod_name}")
+
+    for line in client.get_job_logs(job_name):
+        print(line)
+
+    client.delete_job(job_name)
+    print("\nLevel 1 complete.\n")
+
+
+def example_level2_named_with_arguments():
+    """
+    Level 2: Named Job with Arguments
+
+    Submit with a custom job name and pass command-line arguments
+    to the Spark application. Lists all jobs before deleting.
+    """
+    print("=" * 70)
+    print("LEVEL 2: NAMED JOB WITH ARGUMENTS")
+    print("=" * 70)
+
+    client = SparkClient(backend_config=_backend_config())
+    job_name = _e2e_job_name("wordcount-args")
+
+    job_name = client.submit_job(
+        main_file=WORDCOUNT_SCRIPT,
+        name=job_name,
+        arguments=["--verbose"],
+    )
+    print(f"\nSubmitted job: {job_name}")
+
+    job = client.wait_for_job_status(job_name)
+    print(f"Job status: {job.status}")
+    print(f"Driver pod: {job.driver_pod_name}")
+
+    for line in client.get_job_logs(job_name):
+        print(line)
+
+    jobs = client.list_jobs()
+    print(f"\nFound {len(jobs)} job(s) in namespace:")
+    for j in jobs:
+        print(f"  {j.name}: status={j.status} driver={j.driver_pod_name}")
+
+    client.delete_job(job_name)
+    print("\nLevel 2 complete.\n")
+
+
+def main():
+    """Run all examples sequentially."""
+    print("E2E: Starting spark_job_simple.py", flush=True)
+    print("\n")
+    print("=" * 70)
+    print("KUBEFLOW SPARKCLIENT - BATCH JOB EXAMPLES")
+    print("=" * 70)
+    print("\nDemonstrating batch job submission:\n")
+
+    try:
+        example_level1_minimal()
+        example_level2_named_with_arguments()
+
+        print("=" * 70)
+        print("ALL EXAMPLES COMPLETE!")
+        print("=" * 70)
+
+    except Exception as e:
+        print(f"\nError: {e}")
+        print("\nNote: Make sure you have:")
+        print("  1. Spark Operator installed and watching your namespace")
+        print("  2. Docker daemon running (needed to build job images)")
+        print("  3. Kind CLI installed (needed to load images into cluster)")
+        print("  4. kubectl configured to access the cluster")
+        raise SystemExit(1) from e
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/spark/wordcount.py
+++ b/examples/spark/wordcount.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""PySpark word count — counts word occurrences in sample text data.
+
+Accepts an optional --verbose flag to print per-word counts.
+"""
+
+import sys
+
+from pyspark.sql import SparkSession
+
+
+def main() -> None:
+    """Run word count on sample text and print results."""
+    verbose = "--verbose" in sys.argv
+
+    spark = SparkSession.builder.appName("PySpark-WordCount").getOrCreate()
+
+    text_data = [
+        "simple Python SDK to run Spark on Kubernetes",
+        "The SDK provides SparkClient with connect and submit job APIs",
+        "connect API creates new Spark Connect sessions or connects to existing servers",
+        "auto provisions Spark Connect servers when configuration is provided",
+        "connects to existing Spark Connect servers when URL is provided",
+        "auto cleans up resources on exit",
+        "batch job support submit and manage SparkApplication jobs via submit job",
+    ]
+
+    word_counts = (
+        spark.sparkContext.parallelize(text_data)
+        .flatMap(lambda line: line.lower().split())
+        .map(lambda word: (word, 1))
+        .reduceByKey(lambda a, b: a + b)
+        .sortBy(lambda x: x[1], ascending=False)
+    )
+
+    results = word_counts.collect()
+    print(f"\nWord count complete: {len(results)} unique words")
+
+    if verbose:
+        print("=" * 40)
+        for word, count in results:
+            print(f"  {word}: {count}")
+        print("=" * 40)
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/e2e-setup-cluster.sh
+++ b/hack/e2e-setup-cluster.sh
@@ -292,26 +292,26 @@ subjects:
     name: default
     namespace: $NAMESPACE
 ---
-# E2E in-cluster runner: default SA can create/get SparkConnect so Job pods use in-cluster URL (no port-forward).
+# E2E in-cluster runner: default SA can create/get SparkConnect/SparkApplication so Job pods use in-cluster URL (no port-forward).
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: e2e-sparkconnect-client
+  name: e2e-spark-client
   namespace: $NAMESPACE
 rules:
   - apiGroups: ["sparkoperator.k8s.io"]
-    resources: ["sparkconnects", "sparkconnects/status"]
+    resources: ["sparkconnects", "sparkconnects/status", "sparkapplications", "sparkapplications/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: e2e-sparkconnect-client
+  name: e2e-spark-client
   namespace: $NAMESPACE
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: e2e-sparkconnect-client
+  name: e2e-spark-client
 subjects:
   - kind: ServiceAccount
     name: default

--- a/kubeflow/spark/__init__.py
+++ b/kubeflow/spark/__init__.py
@@ -16,6 +16,7 @@
 
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.api.spark_client import SparkClient
+from kubeflow.spark.image.loaders import ImageLoader, KindImageLoader
 from kubeflow.spark.types.options import (
     Annotations,
     Labels,
@@ -29,6 +30,8 @@ from kubeflow.spark.types.types import (
     Executor,
     SparkConnectInfo,
     SparkConnectState,
+    SparkJob,
+    SparkJobStatus,
 )
 
 __all__ = [
@@ -46,6 +49,12 @@ __all__ = [
     "NodeSelector",
     "PodTemplateOverride",
     "Toleration",
+    # Batch job types
+    "SparkJob",
+    "SparkJobStatus",
+    # Image loaders
+    "ImageLoader",
+    "KindImageLoader",
     # Configuration
     "KubernetesBackendConfig",
 ]

--- a/kubeflow/spark/api/spark_client.py
+++ b/kubeflow/spark/api/spark_client.py
@@ -14,15 +14,16 @@
 
 """SparkClient for Kubeflow SDK."""
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 import logging
+from typing import Any
 
 from pyspark.sql import SparkSession
 
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.backends.kubernetes import KubernetesBackend
 from kubeflow.spark.backends.kubernetes.utils import validate_spark_connect_url
-from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo
+from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo, SparkJob, SparkJobStatus
 
 logger = logging.getLogger(__name__)
 
@@ -141,3 +142,82 @@ class SparkClient:
     def get_session_logs(self, name: str, follow: bool = False) -> Iterator[str]:
         """Get logs from a session."""
         return self.backend.get_session_logs(name, follow=follow)
+
+    def submit_job(
+        self,
+        func: Callable[[SparkSession], Any] | None = None,
+        func_args: dict[str, Any] | None = None,
+        main_file: str | None = None,
+        main_class: str | None = None,
+        arguments: list[str] | None = None,
+        name: str | None = None,
+    ) -> str:
+        """Submit a batch Spark job.
+
+        Supports two modes based on parameters:
+        - Function mode: Pass `func` to submit a Python function with Spark transformations.
+        - File mode: Pass `main_file` to submit an existing Python/Jar file.
+
+        Args:
+            func: Python function that receives SparkSession (function mode).
+            func_args: Arguments to pass to the function.
+            main_file: Path to Python/Jar file (file mode).
+            main_class: Main class for Jar files.
+            arguments: Command-line arguments for the job.
+            name: Optional job name.
+
+        Returns:
+            The job name (string) for tracking.
+
+        Raises:
+            ValueError: If neither `func` nor `main_file` is provided, or both are provided.
+        """
+        if func is not None and main_file is not None:
+            raise ValueError("Provide either `func` or `main_file`, not both.")
+        if func is None and main_file is None:
+            raise ValueError("Either `func` or `main_file` must be provided.")
+
+        if func is not None and main_file is None:
+            raise NotImplementedError("Function mode is not yet implemented.")
+
+        return self.backend.submit_job(
+            main_file=main_file,
+            name=name,
+            arguments=arguments,
+        ).name
+
+    def list_jobs(
+        self,
+        status: SparkJobStatus | None = None,
+    ) -> list[SparkJob]:
+        """List batch Spark jobs."""
+        jobs = self.backend.list_jobs()
+        if status is not None:
+            jobs = [j for j in jobs if j.status == status]
+        return jobs
+
+    def get_job(self, name: str) -> SparkJob:
+        """Get a specific Spark job by name."""
+        return self.backend.get_job(name)
+
+    def get_job_logs(
+        self,
+        name: str,
+        container: str = "spark-kubernetes-driver",
+        follow: bool = False,
+    ) -> Iterator[str]:
+        """Get logs from a Spark job (driver or executor)."""
+        return self.backend.get_job_logs(name, container=container, follow=follow)
+
+    def wait_for_job_status(
+        self,
+        name: str,
+        status: set[SparkJobStatus] = {SparkJobStatus.COMPLETED},
+        timeout: int = 600,
+    ) -> SparkJob:
+        """Wait for a job to reach desired status."""
+        return self.backend.wait_for_job(name, status=status, timeout=timeout)
+
+    def delete_job(self, name: str) -> None:
+        """Delete a Spark job."""
+        self.backend.delete_job(name)

--- a/kubeflow/spark/backends/base.py
+++ b/kubeflow/spark/backends/base.py
@@ -17,7 +17,7 @@
 import abc
 from collections.abc import Iterator
 
-from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo
+from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo, SparkJob, SparkJobStatus
 
 
 class RuntimeBackend(abc.ABC):
@@ -146,5 +146,116 @@ class RuntimeBackend(abc.ABC):
         Raises:
             TimeoutError: If reading logs times out.
             RuntimeError: If the session/pod is not found or reading fails.
+        """
+        raise NotImplementedError()
+
+    # ------------------------------------------------------------------
+    # Batch job methods (SparkApplication CRD)
+    # ------------------------------------------------------------------
+
+    @abc.abstractmethod
+    def submit_job(
+        self,
+        main_file: str,
+        name: str | None = None,
+        arguments: list[str] | None = None,
+    ) -> SparkJob:
+        """Submit a batch Spark job.
+
+        Args:
+            main_file: Local path to the Python script.
+            name: Optional job name; auto-generated if not provided.
+            arguments: Arguments to pass to the application.
+
+        Returns:
+            SparkJob with job details.
+
+        Raises:
+            FileNotFoundError: If main_file does not exist.
+            RuntimeError: If image build, load, or submission fails.
+            TimeoutError: If the submission request times out.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def list_jobs(self) -> list[SparkJob]:
+        """List all batch Spark jobs in the namespace.
+
+        Returns:
+            List of SparkJob objects.
+
+        Raises:
+            TimeoutError: If the request times out.
+            RuntimeError: If listing fails.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_job(self, name: str) -> SparkJob:
+        """Get information about a batch Spark job.
+
+        Args:
+            name: Job name.
+
+        Returns:
+            SparkJob with job details.
+
+        Raises:
+            TimeoutError: If the request times out.
+            RuntimeError: If the job is not found or request fails.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def delete_job(self, name: str) -> None:
+        """Delete a batch Spark job.
+
+        Args:
+            name: Job name.
+
+        Raises:
+            TimeoutError: If the deletion request times out.
+            RuntimeError: If the job is not found or deletion fails.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_job_logs(self, name: str, container: str = "spark-kubernetes-driver", follow: bool = False) -> Iterator[str]:
+        """Get logs from a batch Spark job pod.
+
+        Args:
+            name: Job name.
+            container: Container name to read logs from. Default ``"driver"``.
+            follow: If True, stream logs continuously.
+
+        Returns:
+            Iterator of log lines.
+
+        Raises:
+            TimeoutError: If reading logs times out.
+            RuntimeError: If the job/pod is not found or reading fails.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def wait_for_job(
+        self,
+        name: str,
+        status: set[SparkJobStatus] = {SparkJobStatus.COMPLETED},
+        timeout: int = 600,
+    ) -> SparkJob:
+        """Wait for a batch Spark job to reach one of the desired statuses.
+
+        Args:
+            name: Job name.
+            status: Set of statuses to wait for. Default ``{COMPLETED}``.
+            timeout: Maximum wait time in seconds.
+
+        Returns:
+            SparkJob when it reaches one of the desired statuses.
+
+        Raises:
+            TimeoutError: If job does not reach desired status within timeout.
+            RuntimeError: If the job is not found or status check fails.
         """
         raise NotImplementedError()

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -672,7 +672,7 @@ class KubernetesBackend(RuntimeBackend):
             raise FileNotFoundError(f"main_file not found: {main_file}")
 
         if loader is None:
-            loader = KindImageLoader()
+            loader = KindImageLoader(cluster_name=os.environ.get("SPARK_TEST_CLUSTER"))
         elif not isinstance(loader, KindImageLoader):
             raise NotImplementedError(
                 f"Loader type '{type(loader).__name__}' is not yet supported. "

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -35,13 +35,19 @@ from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.backends.base import RuntimeBackend
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.utils import (
+    _build_job_image,
+    _is_local_main_file,
     build_service_url,
+    build_spark_application_cr,
     build_spark_connect_cr,
+    generate_job_name,
     generate_session_name,
+    get_spark_application_info_from_cr,
     get_spark_connect_info_from_cr,
 )
+from kubeflow.spark.image.loaders import ImageLoader, KindImageLoader
 from kubeflow.spark.types.options import Name
-from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo, SparkConnectState
+from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo, SparkConnectState, SparkJob, SparkJobStatus
 
 logger = logging.getLogger(__name__)
 
@@ -624,3 +630,309 @@ class KubernetesBackend(RuntimeBackend):
             raise RuntimeError(
                 f"Failed to get logs for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
             ) from e
+
+    def submit_job(
+        self,
+        main_file: str,
+        name: str | None = None,
+        arguments: list[str] | None = None,
+        loader: ImageLoader | None = None,
+    ) -> SparkJob:
+        """Submit a batch Spark job via SparkApplication CRD.
+
+        Builds a Docker image from the provided local script on top of the default
+        Spark base image, loads it into the cluster, then submits a SparkApplication CR.
+
+        Args:
+            main_file: Local path to the Python script. Remote URIs (s3://, gs://, etc.) are not yet supported.
+            name: Optional job name; auto-generated if not provided.
+            arguments: Arguments passed to the Spark application.
+            loader: Image loader used to push the built image into the cluster.
+                Defaults to KindImageLoader. Must be a KindImageLoader instance;
+                other loader types are not yet supported.
+
+        Returns:
+            SparkJob with initial job details.
+
+        Raises:
+            FileNotFoundError: If main_file does not exist on the local filesystem.
+            NotImplementedError: If main_file is a remote URI or loader is not a KindImageLoader.
+            RuntimeError: If image build, load, or submission fails.
+            TimeoutError: If the API call times out.
+        """
+        job_name = name or generate_job_name()
+
+        if not _is_local_main_file(main_file):
+            raise NotImplementedError(
+                f"Remote main_file URIs are not yet supported: '{main_file}'. "
+                "Provide a local file path instead."
+            )
+
+        if not os.path.isfile(main_file):
+            raise FileNotFoundError(f"main_file not found: {main_file}")
+
+        if loader is None:
+            loader = KindImageLoader()
+        elif not isinstance(loader, KindImageLoader):
+            raise NotImplementedError(
+                f"Loader type '{type(loader).__name__}' is not yet supported. "
+                "Use KindImageLoader instead."
+            )
+
+        image = _build_job_image(main_file, constants.DEFAULT_SPARK_IMAGE)
+        logger.info("Built image '%s' for script '%s'", image, main_file)
+        loader.load(image)
+        logger.info("Loaded image '%s' into Kind cluster", image)
+
+        script_name = os.path.basename(main_file)
+        container_main_file = f"local://{constants.JOB_SCRIPT_MOUNT_PATH}/{script_name}"
+
+        spark_application = build_spark_application_cr(
+            name=job_name,
+            namespace=self.namespace,
+            main_file=container_main_file,
+            image=image,
+            arguments=arguments,
+        )
+
+        logger.info("Submitting SparkApplication '%s/%s'", self.namespace, job_name)
+
+        try:
+            thread = self.custom_api.create_namespaced_custom_object(
+                group=constants.SPARK_APPLICATION_GROUP,
+                version=constants.SPARK_APPLICATION_VERSION,
+                namespace=self.namespace,
+                plural=constants.SPARK_APPLICATION_PLURAL,
+                body=spark_application.to_dict(),
+                async_req=True,
+            )
+            response = thread.get(common_constants.DEFAULT_TIMEOUT)
+        except multiprocessing.TimeoutError as e:
+            raise TimeoutError(
+                f"Timeout submitting {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{job_name}"
+            ) from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to submit {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{job_name}"
+            ) from e
+
+        cr = models.SparkV1beta2SparkApplication.from_dict(response)
+        return get_spark_application_info_from_cr(cr)
+
+    def get_job(self, name: str) -> SparkJob:
+        """Get information about a batch Spark job.
+
+        Args:
+            name: Job name.
+
+        Returns:
+            SparkJob with current state.
+
+        Raises:
+            TimeoutError: If the request times out.
+            RuntimeError: If the job is not found or request fails.
+        """
+        try:
+            thread = self.custom_api.get_namespaced_custom_object(
+                group=constants.SPARK_APPLICATION_GROUP,
+                version=constants.SPARK_APPLICATION_VERSION,
+                namespace=self.namespace,
+                plural=constants.SPARK_APPLICATION_PLURAL,
+                name=name,
+                async_req=True,
+            )
+            response = thread.get(common_constants.DEFAULT_TIMEOUT)
+            cr = models.SparkV1beta2SparkApplication.from_dict(response)
+            return get_spark_application_info_from_cr(cr)
+        except multiprocessing.TimeoutError as e:
+            raise TimeoutError(
+                f"Timeout getting {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{name}"
+            ) from e
+        except client.ApiException as e:
+            if e.status == 404:
+                raise RuntimeError(
+                    f"{constants.SPARK_APPLICATION_KIND} not found: {self.namespace}/{name}"
+                ) from e
+            raise RuntimeError(
+                f"Failed to get {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{name}"
+            ) from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to get {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{name}"
+            ) from e
+
+    def list_jobs(self) -> list[SparkJob]:
+        """List all batch Spark jobs in the namespace.
+
+        Returns:
+            List of SparkJob objects.
+
+        Raises:
+            TimeoutError: If the request times out.
+            RuntimeError: If listing fails.
+        """
+        try:
+            thread = self.custom_api.list_namespaced_custom_object(
+                group=constants.SPARK_APPLICATION_GROUP,
+                version=constants.SPARK_APPLICATION_VERSION,
+                namespace=self.namespace,
+                plural=constants.SPARK_APPLICATION_PLURAL,
+                async_req=True,
+            )
+            response = thread.get(common_constants.DEFAULT_TIMEOUT)
+        except multiprocessing.TimeoutError as e:
+            raise TimeoutError(
+                f"Timeout listing {constants.SPARK_APPLICATION_KIND}s in: {self.namespace}"
+            ) from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to list {constants.SPARK_APPLICATION_KIND}s in: {self.namespace}"
+            ) from e
+
+        cr_list = models.SparkV1beta2SparkApplicationList.from_dict(response)
+        return [get_spark_application_info_from_cr(cr) for cr in cr_list.items]
+
+    def delete_job(self, name: str) -> None:
+        """Delete a batch Spark job.
+
+        Args:
+            name: Job name.
+
+        Raises:
+            TimeoutError: If the deletion request times out.
+            RuntimeError: If the job is not found or deletion fails.
+        """
+        try:
+            thread = self.custom_api.delete_namespaced_custom_object(
+                group=constants.SPARK_APPLICATION_GROUP,
+                version=constants.SPARK_APPLICATION_VERSION,
+                namespace=self.namespace,
+                plural=constants.SPARK_APPLICATION_PLURAL,
+                name=name,
+                async_req=True,
+            )
+            thread.get(common_constants.DEFAULT_TIMEOUT)
+            logger.info("Deleted SparkApplication '%s/%s'", self.namespace, name)
+        except multiprocessing.TimeoutError as e:
+            raise TimeoutError(
+                f"Timeout deleting {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{name}"
+            ) from e
+        except client.ApiException as e:
+            if e.status == 404:
+                raise RuntimeError(
+                    f"{constants.SPARK_APPLICATION_KIND} not found: {self.namespace}/{name}"
+                ) from e
+            raise RuntimeError(
+                f"Failed to delete {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{name}"
+            ) from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to delete {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{name}"
+            ) from e
+
+    def get_job_logs(self, name: str, container: str = "driver", follow: bool = False) -> Iterator[str]:
+        """Get logs from a batch Spark job pod.
+
+        Args:
+            name: Job name.
+            container: ``"driver"`` or ``"executor"``. Mapped to actual Spark container names.
+            follow: If True, stream logs continuously.
+
+        Returns:
+            Iterator of log lines.
+
+        Raises:
+            TimeoutError: If reading logs times out.
+            RuntimeError: If the job/pod is not found or reading fails.
+        """
+        job = self.get_job(name)
+        actual_container = constants.SPARK_CONTAINER_NAME_MAP.get(container, container)
+
+        if job.error_message:
+            yield f"[operator] {job.error_message}"
+
+        if not job.driver_pod_name:
+            return
+
+        try:
+            if follow:
+                thread = self.core_api.read_namespaced_pod_log(
+                    name=job.driver_pod_name,
+                    namespace=self.namespace,
+                    container=actual_container,
+                    follow=True,
+                    _preload_content=False,
+                    async_req=True,
+                )
+                resp = thread.get(common_constants.DEFAULT_TIMEOUT)
+                for line in resp.stream():
+                    yield line.decode("utf-8").rstrip("\n")
+            else:
+                thread = self.core_api.read_namespaced_pod_log(
+                    name=job.driver_pod_name,
+                    namespace=self.namespace,
+                    container=actual_container,
+                    async_req=True,
+                )
+                logs = thread.get(common_constants.DEFAULT_TIMEOUT)
+                for line in logs.split("\n"):
+                    yield line
+        except multiprocessing.TimeoutError:
+            yield f"[error] Timeout reading logs for {self.namespace}/{name}"
+        except Exception as e:
+            yield f"[error] Failed to read pod logs for {self.namespace}/{name}: {e}"
+
+    def wait_for_job(
+        self,
+        name: str,
+        status: set[SparkJobStatus] = {SparkJobStatus.COMPLETED},
+        timeout: int = 600,
+    ) -> SparkJob:
+        """Wait for a batch Spark job to reach one of the desired statuses.
+
+        Args:
+            name: Job name.
+            status: Set of statuses to wait for. Default ``{COMPLETED}``.
+            timeout: Maximum wait time in seconds.
+
+        Returns:
+            SparkJob when it reaches one of the desired statuses.
+
+        Raises:
+            TimeoutError: If job does not reach desired status within timeout.
+            RuntimeError: If the job is not found or status check fails.
+        """
+        start_time = time.time()
+        last_log_time = 0.0
+
+        while True:
+            job = self.get_job(name)
+
+            if job.status in status:
+                logger.info(
+                    "Job reached desired status: %s/%s status=%s (%.0fs)",
+                    self.namespace,
+                    name,
+                    job.status,
+                    time.time() - start_time,
+                )
+                return job
+
+            now = time.time()
+            if now - last_log_time >= 10.0:
+                logger.info(
+                    "Waiting for job: %s/%s status=%s elapsed=%.0fs",
+                    self.namespace,
+                    name,
+                    job.status,
+                    now - start_time,
+                )
+                last_log_time = now
+
+            if now - start_time >= timeout:
+                raise TimeoutError(
+                    f"Timeout waiting for {constants.SPARK_APPLICATION_KIND}: "
+                    f"{self.namespace}/{name} (timeout: {timeout}s, current status: {job.status})"
+                )
+
+            time.sleep(constants.SPARK_JOB_POLLING_INTERVAL_SEC)

--- a/kubeflow/spark/backends/kubernetes/constants.py
+++ b/kubeflow/spark/backends/kubernetes/constants.py
@@ -14,6 +14,32 @@
 
 """Constants for Kubernetes Spark backend."""
 
+# SparkApplication CRD (batch jobs via Spark Operator v1beta2)
+SPARK_APPLICATION_GROUP = "sparkoperator.k8s.io"
+SPARK_APPLICATION_VERSION = "v1beta2"
+SPARK_APPLICATION_PLURAL = "sparkapplications"
+SPARK_APPLICATION_KIND = "SparkApplication"
+SPARK_APPLICATION_TYPE_PYTHON = "Python"
+SPARK_APPLICATION_MODE = "cluster"
+
+# Batch job naming and image defaults
+JOB_NAME_PREFIX = "spark-job"
+JOB_IMAGE_PREFIX = "spark-job"
+JOB_SCRIPT_MOUNT_PATH = "/opt/spark/scripts"
+
+# Container names inside Spark pods (set by Spark itself, not configurable via CR)
+SPARK_DRIVER_CONTAINER_NAME = "spark-kubernetes-driver"
+SPARK_EXECUTOR_CONTAINER_NAME = "spark-kubernetes-executor"
+
+# Maps user-friendly container alias → actual container name
+SPARK_CONTAINER_NAME_MAP: dict[str, str] = {
+    "driver": SPARK_DRIVER_CONTAINER_NAME,
+    "executor": SPARK_EXECUTOR_CONTAINER_NAME,
+}
+
+# Polling interval for wait_for_job
+SPARK_JOB_POLLING_INTERVAL_SEC = 5
+
 # SparkConnect CRD
 SPARK_CONNECT_GROUP = "sparkoperator.k8s.io"
 SPARK_CONNECT_VERSION = "v1alpha1"
@@ -37,6 +63,9 @@ SPARK_CONNECT_PORT = 15002
 
 # Session name prefix
 SESSION_NAME_PREFIX = "spark-connect"
+
+# Remote URI schemes
+REMOTE_URI_SCHEMES = ("s3://", "s3a://", "gs://", "gcs://", "http://", "https://", "hdfs://")
 
 # Spark Connect Maven package (required for Connect server main class on classpath)
 SPARK_CONNECT_PACKAGE_SCALA_VERSION = "2.13"

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -14,7 +14,12 @@
 
 """Utility functions for Kubernetes Spark backend."""
 
+import hashlib
+import logging
+import os
 import re
+import shutil
+import tempfile
 from typing import Any
 from urllib.parse import urlparse
 import uuid
@@ -22,7 +27,16 @@ import uuid
 from kubeflow_spark_api import models
 
 from kubeflow.spark.backends.kubernetes import constants
-from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo, SparkConnectState
+from kubeflow.spark.types.types import (
+    Driver,
+    Executor,
+    SparkConnectInfo,
+    SparkConnectState,
+    SparkJob,
+    SparkJobStatus,
+)
+
+logger = logging.getLogger(__name__)
 
 
 def generate_session_name() -> str:
@@ -302,4 +316,179 @@ def get_spark_connect_info_from_cr(
         pod_ip=server_status.pod_ip if server_status else None,
         service_name=server_status.service_name if server_status else None,
         creation_timestamp=spark_connect_cr.metadata.creation_timestamp,
+    )
+
+def generate_job_name() -> str:
+    """Generate a unique batch job name.
+
+    Returns:
+        Job name in format: spark-job-{uuid}.
+    """
+    short_uuid = str(uuid.uuid4())[:8]
+    return f"{constants.JOB_NAME_PREFIX}-{short_uuid}"
+
+
+def _is_local_main_file(main_file: str) -> bool:
+    """Return True if main_file is a local filesystem path (not a remote URI)."""
+    return not any(main_file.startswith(scheme) for scheme in constants.REMOTE_URI_SCHEMES)
+
+
+def _build_job_image(main_file: str, base_image: str) -> str:
+    """Build a Docker image containing the user's Python script.
+
+    The image tag is derived from the SHA-256 hash of the script content so that
+    identical scripts produce the same tag.
+
+    Dockerfile generated:
+        FROM <base_image>
+        COPY <script_name> <JOB_SCRIPT_MOUNT_PATH>/<script_name>
+
+    Args:
+        main_file: Local path to the Python script.
+        base_image: Base Spark image to build FROM.
+
+    Returns:
+        Built image tag (e.g., "spark-job-abc12345:latest").
+
+    Raises:
+        FileNotFoundError: If main_file does not exist.
+        ImportError: If the docker Python package is not installed.
+        RuntimeError: If the Docker build fails.
+    """
+    try:
+        import docker as docker_sdk  # type: ignore
+    except ImportError as e:
+        raise ImportError(
+            "The 'docker' Python package is required to build Spark job images. "
+            "Install it with: pip install kubeflow[docker]"
+        ) from e
+
+    if not os.path.isfile(main_file):
+        raise FileNotFoundError(f"main_file not found: {main_file}")
+
+    # Derive deterministic image tag from file content hash
+    with open(main_file, "rb") as f:
+        content_hash = hashlib.sha256(f.read()).hexdigest()[:8]
+    image_tag = f"{constants.JOB_IMAGE_PREFIX}-{content_hash}:latest"
+
+    try:
+        docker_sdk.from_env().images.get(image_tag)
+        logger.info("Image '%s' already exists for same file content, reusing it", image_tag)
+        return image_tag
+    except Exception:
+        pass  # Image not found locally, build it
+
+    script_name = os.path.basename(main_file)
+    dockerfile_content = (
+        f"FROM {base_image}\n"
+        f"COPY {script_name} {constants.JOB_SCRIPT_MOUNT_PATH}/{script_name}\n"
+    )
+
+    tmpdir = tempfile.mkdtemp(prefix="spark-job-build-")
+    try:
+        with open(os.path.join(tmpdir, "Dockerfile"), "w") as f:
+            f.write(dockerfile_content)
+        shutil.copy2(main_file, os.path.join(tmpdir, script_name))
+
+        client = docker_sdk.from_env()
+        _, build_logs = client.images.build(path=tmpdir, tag=image_tag, rm=True)
+
+    except docker_sdk.errors.BuildError as e:
+        raise RuntimeError(f"Docker build failed for '{main_file}': {e}") from e
+    except docker_sdk.errors.DockerException as e:
+        raise RuntimeError(
+            f"Docker daemon error while building image for '{main_file}': {e}. "
+            "Is Docker running?"
+        ) from e
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    return image_tag
+
+
+def build_spark_application_cr(
+    name: str,
+    namespace: str,
+    main_file: str,
+    image: str,
+    arguments: list[str] | None = None,
+    spark_conf: dict[str, str] | None = None,
+) -> models.SparkV1beta2SparkApplication:
+    """Build a SparkApplication CR using typed API models.
+
+    Args:
+        name: Job name (used as the Kubernetes resource name).
+        namespace: Kubernetes namespace.
+        main_file: Path to the main Python file (local:// or remote URI).
+        image: Docker image for driver and executors.
+        arguments: Optional list of arguments passed to the application.
+        spark_conf: Optional Spark configuration properties.
+
+    Returns:
+        SparkV1beta2SparkApplication model ready for submission.
+    """
+    driver_spec = models.SparkV1beta2DriverSpec(
+        cores=constants.DEFAULT_DRIVER_CPU,
+        memory=_memory_kubernetes_to_spark(constants.DEFAULT_DRIVER_MEMORY),
+    )
+    executor_spec = models.SparkV1beta2ExecutorSpec(
+        instances=constants.DEFAULT_NUM_EXECUTORS,
+        cores=constants.DEFAULT_EXECUTOR_CPU,
+        memory=_memory_kubernetes_to_spark(constants.DEFAULT_EXECUTOR_MEMORY),
+    )
+
+    return models.SparkV1beta2SparkApplication(
+        api_version=f"{constants.SPARK_APPLICATION_GROUP}/{constants.SPARK_APPLICATION_VERSION}",
+        kind=constants.SPARK_APPLICATION_KIND,
+        metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+            name=name,
+            namespace=namespace,
+        ),
+        spec=models.SparkV1beta2SparkApplicationSpec(
+            type=constants.SPARK_APPLICATION_TYPE_PYTHON,
+            image=image,
+            spark_version=constants.DEFAULT_SPARK_VERSION,
+            main_application_file=main_file,
+            arguments=arguments or None,
+            spark_conf=spark_conf or None,
+            driver=driver_spec,
+            executor=executor_spec,
+        ),
+    )
+
+
+def get_spark_application_info_from_cr(
+    cr: models.SparkV1beta2SparkApplication,
+) -> SparkJob:
+    """Convert API SparkApplication model to SDK SparkJob.
+
+    Args:
+        cr: SparkV1beta2SparkApplication model from the Kubernetes API.
+
+    Returns:
+        SDK SparkJob dataclass.
+    """
+    if not (cr.metadata and cr.metadata.name):
+        raise ValueError(f"SparkApplication CR is invalid: {cr}")
+
+    status = SparkJobStatus.NEW
+    error_message = None
+    if cr.status and cr.status.application_state:
+        raw_state = cr.status.application_state.state or ""
+        try:
+            status = SparkJobStatus(raw_state)
+        except ValueError:
+            status = SparkJobStatus.UNKNOWN
+        error_message = cr.status.application_state.error_message
+
+    driver_pod_name = None
+    if cr.status and cr.status.driver_info:
+        driver_pod_name = cr.status.driver_info.pod_name
+
+    return SparkJob(
+        name=cr.metadata.name,
+        namespace=cr.metadata.namespace or "",
+        status=status,
+        driver_pod_name=driver_pod_name,
+        error_message=error_message,
     )

--- a/kubeflow/spark/image/__init__.py
+++ b/kubeflow/spark/image/__init__.py
@@ -1,0 +1,31 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Image loading utilities for Kubeflow Spark SDK."""
+
+from kubeflow.spark.image.loaders import (
+    ImageLoader,
+    K3dImageLoader,
+    KindImageLoader,
+    MinikubeImageLoader,
+    RegistryImageLoader,
+)
+
+__all__ = [
+    "ImageLoader",
+    "KindImageLoader",
+    "K3dImageLoader",
+    "MinikubeImageLoader",
+    "RegistryImageLoader",
+]

--- a/kubeflow/spark/image/__init__.py
+++ b/kubeflow/spark/image/__init__.py
@@ -16,7 +16,6 @@
 
 from kubeflow.spark.image.loaders import (
     ImageLoader,
-    K3dImageLoader,
     KindImageLoader,
     MinikubeImageLoader,
     RegistryImageLoader,
@@ -25,7 +24,6 @@ from kubeflow.spark.image.loaders import (
 __all__ = [
     "ImageLoader",
     "KindImageLoader",
-    "K3dImageLoader",
     "MinikubeImageLoader",
     "RegistryImageLoader",
 ]

--- a/kubeflow/spark/image/loaders.py
+++ b/kubeflow/spark/image/loaders.py
@@ -1,0 +1,145 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Image loaders for loading Docker images into Kubernetes clusters.
+
+Each loader abstracts the cluster-specific CLI command needed to make a locally
+built Docker image available to cluster nodes. Choose the loader that matches
+your local cluster type:
+
+- KindImageLoader  → Kind clusters  (kind load docker-image)
+- MinikubeImageLoader → Minikube     (minikube image load)      [not yet implemented]
+- RegistryImageLoader → Any cluster  (docker push to registry)  [not yet implemented]
+
+Example:
+    loader = KindImageLoader(cluster_name="spark-cluster")
+    loader.load("my-spark-app:v1.0")
+"""
+
+import abc
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+class ImageLoader(abc.ABC):
+    """Abstract base class for loading Docker images into a Kubernetes cluster.
+
+    Implementations wrap the cluster-specific CLI tool (kind, k3d, minikube, etc.)
+    so that the rest of the SDK stays decoupled from the cluster type.
+    """
+
+    @abc.abstractmethod
+    def load(self, image: str) -> None:
+        """Load a Docker image into the target cluster.
+
+        The image must already exist in the local Docker daemon before calling
+        this method.
+
+        Args:
+            image: Image name and tag (e.g., "my-spark-app:latest").
+
+        Raises:
+            RuntimeError: If the load command fails or the CLI tool is not found.
+        """
+        raise NotImplementedError()
+
+
+class KindImageLoader(ImageLoader):
+    """Load a Docker image into a Kind cluster via `kind load docker-image`.
+
+    Args:
+        cluster_name: Name of the Kind cluster. If None, Kind uses the current
+            kubectl context cluster (typically named "kind").
+    """
+
+    def __init__(self, cluster_name: str | None = None):
+        """Initialize KindImageLoader.
+
+        Args:
+            cluster_name: Name of the Kind cluster, or None for the default cluster.
+        """
+        self.cluster_name = cluster_name
+
+    def load(self, image: str) -> None:
+        """Load image into the Kind cluster.
+
+        Args:
+            image: Image name and tag (e.g., "my-spark-app:latest").
+
+        Raises:
+            RuntimeError: If `kind` is not installed, or if the load command fails.
+        """
+        cmd = ["kind", "load", "docker-image", image]
+        if self.cluster_name:
+            cmd += ["--name", self.cluster_name]
+
+        logger.info("Loading image '%s' into Kind cluster (cmd: %s)", image, " ".join(cmd))
+
+        try:
+            result = subprocess.run(
+                cmd,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            if result.stdout:
+                logger.info("kind load output: %s", result.stdout.strip())
+        except FileNotFoundError as e:
+            raise RuntimeError(
+                "The 'kind' CLI was not found. "
+                "Install it from: https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
+            ) from e
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.strip() if e.stderr else "(no stderr)"
+            raise RuntimeError(
+                f"Failed to load image '{image}' into Kind cluster: {stderr}"
+            ) from e
+
+class MinikubeImageLoader(ImageLoader):
+    """Load a Docker image into a Minikube cluster via `minikube image load`.
+
+    Args:
+        profile: Minikube profile name. If None, uses the default profile.
+    """
+
+    def __init__(self, profile: str | None = None):
+        self.profile = profile
+
+    def load(self, image: str) -> None:
+        raise NotImplementedError(
+            "MinikubeImageLoader is not yet implemented. "
+            "To load manually: minikube image load "
+            + image
+            + (" -p " + self.profile if self.profile else "")
+        )
+
+
+class RegistryImageLoader(ImageLoader):
+    """Push a Docker image to a container registry so the cluster can pull it.
+    Args:
+        registry: Registry host (e.g., "gcr.io/my-project").
+
+    """
+
+    def __init__(self, registry: str):
+        self.registry = registry
+
+    def load(self, image: str) -> None:
+        raise NotImplementedError(
+            "RegistryImageLoader is not yet implemented. "
+            f"To push manually: docker tag {image} {self.registry}/{image} "
+            f"&& docker push {self.registry}/{image}"
+        )

--- a/kubeflow/spark/types/types.py
+++ b/kubeflow/spark/types/types.py
@@ -19,6 +19,43 @@ from datetime import datetime
 from enum import Enum
 
 
+
+class SparkJobStatus(str, Enum):
+    """State of a batch Spark job (SparkApplication CRD).
+    """
+
+    NEW = ""  # Initial state before the operator processes the resource
+    SUBMITTED = "SUBMITTED"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    SUBMISSION_FAILED = "SUBMISSION_FAILED"
+    PENDING_RERUN = "PENDING_RERUN"
+    INVALIDATING = "INVALIDATING"
+    SUCCEEDING = "SUCCEEDING"
+    FAILING = "FAILING"
+    UNKNOWN = "UNKNOWN"
+
+
+@dataclass
+class SparkJob:
+    """Information about a batch Spark job (SparkApplication CRD).
+
+    Args:
+        name: Name of the SparkApplication resource.
+        namespace: Kubernetes namespace.
+        status: Current application state.
+        driver_pod_name: Name of the driver pod.
+        error_message: Error message from the operator if the job failed.
+    """
+
+    name: str
+    namespace: str
+    status: SparkJobStatus
+    driver_pod_name: str | None = None
+    error_message: str | None = None
+
+
 class SparkConnectState(str, Enum):
     """State of a SparkConnect session."""
 

--- a/kubeflow/trainer/constants/constants.py
+++ b/kubeflow/trainer/constants/constants.py
@@ -73,7 +73,7 @@ MODEL_INITIALIZER = "model-initializer"
 INITIALIZER_ENV_ACCESS_TOKEN = "ACCESS_TOKEN"
 
 # The default value for initializer to ignore files.
-INITIALIZER_DEFAULT_IGNORE_PATTERNS = ["*.msgpack", "*.h5", "*.bin", ".pt", ".pth"]
+INITIALIZER_DEFAULT_IGNORE_PATTERNS = ["*.msgpack", "*.h5", "*.bin", "*.pt", "*.pth"]
 
 # The default path to the users' workspace.
 # TODO (andreyvelich): Discuss how to keep this path is sync with pkg.initializers.constants

--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -451,7 +451,7 @@ class S3ModelInitializer(BaseInitializer):
     Args:
         storage_uri (`str`): The S3 URI for the model in the format 's3://bucket-name/path/to/model'.
         ignore_patterns (`Optional[list[str]]`): List of file patterns to ignore during download.
-            Defaults to `['*.msgpack', '*.h5', '*.bin', '.pt', '.pth']`.
+            Defaults to `['*.msgpack', '*.h5', '*.bin', '*.pt', '*.pth']`.
         endpoint (`Optional[str]`): Custom S3 endpoint URL.
         access_key_id (`Optional[str]`): Access key for authentication.
         secret_access_key (`Optional[str]`): Secret key for authentication.

--- a/test/e2e/spark/test_spark_examples.py
+++ b/test/e2e/spark/test_spark_examples.py
@@ -210,3 +210,26 @@ class TestSparkExamples:
             pytest.skip("Requires in-cluster execution (SPARK_E2E_RUN_IN_CLUSTER=1)")
 
         self._run_example("connect_existing_session.py", namespace)
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.timeout(EXAMPLE_TIMEOUT_SEC + 120)
+class TestSparkJobExamples:
+    """Validate Spark batch job examples execute successfully."""
+
+    def test_spark_job_simple_example(self):
+        """EX04: Validate spark_job_simple.py submits and completes batch jobs."""
+        namespace = os.environ.get("SPARK_TEST_NAMESPACE", "spark-test")
+        returncode, stdout, stderr, _ = _run_example_with_watcher(
+            EXAMPLES_DIR / "spark_job_simple.py",
+            namespace,
+            timeout_sec=EXAMPLE_TIMEOUT_SEC,
+        )
+        fail_msg = (
+            f"spark_job_simple.py exited with code {returncode} (expected 0).\n"
+            f"--- stdout ---\n{stdout or '(empty)'}\n"
+            f"--- stderr ---\n{stderr or '(empty)'}"
+        )
+        assert returncode == 0, fail_msg
+        assert "ALL EXAMPLES COMPLETE" in stdout, f"Expected completion message. stdout:\n{stdout}"


### PR DESCRIPTION
# feat(spark): implement batch job support via SparkApplication CRD (KEP-107 Phase 1)

## Summary

Implements the batch job portion of Phase 1 from the [Spark Client KEP](https://github.com/kubeflow/sdk/blob/main/docs/proposals/107-spark-client/README.md). The `connect()` API (SparkConnect sessions) was already merged in #225. This PR
adds the batch job layer on top of the same `SparkClient` and `KubernetesBackend`.

## What's added

- Batch job types: `SparkJob` dataclass and `SparkJobStatus` enum
- `ImageLoader` abstraction with `KindImageLoader` for Kind clusters
- `KubernetesBackend` batch methods: `submit_job`, `get_job`, `list_jobs`, `delete_job`, `get_job_logs`, `wait_for_job`
- `SparkClient` exposes all batch methods as public API
- Examples: `spark_job_simple.py` + `wordcount.py`
- E2E test for the batch job example
- RBAC: extended e2e role to cover `sparkapplications`

## Intentionally deferred (Phase 2)

- Extended `submit_job` parameters: driver/executor resources, spark conf, image, service account, etc. (consistent with `connect()` API)
- Loaders beyond KindImageLoader
- Remote URI main files (`s3://`, `gs://`, etc.)
- `submit_job(func=...)`: function mode

## How it works

```python
client = SparkClient()
job_name = client.submit_job(main_file="etl.py", arguments=["--date", "2024-01-15"])
job = client.wait_for_job_status(job_name, status={SparkJobStatus.COMPLETED, SparkJobStatus.FAILED}, timeout=300)
print(job.status)
```

Under the hood `submit_job` does:

1. Dynamically builds a Docker image on top of the base Spark image using the Docker
   client API (discussed in [#107](https://github.com/kubeflow/sdk/issues/107#issuecomment-3357937387))
2. Loads the image into the Kind cluster
3. Submits a `SparkApplication` CR to the Spark Operator v1beta2 API

## Test plan

- [ ] `SPARK_TEST_CLUSTER=spark-test SPARK_TEST_NAMESPACE=spark-test uv run pytest test/e2e/spark/test_spark_examples.py::TestSparkJobExamples -v`
- [ ] CI: `.github/workflows/test-spark-examples.yaml` runs the full file including new `TestSparkJobExamples`

Ref: #107
KEP: [docs/proposals/107-spark-client/README.md](https://github.com/kubeflow/sdk/blob/main/docs/proposals/107-spark-client/README.md)
