### PR TITLE
docs: add usage documentation for TrainerClient options

### DIFF
--- a/docs/source/train/options.rst
+++ b/docs/source/train/options.rst
@@ -60,3 +60,37 @@ Options Reference
 .. autoclass:: kubeflow.trainer.options.ContainerPatch
    :members:
    :show-inheritance:
+
+Using options with TrainerClient
+===============================
+
+The ``options`` parameter in ``TrainerClient`` allows users to customize runtime behavior
+and backend-specific configurations for training jobs.
+
+It provides flexibility to control how training jobs are executed depending on the
+selected backend (e.g., Kubernetes, local, container).
+
+Example
+-------
+
+.. code-block:: python
+
+    from kubeflow.trainer import TrainerClient, CustomTrainer
+
+    def train_fn():
+        print("Training...")
+
+    client = TrainerClient()
+
+    job_id = client.train(
+        trainer=CustomTrainer(func=train_fn),
+        options={
+            "epochs": 10,
+            "batch_size": 32
+        }
+    )
+
+    client.wait_for_job_status(job_id)
+
+The ``options`` dictionary can include different parameters depending on the backend
+and runtime configuration.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds documentation for using `options` in TrainerClient.
It includes example usage and improves clarity for users working with training configurations.

**Which issue(s) this PR fixes**:
Fixes #388

**Checklist:**
- [x] Docs included (this PR adds documentation)
