### PR TITLE
fix: mutable default set argument in wait_for_job_status (#329)

### DIFF
--- a/kubeflow/optimizer/api/optimizer_client.py
+++ b/kubeflow/optimizer/api/optimizer_client.py
@@ -18,7 +18,6 @@ from typing import Any
 
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.optimizer.backends.kubernetes.backend import KubernetesBackend
-from kubeflow.optimizer.constants import constants
 from kubeflow.optimizer.types.algorithm_types import BaseAlgorithm
 from kubeflow.optimizer.types.optimization_types import (
     Objective,
@@ -182,7 +181,7 @@ class OptimizerClient:
     def wait_for_job_status(
         self,
         name: str,
-        status: set[str] = {constants.OPTIMIZATION_JOB_COMPLETE},
+        status: set[str] | None = None,
         timeout: int = 3600,
         polling_interval: int = 2,
         callbacks: list[Callable[[OptimizationJob], None]] | None = None,

--- a/kubeflow/optimizer/backends/base.py
+++ b/kubeflow/optimizer/backends/base.py
@@ -16,7 +16,6 @@ import abc
 from collections.abc import Callable, Iterator
 from typing import Any
 
-from kubeflow.optimizer.constants import constants
 from kubeflow.optimizer.types.algorithm_types import RandomSearch
 from kubeflow.optimizer.types.optimization_types import (
     Objective,
@@ -65,7 +64,7 @@ class RuntimeBackend(abc.ABC):
     def wait_for_job_status(
         self,
         name: str,
-        status: set[str] = {constants.OPTIMIZATION_JOB_COMPLETE},
+        status: set[str] | None = None,
         timeout: int = 3600,
         polling_interval: int = 2,
         callbacks: list[Callable[[OptimizationJob], None]] | None = None,

--- a/kubeflow/optimizer/backends/kubernetes/backend.py
+++ b/kubeflow/optimizer/backends/kubernetes/backend.py
@@ -269,11 +269,14 @@ class KubernetesBackend(RuntimeBackend):
     def wait_for_job_status(
         self,
         name: str,
-        status: set[str] = {constants.OPTIMIZATION_JOB_COMPLETE},
+        status: set[str] | None = None,
         timeout: int = 3600,
         polling_interval: int = 2,
         callbacks: list[Callable[[OptimizationJob], None]] | None = None,
     ) -> OptimizationJob:
+        if status is None:
+            status = {constants.OPTIMIZATION_JOB_COMPLETE}
+
         job_statuses = {
             constants.OPTIMIZATION_JOB_CREATED,
             constants.OPTIMIZATION_JOB_RUNNING,

--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -233,7 +233,7 @@ class TrainerClient:
     def wait_for_job_status(
         self,
         name: str,
-        status: set[str] = {constants.TRAINJOB_COMPLETE},
+        status: set[str] | None = None,
         timeout: int = 600,
         polling_interval: int = 2,
         callbacks: list[Callable[[types.TrainJob], None]] | None = None,

--- a/kubeflow/trainer/backends/base.py
+++ b/kubeflow/trainer/backends/base.py
@@ -75,7 +75,7 @@ class RuntimeBackend(abc.ABC):
     def wait_for_job_status(
         self,
         name: str,
-        status: set[str] = {constants.TRAINJOB_COMPLETE},
+        status: set[str] | None = None,
         timeout: int = 600,
         polling_interval: int = 2,
         callbacks: list[Callable[[types.TrainJob], None]] | None = None,

--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -803,12 +803,15 @@ class ContainerBackend(RuntimeBackend):
     def wait_for_job_status(
         self,
         name: str,
-        status: set[str] = {constants.TRAINJOB_COMPLETE},
+        status: set[str] | None = None,
         timeout: int = 600,
         polling_interval: int = 2,
         callbacks: list[Callable[[types.TrainJob], None]] | None = None,
     ) -> types.TrainJob:
         import time
+
+        if status is None:
+            status = {constants.TRAINJOB_COMPLETE}
 
         end = time.time() + timeout
         while time.time() < end:

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -446,11 +446,14 @@ class KubernetesBackend(RuntimeBackend):
     def wait_for_job_status(
         self,
         name: str,
-        status: set[str] = {constants.TRAINJOB_COMPLETE},
+        status: set[str] | None = None,
         timeout: int = 600,
         polling_interval: int = 2,
         callbacks: list[Callable[[types.TrainJob], None]] | None = None,
     ) -> types.TrainJob:
+        if status is None:
+            status = {constants.TRAINJOB_COMPLETE}
+
         job_statuses = {
             constants.TRAINJOB_CREATED,
             constants.TRAINJOB_RUNNING,

--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -215,11 +215,14 @@ class LocalProcessBackend(RuntimeBackend):
     def wait_for_job_status(
         self,
         name: str,
-        status: set[str] = {constants.TRAINJOB_COMPLETE},
+        status: set[str] | None = None,
         timeout: int = 600,
         polling_interval: int = 2,
         callbacks: list[Callable[[types.TrainJob], None]] | None = None,
     ) -> types.TrainJob:
+        if status is None:
+            status = {constants.TRAINJOB_COMPLETE}
+
         # find first match or fallback
         _job = next((_job for _job in self.__local_jobs if _job.name == name), None)
 


### PR DESCRIPTION
Fixes kubeflow/sdk#329

Description
This PR resolves the mutable default argument anti-pattern present in the wait_for_job_status methods across the Trainer and Optimizer APIs. Previously, these methods defined `status: set[str] = {constants.TRAINJOB_COMPLETE}`, which initializes the set object exactly once when the module is evaluated by the Python interpreter. 

Because sets are mutable, this pattern causes the exact same set instance to be shared across all subsequent invocations of wait_for_job_status within the same process. If any subclass or client code were to mutate this argument during execution, it would cause side effects across parallel or future SDK calls, leading to unpredictable job polling behavior.

- Updated the method signatures in 8 files across kubeflow/trainer and kubeflow/optimizer client APIs and backends (LocalProcess, Kubernetes, Container) to use `status: set[str] | None = None`.
- Shifted the default set instantiation into the function bodies using `if status is None: status = {constants.*}` to guarantee a fresh, isolated set per invocation.
- Removed unused `kubeflow.optimizer.constants.constants` imports from optimizer_client.py and optimizer/backends/base.py that were orphaned by removing the constants from the method signatures.
- Verified changes via the existing `make test-python` suite to ensure test coverage, alongside `uv run ruff check` and `uv run ty check` inside `make verify` for strict type and format compliance.