### PR TITLE
fix(trainer): raise RuntimeError instead of ValueError in LocalProcess and Container backends

### DIFF
--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -507,7 +507,7 @@ class ContainerBackend(RuntimeBackend):
         containers = self._adapter.list_containers(filters=filters)
 
         if not containers:
-            raise ValueError(f"No TrainJob with name {name}")
+            raise RuntimeError(f"No TrainJob with name {name}")
 
         return containers
 
@@ -672,17 +672,16 @@ class ContainerBackend(RuntimeBackend):
             ValueError: If network metadata is missing or runtime not found
         """
         if not containers:
-            raise ValueError(f"No containers found for TrainJob {job_name}")
+            raise RuntimeError(f"No containers found for TrainJob {job_name}")
 
         # Get metadata from network
         network_id = containers[0]["labels"].get(f"{self.label_prefix}/network-id")
         if not network_id:
-            raise ValueError(f"TrainJob {job_name} is missing network metadata")
+            raise RuntimeError(f"TrainJob {job_name} is missing network metadata")
 
         network_info = self._adapter.get_network(network_id)
         if not network_info:
-            raise ValueError(f"TrainJob {job_name} network not found")
-
+            raise RuntimeError(f"TrainJob {job_name} network not found")
         network_labels = network_info.get("labels", {})
         runtime_name = network_labels.get(f"{self.label_prefix}/runtime-name")
 
@@ -690,10 +689,10 @@ class ContainerBackend(RuntimeBackend):
         try:
             job_runtime = self.get_runtime(runtime_name) if runtime_name else None
         except Exception as e:
-            raise ValueError(f"Runtime {runtime_name} not found for job {job_name}") from e
+            raise RuntimeError(f"Runtime {runtime_name} not found for job {job_name}") from e
 
         if not job_runtime:
-            raise ValueError(f"Runtime {runtime_name} not found for job {job_name}")
+            raise RuntimeError(f"Runtime {runtime_name} not found for job {job_name}")
 
         # Parse creation timestamp from first container
         created_str = containers[0].get("created", "")

--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -57,14 +57,14 @@ class LocalProcessBackend(RuntimeBackend):
             None,
         )
         if not runtime:
-            raise ValueError(f"Runtime '{name}' not found.")
+            raise RuntimeError(f"Runtime '{name}' not found.")
 
         return runtime
 
     def get_runtime_packages(self, runtime: types.Runtime):
         local_runtime = next((rt for rt in local_runtimes if rt.name == runtime.name), None)
         if not local_runtime:
-            raise ValueError(f"Runtime '{runtime.name}' not found.")
+            raise RuntimeError(f"Runtime '{runtime.name}' not found.")
 
         return local_runtime.trainer.packages
 
@@ -169,7 +169,7 @@ class LocalProcessBackend(RuntimeBackend):
     def get_job(self, name: str) -> types.TrainJob:
         _job = next((j for j in self.__local_jobs if j.name == name), None)
         if _job is None:
-            raise ValueError(f"No TrainJob with name {name}")
+            raise RuntimeError(f"No TrainJob with name {name}")
 
         # check and set the correct job status to match `TrainerClient` supported statuses
         status = self.__get_job_status(_job)
@@ -198,7 +198,7 @@ class LocalProcessBackend(RuntimeBackend):
     ) -> Iterator[str]:
         _job = [j for j in self.__local_jobs if j.name == name]
         if not _job:
-            raise ValueError(f"No TrainJob with name {name}")
+            raise RuntimeError(f"No TrainJob with name {name}")
 
         want_all_steps = step == constants.NODE + "-0"
 
@@ -224,10 +224,10 @@ class LocalProcessBackend(RuntimeBackend):
         _job = next((_job for _job in self.__local_jobs if _job.name == name), None)
 
         if _job is None:
-            raise ValueError(f"No TrainJob with name {name}")
+            raise RuntimeError(f"No TrainJob with name {name}")
 
         if polling_interval > timeout:
-            raise ValueError(
+            raise RuntimeError(
                 f"Polling interval {polling_interval} must be less than timeout: {timeout}"
             )
 
@@ -253,7 +253,7 @@ class LocalProcessBackend(RuntimeBackend):
         # find job first.
         _job = next((j for j in self.__local_jobs if j.name == name), None)
         if _job is None:
-            raise ValueError(f"No TrainJob with name {name}")
+            raise RuntimeError(f"No TrainJob with name {name}")
 
         # cancel all nested step jobs in target job
         _ = [step.job.cancel() for step in _job.steps]


### PR DESCRIPTION
Fixes #433

LocalProcess and Container backends were raising ValueError for 
operational failures (job not found, runtime not found), inconsistent 
with the Kubernetes backend which correctly raises RuntimeError.

Changes:
- localprocess/backend.py: get_runtime, get_job, get_job_logs, 
  wait_for_job_status, delete_job
- container/backend.py: _get_job_containers, __get_trainjob_from_containers
  (updated raise statements and docstrings)

Input validation errors remain ValueError as intended.