### PR TITLE
chore(trainer): fix typos in TrainerClient docstrings

### DIFF
--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -156,7 +156,7 @@ class TrainerClient:
             runtime: Reference to one of the existing runtimes.
 
         Returns:
-            List of created TrainJobs. If no TrainJob exist, an empty list is returned.
+            List of created TrainJobs. If no TrainJobs exist, an empty list is returned.
 
         Raises:
             TimeoutError: Timeout to list TrainJobs.
@@ -165,7 +165,7 @@ class TrainerClient:
         return self.backend.list_jobs(runtime=runtime)
 
     def get_job(self, name: str) -> types.TrainJob:
-        """Get the TrainJob object
+        """Get the TrainJob object.
 
         Args:
             name: Name of the TrainJob.


### PR DESCRIPTION
Fix grammatical error in list_jobs returns description ("TrainJob exist" -> "TrainJobs exist") and add missing period in get_job docstring.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
