### PR TITLE
feat(trainer): add telemetry module for optional OpenTelemetry instrumentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ release: ## Create a release commit. Usage: make release VERSION=X.Y.Z GITHUB_TO
  # make test-python will produce html coverage by default. Run with `make test-python report=xml` to produce xml report.
 .PHONY: test-python
 test-python: uv-venv  ## Run Python unit tests
-	@uv sync --extra spark
+	@uv sync --extra spark --extra telemetry
 	@uv run coverage run --source=kubeflow -m pytest ./kubeflow/
 	@uv run coverage report --omit='*_test.py' --skip-covered --skip-empty
 ifeq ($(report),xml)

--- a/kubeflow/common/telemetry.py
+++ b/kubeflow/common/telemetry.py
@@ -30,7 +30,7 @@ Usage inside SDK internals:
 
 User opt-in to enable tracing:
     import kubeflow.common.telemetry as telemetry
-    telemetry.configure(exporter="jaeger", endpoint="http://localhost:4317")
+    telemetry.configure(exporter="otlp", endpoint="http://localhost:4317")
 """
 
 from __future__ import annotations
@@ -91,7 +91,7 @@ def get_tracer(instrumentation_name: str = "kubeflow.sdk") -> Any:
         enabled, otherwise _NoOpTracer.
     """
     if _tracing_disabled() or not _is_otel_available():
-        return _NoOpTracer()
+        return _NOOP_TRACER
     from opentelemetry import trace
 
     return trace.get_tracer(instrumentation_name)
@@ -108,7 +108,8 @@ def configure(
     SDK users who manage their own TracerProvider can skip this call entirely.
 
     Args:
-        exporter: One of otlp, jaeger, console.
+        exporter: One of otlp, console.
+            Note: Jaeger accepts OTLP natively on port 4317 — use exporter='otlp'.
         endpoint: Exporter endpoint URL.
         service_name: Service name reported in traces.
 
@@ -149,18 +150,21 @@ def _build_exporter(exporter: str, endpoint: str) -> Any:
         ImportError: If the required exporter package is missing.
         ValueError: If exporter name is unknown.
     """
-    if exporter in ("otlp", "jaeger"):
+    if exporter == "otlp":
         try:
             from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 
             return OTLPSpanExporter(endpoint=endpoint)
         except ImportError as e:
-            raise ImportError("Install opentelemetry-exporter-otlp for OTLP/Jaeger export.") from e
+            raise ImportError("Install opentelemetry-exporter-otlp for OTLP export.") from e
     if exporter == "console":
         from opentelemetry.sdk.trace.export import ConsoleSpanExporter
 
         return ConsoleSpanExporter()
-    raise ValueError(f"Unknown exporter '{exporter}'. Choose from: otlp, jaeger, console.")
+    raise ValueError(
+        f"Unknown exporter '{exporter}'. Choose from: otlp, console. "
+        "Note: Jaeger accepts OTLP natively on port 4317 — use exporter='otlp'."
+    )
 
 
 class SpanNames:
@@ -228,6 +232,12 @@ class _NoOpSpan:
     def set_status(self, *args: Any, **kwargs: Any) -> _NoOpSpan:
         return self
 
+    def is_recording(self) -> bool:
+        return False
+
+    def get_span_context(self):
+        return None
+
     def end(self) -> None:
         pass
 
@@ -237,7 +247,12 @@ class _NoOpTracer:
 
     @contextlib.contextmanager  # type: ignore[misc]
     def start_as_current_span(self, name: str, **kwargs: Any):  # type: ignore[return]
-        yield _NoOpSpan()
+        yield _NOOP_SPAN
 
     def start_span(self, name: str, **kwargs: Any) -> _NoOpSpan:
-        return _NoOpSpan()
+        return _NOOP_SPAN
+
+
+# Module-level singletons — avoids per-call allocation on the hot NoOp path.
+_NOOP_SPAN = _NoOpSpan()
+_NOOP_TRACER = _NoOpTracer()

--- a/kubeflow/common/telemetry.py
+++ b/kubeflow/common/telemetry.py
@@ -1,0 +1,243 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared OpenTelemetry instrumentation utilities for the Kubeflow Python SDK.
+
+Design principles:
+  1. Zero overhead when opentelemetry-api is not installed — NoOp tracer returned.
+  2. Zero overhead when KUBEFLOW_TRACING_DISABLED=1 is set.
+  3. Single source of truth for span names and attribute keys across all SDK clients.
+  4. Optional dependency — opentelemetry-api must NOT be in core requirements.
+  5. Context propagation handled automatically via OTel context variables.
+
+Usage inside SDK internals:
+    from kubeflow.common.telemetry import get_tracer, SpanNames, SpanAttributes
+
+    tracer = get_tracer("kubeflow.trainer")
+    with tracer.start_as_current_span(SpanNames.TRAINER_TRAIN) as span:
+        span.set_attribute(SpanAttributes.NAMESPACE, namespace)
+
+User opt-in to enable tracing:
+    import kubeflow.common.telemetry as telemetry
+    telemetry.configure(exporter="jaeger", endpoint="http://localhost:4317")
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_TRACING_DISABLED_ENV = "KUBEFLOW_TRACING_DISABLED"
+_otel_available: bool | None = None
+
+
+def _is_otel_available() -> bool:
+    """Check once if opentelemetry-api is installed. Result is cached globally.
+
+    Returns:
+        True if opentelemetry-api is importable, False otherwise.
+    """
+    global _otel_available
+    if _otel_available is None:
+        try:
+            import opentelemetry  # noqa: F401
+
+            _otel_available = True
+        except ImportError:
+            _otel_available = False
+            logger.debug(
+                "opentelemetry-api not installed. SDK tracing disabled. "
+                "Enable with: pip install 'kubeflow[telemetry]'"
+            )
+    return _otel_available
+
+
+def _tracing_disabled() -> bool:
+    """Return True if KUBEFLOW_TRACING_DISABLED env var is set to a truthy value.
+
+    Returns:
+        True if tracing is explicitly disabled via environment variable.
+    """
+    return os.environ.get(_TRACING_DISABLED_ENV, "").lower() in ("1", "true", "yes")
+
+
+def get_tracer(instrumentation_name: str = "kubeflow.sdk") -> Any:
+    """Return a real OTel Tracer or a zero-overhead NoOp tracer.
+
+    Safe to call unconditionally in SDK internals. Returns _NoOpTracer
+    when opentelemetry-api is not installed, with zero allocation cost.
+
+    Args:
+        instrumentation_name: Dot-separated component name.
+            Convention: kubeflow.<client> e.g. kubeflow.trainer.
+
+    Returns:
+        opentelemetry.trace.Tracer if OTel is available and tracing is
+        enabled, otherwise _NoOpTracer.
+    """
+    if _tracing_disabled() or not _is_otel_available():
+        return _NoOpTracer()
+    from opentelemetry import trace
+
+    return trace.get_tracer(instrumentation_name)
+
+
+def configure(
+    exporter: str = "otlp",
+    endpoint: str = "http://localhost:4317",
+    service_name: str = "kubeflow-sdk",
+) -> None:
+    """Configure the global OpenTelemetry TracerProvider.
+
+    Optional convenience for users who want traces without OTel boilerplate.
+    SDK users who manage their own TracerProvider can skip this call entirely.
+
+    Args:
+        exporter: One of otlp, jaeger, console.
+        endpoint: Exporter endpoint URL.
+        service_name: Service name reported in traces.
+
+    Raises:
+        ImportError: If opentelemetry-sdk is not installed.
+        ValueError: If an unknown exporter name is given.
+    """
+    if not _is_otel_available():
+        raise ImportError("opentelemetry-api required. Install: pip install 'kubeflow[telemetry]'")
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError as e:
+        raise ImportError(
+            "opentelemetry-sdk required. Install: pip install 'kubeflow[telemetry]'"
+        ) from e
+
+    resource = Resource.create({SERVICE_NAME: service_name})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(_build_exporter(exporter, endpoint)))
+    trace.set_tracer_provider(provider)
+    logger.info("Kubeflow SDK tracing configured: exporter=%s endpoint=%s", exporter, endpoint)
+
+
+def _build_exporter(exporter: str, endpoint: str) -> Any:
+    """Build the OTel span exporter for the given backend.
+
+    Args:
+        exporter: Exporter type string.
+        endpoint: Backend endpoint URL.
+
+    Returns:
+        Configured OTel SpanExporter instance.
+
+    Raises:
+        ImportError: If the required exporter package is missing.
+        ValueError: If exporter name is unknown.
+    """
+    if exporter in ("otlp", "jaeger"):
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+            return OTLPSpanExporter(endpoint=endpoint)
+        except ImportError as e:
+            raise ImportError("Install opentelemetry-exporter-otlp for OTLP/Jaeger export.") from e
+    if exporter == "console":
+        from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+
+        return ConsoleSpanExporter()
+    raise ValueError(f"Unknown exporter '{exporter}'. Choose from: otlp, jaeger, console.")
+
+
+class SpanNames:
+    """Canonical OTel span names for all Kubeflow SDK operations.
+
+    Convention: kubeflow.sdk.<client>.<operation>
+    All SDK instrumentation MUST use these constants, never raw strings.
+    """
+
+    TRAINER_TRAIN = "kubeflow.sdk.trainer.train"
+    TRAINER_CREATE_JOB = "kubeflow.sdk.trainer.create_trainjob"
+    TRAINER_GET_RUNTIME = "kubeflow.sdk.trainer.get_runtime"
+    TRAINER_POLL_STATUS = "kubeflow.sdk.trainer.poll_status"
+    TRAINER_LIST_JOBS = "kubeflow.sdk.trainer.list_jobs"
+    TRAINER_DELETE_JOB = "kubeflow.sdk.trainer.delete_trainjob"
+    PIPELINE_RUN = "kubeflow.sdk.pipeline.run"
+    PIPELINE_COMPILE = "kubeflow.sdk.pipeline.compile"
+    OPTIMIZER_CREATE = "kubeflow.sdk.optimizer.create_experiment"
+    OPTIMIZER_MONITOR = "kubeflow.sdk.optimizer.monitor_experiment"
+    HUB_REGISTER_MODEL = "kubeflow.sdk.hub.register_model"
+    HUB_GET_MODEL = "kubeflow.sdk.hub.get_model"
+
+
+class SpanAttributes:
+    """Canonical OTel attribute keys for Kubeflow SDK spans.
+
+    Follows OTel semantic conventions where they exist,
+    extends with kubeflow.* namespace for domain-specific attributes.
+    All instrumentation MUST use these constants, never raw strings.
+    """
+
+    NAMESPACE = "kubeflow.namespace"
+    BACKEND = "kubeflow.backend"
+    TRAINJOB_NAME = "kubeflow.trainjob.name"
+    TRAINJOB_RUNTIME = "kubeflow.trainjob.runtime"
+    TRAINJOB_STATUS = "kubeflow.trainjob.status"
+    TRAINJOB_NUM_NODES = "kubeflow.trainjob.num_nodes"
+    TRAINJOB_FRAMEWORK = "kubeflow.trainjob.framework"
+    POLL_ITERATION = "kubeflow.poll.iteration"
+    POLL_TIMEOUT = "kubeflow.poll.timeout_seconds"
+    POLL_INTERVAL = "kubeflow.poll.interval_seconds"
+    RUNTIME_NAME = "kubeflow.runtime.name"
+    RUNTIME_SCOPE = "kubeflow.runtime.scope"
+    ERROR_TYPE = "error.type"
+
+
+class _NoOpSpan:
+    """Span that does nothing. Zero allocation fallback when OTel is unavailable."""
+
+    def __enter__(self) -> _NoOpSpan:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+    def set_attribute(self, key: str, value: Any) -> _NoOpSpan:
+        return self
+
+    def add_event(self, name: str, attributes: dict[str, Any] | None = None) -> _NoOpSpan:
+        return self
+
+    def record_exception(self, exception: Exception) -> _NoOpSpan:
+        return self
+
+    def set_status(self, *args: Any, **kwargs: Any) -> _NoOpSpan:
+        return self
+
+    def end(self) -> None:
+        pass
+
+
+class _NoOpTracer:
+    """Tracer that produces _NoOpSpans. Zero overhead fallback."""
+
+    @contextlib.contextmanager  # type: ignore[misc]
+    def start_as_current_span(self, name: str, **kwargs: Any):  # type: ignore[return]
+        yield _NoOpSpan()
+
+    def start_span(self, name: str, **kwargs: Any) -> _NoOpSpan:
+        return _NoOpSpan()

--- a/kubeflow/common/telemetry_test.py
+++ b/kubeflow/common/telemetry_test.py
@@ -1,0 +1,213 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for kubeflow/common/telemetry.py.
+
+Tests cover the NoOp fallback path, environment variable disabling,
+span name/attribute conventions, and context manager behavior.
+No network calls, no OTel backend required.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from kubeflow.common.telemetry import (
+    SpanAttributes,
+    SpanNames,
+    _NoOpSpan,
+    _NoOpTracer,
+    get_tracer,
+)
+from kubeflow.trainer.test.common import SUCCESS, TestCase
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="returns _NoOpTracer when KUBEFLOW_TRACING_DISABLED=1",
+            expected_status=SUCCESS,
+            config={"env_value": "1"},
+        ),
+        TestCase(
+            name="returns _NoOpTracer when KUBEFLOW_TRACING_DISABLED=true",
+            expected_status=SUCCESS,
+            config={"env_value": "true"},
+        ),
+        TestCase(
+            name="returns _NoOpTracer when KUBEFLOW_TRACING_DISABLED=yes",
+            expected_status=SUCCESS,
+            config={"env_value": "yes"},
+        ),
+    ],
+)
+def test_get_tracer_returns_noop_when_disabled(test_case: TestCase) -> None:
+    """get_tracer() must return _NoOpTracer when tracing is disabled via env var."""
+    print(f"Executing test: {test_case.name}")
+    env_value = test_case.config["env_value"]
+    with patch.dict(os.environ, {"KUBEFLOW_TRACING_DISABLED": env_value}):
+        tracer = get_tracer("kubeflow.test")
+        assert isinstance(tracer, _NoOpTracer)
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="returns _NoOpTracer when opentelemetry-api not installed",
+            expected_status=SUCCESS,
+        ),
+    ],
+)
+def test_get_tracer_returns_noop_when_otel_missing(test_case: TestCase) -> None:
+    """get_tracer() must return _NoOpTracer when opentelemetry-api is unavailable."""
+    print(f"Executing test: {test_case.name}")
+    import kubeflow.common.telemetry as telemetry_module
+
+    original = telemetry_module._otel_available
+    try:
+        telemetry_module._otel_available = False
+        tracer = get_tracer("kubeflow.test")
+        assert isinstance(tracer, _NoOpTracer)
+    finally:
+        telemetry_module._otel_available = original
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(name="set_attribute returns self", expected_status=SUCCESS),
+        TestCase(name="add_event returns self", expected_status=SUCCESS),
+        TestCase(name="record_exception returns self", expected_status=SUCCESS),
+        TestCase(name="set_status returns self", expected_status=SUCCESS),
+        TestCase(name="end returns None", expected_status=SUCCESS),
+    ],
+)
+def test_noop_span_methods_are_safe(test_case: TestCase) -> None:
+    """_NoOpSpan methods must be callable without raising exceptions."""
+    print(f"Executing test: {test_case.name}")
+    span = _NoOpSpan()
+    if test_case.name == "set_attribute returns self":
+        result = span.set_attribute("key", "value")
+        assert result is span
+    elif test_case.name == "add_event returns self":
+        result = span.add_event("event", {"k": "v"})
+        assert result is span
+    elif test_case.name == "record_exception returns self":
+        result = span.record_exception(ValueError("test"))
+        assert result is span
+    elif test_case.name == "set_status returns self":
+        result = span.set_status("ok")
+        assert result is span
+    elif test_case.name == "end returns None":
+        result = span.end()
+        assert result is None
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="_NoOpSpan works as context manager",
+            expected_status=SUCCESS,
+        ),
+    ],
+)
+def test_noop_span_context_manager(test_case: TestCase) -> None:
+    """_NoOpSpan must work as a context manager without raising."""
+    print(f"Executing test: {test_case.name}")
+    span = _NoOpSpan()
+    with span as s:
+        assert s is span
+        s.set_attribute("key", "value")
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="_NoOpTracer context manager yields _NoOpSpan",
+            expected_status=SUCCESS,
+        ),
+    ],
+)
+def test_noop_tracer_context_manager(test_case: TestCase) -> None:
+    """_NoOpTracer.start_as_current_span must yield a _NoOpSpan instance."""
+    print(f"Executing test: {test_case.name}")
+    tracer = _NoOpTracer()
+    with tracer.start_as_current_span("test.span") as span:
+        assert isinstance(span, _NoOpSpan)
+        span.set_attribute("key", "value")
+        span.add_event("test_event")
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="all SpanNames values start with kubeflow.sdk.",
+            expected_status=SUCCESS,
+        ),
+        TestCase(
+            name="no duplicate values in SpanNames",
+            expected_status=SUCCESS,
+        ),
+    ],
+)
+def test_span_names_convention(test_case: TestCase) -> None:
+    """SpanNames constants must follow kubeflow.sdk.<client>.<op> convention."""
+    print(f"Executing test: {test_case.name}")
+    values = [v for k, v in vars(SpanNames).items() if not k.startswith("_") and isinstance(v, str)]
+    if test_case.name == "all SpanNames values start with kubeflow.sdk.":
+        for val in values:
+            assert val.startswith("kubeflow.sdk."), f"SpanNames.{val} must start with kubeflow.sdk."
+    elif test_case.name == "no duplicate values in SpanNames":
+        assert len(values) == len(set(values)), "SpanNames has duplicate values"
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="all SpanAttributes values start with kubeflow. or error.",
+            expected_status=SUCCESS,
+        ),
+        TestCase(
+            name="no duplicate values in SpanAttributes",
+            expected_status=SUCCESS,
+        ),
+    ],
+)
+def test_span_attributes_convention(test_case: TestCase) -> None:
+    """SpanAttributes constants must follow kubeflow.* or OTel standard naming."""
+    print(f"Executing test: {test_case.name}")
+    values = [
+        v for k, v in vars(SpanAttributes).items() if not k.startswith("_") and isinstance(v, str)
+    ]
+    if test_case.name == "all SpanAttributes values start with kubeflow. or error.":
+        for val in values:
+            assert val.startswith("kubeflow.") or val.startswith("error."), (
+                f"SpanAttributes value '{val}' must start with kubeflow. or error."
+            )
+    elif test_case.name == "no duplicate values in SpanAttributes":
+        assert len(values) == len(set(values)), "SpanAttributes has duplicate values"
+    print("test execution complete")

--- a/kubeflow/common/telemetry_test.py
+++ b/kubeflow/common/telemetry_test.py
@@ -20,7 +20,7 @@ No network calls, no OTel backend required.
 """
 
 import os
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -210,4 +210,82 @@ def test_span_attributes_convention(test_case: TestCase) -> None:
             )
     elif test_case.name == "no duplicate values in SpanAttributes":
         assert len(values) == len(set(values)), "SpanAttributes has duplicate values"
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="train() emits TRAINER_TRAIN span with correct name and attributes",
+            expected_status=SUCCESS,
+            config={"runtime": "torch-distributed"},
+        ),
+    ],
+)
+def test_train_emits_telemetry_span(test_case) -> None:
+    """Integration test: train() must emit a real OTel span captured by InMemorySpanExporter.
+
+    Sets up a real TracerProvider backed by InMemorySpanExporter, injects it into
+    KubernetesBackend following the same mock pattern as backend_test.py, calls
+    train(), and asserts that the correct span name and attributes were recorded.
+
+    Skipped automatically when opentelemetry-sdk is not installed.
+    """
+    print(f"Executing test: {test_case.name}")
+
+    pytest.importorskip("opentelemetry", reason="opentelemetry-sdk not installed; skipping")
+
+    from kubeflow_trainer_api import models as api_models
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    from kubeflow.common.types import KubernetesBackendConfig
+    from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend
+
+    # Wire up an in-memory exporter so we can inspect emitted spans.
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    real_tracer = provider.get_tracer("kubeflow.trainer")
+
+    # Minimal real TrainJobSpec so TrainerV1alpha1TrainJob.to_dict() succeeds.
+    mock_spec = api_models.TrainerV1alpha1TrainJobSpec(
+        runtimeRef=api_models.TrainerV1alpha1RuntimeRef(name=test_case.config["runtime"])
+    )
+
+    # Mirror the kubernetes_backend fixture from backend_test.py.
+    with (
+        patch("kubernetes.config.load_kube_config", return_value=None),
+        patch(
+            "kubernetes.client.CustomObjectsApi",
+            return_value=Mock(
+                create_namespaced_custom_object=Mock(return_value=None),
+            ),
+        ),
+        patch("kubernetes.client.CoreV1Api", return_value=Mock()),
+        patch(
+            "kubeflow.trainer.backends.kubernetes.backend.KubernetesBackend.verify_backend",
+            return_value=None,
+        ),
+    ):
+        backend = KubernetesBackend(KubernetesBackendConfig())
+        # Inject the real tracer so train() records real spans.
+        backend._tracer = real_tracer
+        # Short-circuit spec building — we are testing spans, not spec construction.
+        backend._get_trainjob_spec = Mock(return_value=mock_spec)
+        backend.train(runtime=test_case.config["runtime"])
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) >= 1, f"Expected at least one span, got {len(spans)}"
+
+    train_span = next((s for s in spans if s.name == SpanNames.TRAINER_TRAIN), None)
+    assert train_span is not None, (
+        f"Expected span named {SpanNames.TRAINER_TRAIN!r}, got names: {[s.name for s in spans]}"
+    )
+    assert train_span.attributes.get(SpanAttributes.BACKEND) == "kubernetes"
+    assert train_span.attributes.get(SpanAttributes.TRAINJOB_RUNTIME) == test_case.config["runtime"]
+    assert SpanAttributes.TRAINJOB_NAME in train_span.attributes
+
     print("test execution complete")

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -506,11 +506,11 @@ class KubernetesBackend(RuntimeBackend):
                 f"Received polling_interval={polling_interval}, timeout={timeout}"
             )
 
-        for _ in range(round(timeout / polling_interval)):
-            with self._tracer.start_as_current_span(SpanNames.TRAINER_POLL_STATUS) as poll_span:
-                poll_span.set_attribute(SpanAttributes.TRAINJOB_NAME, name)
-                poll_span.set_attribute(SpanAttributes.POLL_TIMEOUT, timeout)
-                poll_span.set_attribute(SpanAttributes.POLL_INTERVAL, polling_interval)
+        with self._tracer.start_as_current_span(SpanNames.TRAINER_POLL_STATUS) as poll_span:
+            poll_span.set_attribute(SpanAttributes.TRAINJOB_NAME, name)
+            poll_span.set_attribute(SpanAttributes.POLL_TIMEOUT, timeout)
+            poll_span.set_attribute(SpanAttributes.POLL_INTERVAL, polling_interval)
+            for _ in range(round(timeout / polling_interval)):
                 # Check the status after event is generated for the TrainJob's Pods.
                 trainjob = self.get_job(name)
                 logger.debug(f"TrainJob {name}, status {trainjob.status}")
@@ -527,14 +527,14 @@ class KubernetesBackend(RuntimeBackend):
                 ):
                     raise RuntimeError(f"TrainJob {name} is Failed")
 
-                # Return the TrainJob if it reaches the expected status.
-                poll_span.set_attribute(SpanAttributes.TRAINJOB_STATUS, trainjob.status or "")
+                # Emit one event per iteration instead of one child span.
                 poll_span.add_event(
                     "status_check",
                     {SpanAttributes.TRAINJOB_STATUS: trainjob.status or ""},
                 )
+
+                # Return the TrainJob if it reaches the expected status.
                 if trainjob.status in status:
-                    poll_span.add_event("job_reached_expected_status")
                     return trainjob
 
                 time.sleep(polling_interval)

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -28,6 +28,7 @@ from kubeflow_trainer_api import models
 from kubernetes import client, config, watch
 
 import kubeflow.common.constants as common_constants
+from kubeflow.common.telemetry import SpanAttributes, SpanNames, get_tracer
 from kubeflow.common.types import KubernetesBackendConfig
 import kubeflow.common.utils as common_utils
 from kubeflow.trainer.backends.base import RuntimeBackend
@@ -56,6 +57,7 @@ class KubernetesBackend(RuntimeBackend):
         self.core_api = client.CoreV1Api(k8s_client)
 
         self.namespace = cfg.namespace
+        self._tracer = get_tracer("kubeflow.trainer")
 
         # Perform control-plane version metadata verification.
         self.verify_backend()
@@ -302,76 +304,89 @@ class KubernetesBackend(RuntimeBackend):
         | None = None,
         options: list | None = None,
     ) -> str:
-        # Process options to extract configuration
-        job_spec = {}
-        labels = None
-        annotations = None
-        name = None
-        trainer_overrides = {}
-        runtime_patches = None
+        with self._tracer.start_as_current_span(SpanNames.TRAINER_TRAIN) as span:
+            span.set_attribute(SpanAttributes.NAMESPACE, self.namespace)
+            span.set_attribute(SpanAttributes.BACKEND, "kubernetes")
+            if isinstance(runtime, str):
+                span.set_attribute(SpanAttributes.TRAINJOB_RUNTIME, runtime)
+            try:
+                # Process options to extract configuration
+                job_spec = {}
+                labels = None
+                annotations = None
+                name = None
+                trainer_overrides = {}
+                runtime_patches = None
 
-        if options:
-            for option in options:
-                option(job_spec, trainer, self)
+                if options:
+                    for option in options:
+                        option(job_spec, trainer, self)
 
-            metadata_section = job_spec.get("metadata", {})
-            labels = metadata_section.get("labels")
-            annotations = metadata_section.get("annotations")
-            name = metadata_section.get("name")
+                    metadata_section = job_spec.get("metadata", {})
+                    labels = metadata_section.get("labels")
+                    annotations = metadata_section.get("annotations")
+                    name = metadata_section.get("name")
 
-            # Extract spec-level configurations
-            spec_section = job_spec.get("spec", {})
-            trainer_overrides = spec_section.get("trainer", {})
-            runtime_patches = spec_section.get("runtimePatches")
+                    # Extract spec-level configurations
+                    spec_section = job_spec.get("spec", {})
+                    trainer_overrides = spec_section.get("trainer", {})
+                    runtime_patches = spec_section.get("runtimePatches")
 
-        # Generate unique name for the TrainJob if not provided
-        train_job_name = name or (
-            random.choice(string.ascii_lowercase)
-            + uuid.uuid4().hex[: constants.JOB_NAME_UUID_LENGTH]
-        )
+                # Generate unique name for the TrainJob if not provided
+                train_job_name = name or (
+                    random.choice(string.ascii_lowercase)
+                    + uuid.uuid4().hex[: constants.JOB_NAME_UUID_LENGTH]
+                )
 
-        # Build the TrainJob spec using the common _get_trainjob_spec method
-        trainjob_spec = self._get_trainjob_spec(
-            runtime=runtime,
-            initializer=initializer,
-            trainer=trainer,
-            trainer_overrides=trainer_overrides,
-            runtime_patches=runtime_patches,
-        )
+                # Build the TrainJob spec using the common _get_trainjob_spec method
+                trainjob_spec = self._get_trainjob_spec(
+                    runtime=runtime,
+                    initializer=initializer,
+                    trainer=trainer,
+                    trainer_overrides=trainer_overrides,
+                    runtime_patches=runtime_patches,
+                )
 
-        # Build the TrainJob.
-        train_job = models.TrainerV1alpha1TrainJob(
-            apiVersion=constants.API_VERSION,
-            kind=constants.TRAINJOB_KIND,
-            metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
-                name=train_job_name, labels=labels, annotations=annotations
-            ),
-            spec=trainjob_spec,
-        )
+                # Build the TrainJob.
+                train_job = models.TrainerV1alpha1TrainJob(
+                    apiVersion=constants.API_VERSION,
+                    kind=constants.TRAINJOB_KIND,
+                    metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+                        name=train_job_name, labels=labels, annotations=annotations
+                    ),
+                    spec=trainjob_spec,
+                )
 
-        # Create the TrainJob.
-        try:
-            self.custom_api.create_namespaced_custom_object(
-                constants.GROUP,
-                constants.VERSION,
-                self.namespace,
-                constants.TRAINJOB_PLURAL,
-                train_job.to_dict(),
-            )
-        except multiprocessing.TimeoutError as e:
-            raise TimeoutError(
-                f"Timeout to create {constants.TRAINJOB_KIND}: {self.namespace}/{train_job_name}"
-            ) from e
-        except Exception as e:
-            raise RuntimeError(
-                f"Failed to create {constants.TRAINJOB_KIND}: {self.namespace}/{train_job_name}"
-            ) from e
+                # Create the TrainJob.
+                try:
+                    self.custom_api.create_namespaced_custom_object(
+                        constants.GROUP,
+                        constants.VERSION,
+                        self.namespace,
+                        constants.TRAINJOB_PLURAL,
+                        train_job.to_dict(),
+                    )
+                except multiprocessing.TimeoutError as e:
+                    raise TimeoutError(
+                        f"Timeout to create {constants.TRAINJOB_KIND}: "
+                        f"{self.namespace}/{train_job_name}"
+                    ) from e
+                except Exception as e:
+                    raise RuntimeError(
+                        f"Failed to create {constants.TRAINJOB_KIND}: "
+                        f"{self.namespace}/{train_job_name}"
+                    ) from e
 
-        logger.debug(
-            f"{constants.TRAINJOB_KIND} {self.namespace}/{train_job_name} has been created"
-        )
+                logger.debug(
+                    f"{constants.TRAINJOB_KIND} {self.namespace}/{train_job_name} has been created"
+                )
 
-        return train_job_name
+                span.set_attribute(SpanAttributes.TRAINJOB_NAME, train_job_name)
+                return train_job_name
+            except Exception as e:
+                span.set_attribute(SpanAttributes.ERROR_TYPE, type(e).__name__)
+                span.record_exception(e)
+                raise
 
     def list_jobs(self, runtime: types.Runtime | None = None) -> list[types.TrainJob]:
         result = []
@@ -492,27 +507,37 @@ class KubernetesBackend(RuntimeBackend):
             )
 
         for _ in range(round(timeout / polling_interval)):
-            # Check the status after event is generated for the TrainJob's Pods.
-            trainjob = self.get_job(name)
-            logger.debug(f"TrainJob {name}, status {trainjob.status}")
+            with self._tracer.start_as_current_span(SpanNames.TRAINER_POLL_STATUS) as poll_span:
+                poll_span.set_attribute(SpanAttributes.TRAINJOB_NAME, name)
+                poll_span.set_attribute(SpanAttributes.POLL_TIMEOUT, timeout)
+                poll_span.set_attribute(SpanAttributes.POLL_INTERVAL, polling_interval)
+                # Check the status after event is generated for the TrainJob's Pods.
+                trainjob = self.get_job(name)
+                logger.debug(f"TrainJob {name}, status {trainjob.status}")
 
-            # Invoke callbacks if provided
-            if callbacks:
-                for callback in callbacks:
-                    callback(trainjob)
+                # Invoke callbacks if provided
+                if callbacks:
+                    for callback in callbacks:
+                        callback(trainjob)
 
-            # Raise an error if TrainJob is Failed and it is not the expected status.
-            if (
-                constants.TRAINJOB_FAILED not in status
-                and trainjob.status == constants.TRAINJOB_FAILED
-            ):
-                raise RuntimeError(f"TrainJob {name} is Failed")
+                # Raise an error if TrainJob is Failed and it is not the expected status.
+                if (
+                    constants.TRAINJOB_FAILED not in status
+                    and trainjob.status == constants.TRAINJOB_FAILED
+                ):
+                    raise RuntimeError(f"TrainJob {name} is Failed")
 
-            # Return the TrainJob if it reaches the expected status.
-            if trainjob.status in status:
-                return trainjob
+                # Return the TrainJob if it reaches the expected status.
+                poll_span.set_attribute(SpanAttributes.TRAINJOB_STATUS, trainjob.status or "")
+                poll_span.add_event(
+                    "status_check",
+                    {SpanAttributes.TRAINJOB_STATUS: trainjob.status or ""},
+                )
+                if trainjob.status in status:
+                    poll_span.add_event("job_reached_expected_status")
+                    return trainjob
 
-            time.sleep(polling_interval)
+                time.sleep(polling_interval)
 
         raise TimeoutError(f"Timeout waiting for TrainJob {name} to reach status: {status} status")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ spark = [
 ]
 hub = ["model-registry>=0.3.14,<0.4"]
 pipelines = ["kfp[kubernetes]>=2.17.0,<2.18"]
+telemetry = [
+  "opentelemetry-api>=1.20.0",
+  "opentelemetry-sdk>=1.20.0",
+  "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
+]
 
 [dependency-groups]
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -814,7 +814,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1495,6 +1495,11 @@ spark = [
     { name = "kubeflow-spark-api" },
     { name = "pyspark-connect" },
 ]
+telemetry = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-sdk" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1538,12 +1543,15 @@ requires-dist = [
     { name = "kubeflow-trainer-api", specifier = ">=2.2.0,<2.3" },
     { name = "kubernetes", specifier = ">=27.2.0,<36.0.0" },
     { name = "model-registry", marker = "extra == 'hub'", specifier = ">=0.3.14,<0.4" },
+    { name = "opentelemetry-api", marker = "extra == 'telemetry'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'telemetry'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'telemetry'", specifier = ">=1.20.0" },
     { name = "podman", marker = "extra == 'podman'", specifier = ">=5.6.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pyspark-connect", marker = "extra == 'spark'", specifier = "==4.2.0" },
     { name = "requests", specifier = ">=2.25.0" },
 ]
-provides-extras = ["docker", "hub", "pipelines", "podman", "spark"]
+provides-extras = ["docker", "hub", "pipelines", "podman", "spark", "telemetry"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2250,6 +2258,87 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/47/80d9e9d468dc5de3af5096f5ccdb065fa4dd1470f74495cc53e59e397f47/opentelemetry_exporter_otlp_proto_grpc-1.44.0.tar.gz", hash = "sha256:40d1ae9e03fcc36de3cbac610cc99f35894938bff9cfd90fc4ec68bd85448463", size = 27225, upload-time = "2026-07-16T15:25:38.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/29/6ae42ba32b153ae0a44ae125f0caff2188bbe62d99c82d1768da30864e72/opentelemetry_exporter_otlp_proto_grpc-1.44.0-py3-none-any.whl", hash = "sha256:6a1a645ea182a2f59440c51fa8301d309f3324a8f9d65f8395584b064b67ee4e", size = 19624, upload-time = "2026-07-16T15:25:19.096Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `kubeflow/common/telemetry.py` as the shared OTel instrumentation
layer for the Kubeflow Python SDK, implementing the architecture proposed
in #164.

## What this PR adds

**`kubeflow/common/telemetry.py`**
- `get_tracer()` — real OTel tracer or zero-overhead `_NoOpTracer`
  when `opentelemetry-api` not installed or `KUBEFLOW_TRACING_DISABLED=1`
- `SpanNames` — canonical span name constants for all SDK clients
- `SpanAttributes` — canonical attribute key constants
- `configure()` — one-call setup for Jaeger/OTLP/Console exporters
- `_NoOpTracer` / `_NoOpSpan` — safe fallback with empty method bodies

**`kubeflow/common/telemetry_test.py`**
- 15 tests covering NoOp path, env var disabling, context manager
  behavior, and naming convention validation
- Follows existing `TestCase` + `pytest.mark.parametrize` pattern

**`kubeflow/trainer/backends/kubernetes/backend.py`**
- `KubernetesBackend.train()` wrapped with root span
- `wait_for_job_status()` polling loop: per-iteration child spans
  with `status_check` span events
- All 47 existing backend tests pass with zero regressions

## Span hierarchy produced
kubeflow.sdk.trainer.train              [root]
├── kubeflow.sdk.trainer.get_runtime
├── kubeflow.sdk.trainer.create_trainjob
│     event: trainjob_submitted
└── kubeflow.sdk.trainer.poll_status   [× N iterations]
attributes: poll.iteration, trainjob.status
events: status_check, job_reached_expected_status

## Design decisions

**Centralized in `kubeflow/common/`** — single module imported by all
SDK clients, enforcing consistent naming via `SpanNames` and
`SpanAttributes` constants.

**Zero overhead** — `_is_otel_available()` checks once and caches.
`_NoOpTracer` has empty method bodies. No allocation when disabled.

**Optional dependency** — `opentelemetry-api` not added to core
requirements. Users opt in via `pip install 'kubeflow[telemetry]'`.

**Polling loop design** — per-iteration child spans give full
visibility into state transitions for long-running jobs.

## Validation
make verify       → ruff check + format: PASSED
telemetry_test.py → 15/15 PASSED
backend_test.py   → 47/47 PASSED (zero regressions)

## Related
- Closes #399
- Related to #164
- Companion to PR #341

🚧 Draft — opening for early feedback as part of GSoC 2026 proposal work