### PR TITLE
feat(trainer): improve DX for LocalProcessBackend missing runtime error

### DIFF
--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -79,7 +79,11 @@ class LocalProcessBackend(RuntimeBackend):
         options: list | None = None,
     ) -> str:
         if runtime is None:
-            raise ValueError("Runtime must be provided for LocalProcessBackend")
+            available_runtimes = [r.name for r in local_runtimes]
+            raise ValueError(
+                f"Runtime must be provided for LocalProcessBackend. "
+                f"Available runtimes are: {available_runtimes}."
+            )
         if isinstance(runtime, str):
             runtime = self.get_runtime(runtime)
 

--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -352,7 +352,10 @@ def test_train(local_backend, mock_train_environment, test_case):
         if "rejects kubernetes" in test_case.name:
             assert "not compatible with" in error_msg
         elif "without runtime" in test_case.name:
-            assert "Runtime must be provided" in error_msg
+            assert (
+                "Runtime must be provided for LocalProcessBackend. Available runtimes are:"
+                in error_msg
+            )
         elif "without custom trainer" in test_case.name:
             assert "CustomTrainer must be set" in error_msg
     else:


### PR DESCRIPTION
**What this PR does / why we need it**:
While exploring the [LocalProcessBackend](cci:2://file:///home/nerdy_unix/.openclaw/workspace-main/kubeflow_gsoc/sdk/kubeflow/trainer/backends/localprocess/backend.py:37:0-314:9) as part of my GSoC proposal preparation, I noticed that the error message when a [runtime](cci:1://file:///home/nerdy_unix/.openclaw/workspace-main/kubeflow_gsoc/sdk/kubeflow/trainer/backends/localprocess/backend.py:49:4-61:22) is missing is quite opaque (`ValueError: Runtime must be provided`). 

This PR improves the Developer Experience (DX) by dynamically listing the available runtimes (e.g., 'torch-distributed') within the error message. This helps newcomers quickly identify the correct runtime string without deep-diving into the source code.

**Checklist:**
- [x] [Docs] included if any changes are user facing (Updated the error message itself)
- [x] I have run `make verify` and it passed.
- [x] I have run `make test-python` and all tests passed.
