### PR TITLE
chore(trainer): Add API reference docs for kubeflow.trainer.options classes

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -147,6 +147,7 @@ Getting Involved
    train/custom-training
    train/distributed
    train/runtimes
+   train/options
    train/api
 
 

--- a/docs/source/train/options.rst
+++ b/docs/source/train/options.rst
@@ -1,0 +1,62 @@
+Options Reference
+=================
+
+.. autoclass:: kubeflow.trainer.options.Name
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.Labels
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.Annotations
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.TrainerCommand
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.TrainerArgs
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.RuntimePatch
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.TrainingRuntimeSpecPatch
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.JobSetTemplatePatch
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.JobSetSpecPatch
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.ReplicatedJobPatch
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.JobTemplatePatch
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.JobSpecPatch
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.PodTemplatePatch
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.PodSpecPatch
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kubeflow.trainer.options.ContainerPatch
+   :members:
+   :show-inheritance:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Following on from https://github.com/kubeflow/blog/issues/192 I noticed that we do not have API docs for trainer options classes on the kubeflow sdk website. This PR adds them.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
