### PR TITLE
chore: add training workflow explanation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,16 @@ TrainerClient().wait_for_job_status(job_id)
 # Print TrainJob logs
 print("\n".join(TrainerClient().get_job_logs(name=job_id)))
 ```
+### Understanding the Training Workflow
 
+The training workflow in Kubeflow SDK typically follows these steps:
+
+1. Define a training function  
+2. Create a `TrainJobTemplate`  
+3. Submit the job using `TrainerClient`  
+4. Monitor execution and retrieve logs  
+
+This structured workflow helps users clearly understand how training jobs are created and executed in Kubeflow.
 ### Optimize hyperparameters for your training
 
 ```python


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves the README by adding a section explaining the training workflow in Kubeflow SDK. It helps new users understand the sequence of steps involved in creating and running training jobs.

**Which issue(s) this PR fixes**:

N/A

**Checklist:**

- [x] Docs included if any changes are user facing

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
