### PR TITLE
fix: support RC version format in Makefile release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,21 +76,25 @@ uv-venv:  ## Create uv virtual environment
 
 .PHONY: release
 release: install-dev
-	@if [ -z "$(VERSION)" ] || ! echo "$(VERSION)" | grep -E -q '^[0-9]+\.[0-9]+\.[0-9]+$$'; then \
-		echo "Error: VERSION must be set in X.Y.Z format. Usage: make release VERSION=X.Y.Z"; \
+	@if [ -z "$(VERSION)" ] || ! echo "$(VERSION)" | grep -E -q '^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$$'; then \
+		echo "Error: VERSION must be set in X.Y.Z or X.Y.ZrcN format. Usage: make release VERSION=X.Y.Z[rcN]"; \
 		exit 1; \
 	fi
 	@$(SED) -i 's/^__version__ = ".*"/__version__ = "$(VERSION)"/' kubeflow/__init__.py
-	@MAJOR_MINOR=$$(echo "$(VERSION)" | cut -d. -f1,2); \
-	CHANGELOG_PATH="CHANGELOG/CHANGELOG-$$MAJOR_MINOR.md"; \
-	echo "Generating changelog for $(VERSION) (unreleased)"; \
-	CLIFF_CMD="uv run git-cliff --unreleased --tag $(VERSION)"; \
-	if [ -f "$$CHANGELOG_PATH" ]; then \
-		$$CLIFF_CMD --prepend "$$CHANGELOG_PATH"; \
+	@if echo "$(VERSION)" | grep -E -q 'rc[0-9]+$$'; then \
+		echo "Skipping changelog generation for RC release $(VERSION)"; \
 	else \
-		$$CLIFF_CMD -o "$$CHANGELOG_PATH"; \
-	fi; \
-	echo "Changelog generated at $$CHANGELOG_PATH"
+		MAJOR_MINOR=$$(echo "$(VERSION)" | cut -d. -f1,2); \
+		CHANGELOG_PATH="CHANGELOG/CHANGELOG-$$MAJOR_MINOR.md"; \
+		echo "Generating changelog for $(VERSION) (unreleased)"; \
+		CLIFF_CMD="uv run git-cliff --unreleased --tag $(VERSION)"; \
+		if [ -f "$$CHANGELOG_PATH" ]; then \
+			$$CLIFF_CMD --prepend "$$CHANGELOG_PATH"; \
+		else \
+			$$CLIFF_CMD -o "$$CHANGELOG_PATH"; \
+		fi; \
+		echo "Changelog generated at $$CHANGELOG_PATH"; \
+	fi
 
 
  # make test-python will produce html coverage by default. Run with `make test-python report=xml` to produce xml report.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Updates the release Makefile target to support pre-release versions (X.Y.ZrcN) as defined in our versioning policy

  - Updated version validation regex to accept both X.Y.Z and X.Y.ZrcN formats
  - Skipped changelog generation for RC releases, since changelogs are only needed for final releases

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
