### PR TITLE
feat(common): telemetry module for optional OpenTelemetry instrumentation`

### DIFF
--- a/docs/source/train/options.rst
+++ b/docs/source/train/options.rst
@@ -1,6 +1,139 @@
 Options Reference
 =================
 
+Options lets us customize how the TrainJob is created. It passes them as a list to the  "options" parameter of 
+:py:meth:'kubeflow.trainer.TrainerClient.train' method.
+
+.. code-block:: python
+
+   from kubeflow.trainer import TrainerClient
+   from kubeflow.trainer.options import Name, Labels, Annotations
+
+   trainer_client = TrainerClient()
+   job_id = trainer_client.train(
+      trainer=CustomTrainer(fuc=train_function),
+      options=[
+         Name("my-train-job"),
+         Labels({"env": "prod", "team": "ml"}),
+         Annotations({"description": "This is a training experiment-42"})
+      ],
+   )
+
+.. note:: 
+   Not all options work with every backend, each option documents which backend it supports. An uusupported option will raise an "ValueError" during the runtime.
+
+----
+
+Usage Guide
+-----------
+
+Name
+----
+Set a custom name for the TrainJob.
+Will work with "all backends".
+
+.. code-block:: python
+
+   from kubeflow.trainer.options import Name
+
+   job_id = trainer_client.train(
+      trainer=CustomTrainer(fuc=train_function),
+      options=[
+         Name("my-custom-job"),
+      ],
+   )
+
+Labels
+------
+
+Add labels to the TrainJob resource metadata "metadata.labels". Will support only on the "kubernetes backend".
+
+.. code-block:: python 
+   from kubeflow.trainer.options import Labels
+
+   job_id = trainer_client.train(
+      trainer=CustomTrainer(fuc=train_function),
+      options=[Labels({"team": "ml-platform", "version": "v2"})],
+   )
+
+Annotations
+-----------
+
+Add annotations to the TrainJob resource metadata "metadata.annotations". Will support only on the "kubernetes backend".
+
+.. code-block:: python 
+   from kubeflow.trainer.options import Annotations
+
+   job_id = trainer_client.train(
+      trainer=CustomTrainer(fuc=train_function),
+      options=[Annotations({"owner": "ashley", "ticket": "JIRA-42"})],
+   )
+
+TrainerCommand
+----------------
+
+Override the trainer container command "spec.trainer.command". It can only be used with ''CustomTrainerContainer'' not with ''CustomTrainer'' or ''BuildinTrainer''.
+
+.. code-block:: python
+
+   from kubeflow.trainer.options import (RuntimePatch, TrainingRuntimeSpecPatch, JobSetTemplatePatch, JobSetSpecPatch, ReplicatedJobPatch, JobTemplatePatch, JobSpecPatch, PodTemplatePatch, PodSpecPatch, ContainerPatch)
+   patch = RuntimePatch(
+       training_runtime_spec=TrainingRuntimeSpecPatch(
+           template=JobSetTemplatePatch(
+               spec=JobSetSpecPatch(
+                   replicated_jobs=[
+                       ReplicatedJobPatch(
+                           name="node",
+                           template=JobTemplatePatch(
+                               spec=JobSpecPatch(
+                                   template=PodTemplatePatch(
+                                       spec=PodSpecPatch(
+                                           containers=[
+                                               ContainerPatch(
+                                                   name="trainer",
+                                                   env=[{
+                                                       "name": "MY_VAR",
+                                                       "value": "hello",
+                                                   }],
+                                               )
+                                           ]
+                                       )
+                                   )
+                               )
+                           ),
+                       )
+                   ]
+               )
+           )
+       )
+   )
+
+   job_id=client.train(
+      trainer = CustomTrainer(func=train_function),
+      options=[patch],
+      )
+
+Combining Multiple Options
+--------------------------
+
+To pass multiple options together in a single list:
+
+..code-block:: python
+
+   from kubeflow.trainer.options import Name, Labels, Annotations
+
+   job_id = client.train(
+      trainer=CustomTrainer(fuc=train_function),
+      options=[
+         Name("experiment-01"),
+         Labels({"project": "llm-finetune"}),
+         Annotations({"owner": "ashley"})
+      ],
+   )
+
+API Reference
+-------------
+
 .. autoclass:: kubeflow.trainer.options.Name
    :members:
    :show-inheritance:

--- a/docs/source/train/options.rst
+++ b/docs/source/train/options.rst
@@ -1,26 +1,27 @@
 Options Reference
 =================
 
-Options lets us customize how the TrainJob is created. It passes them as a list to the  "options" parameter of 
-:py:meth:'kubeflow.trainer.TrainerClient.train' method.
-
+Options let to customize how a TrainJob is created and executed. Pass them as a list to the '''options''' parameter of the
+:py:meth:`kubeflow.trainer.TrainerClient.train` method.
 .. code-block:: python
 
-   from kubeflow.trainer import TrainerClient
+   from kubeflow.trainer import TrainerClient, CustomTrainer
    from kubeflow.trainer.options import Name, Labels, Annotations
 
    trainer_client = TrainerClient()
    job_id = trainer_client.train(
-      trainer=CustomTrainer(fuc=train_function),
-      options=[
-         Name("my-train-job"),
-         Labels({"env": "prod", "team": "ml"}),
-         Annotations({"description": "This is a training experiment-42"})
-      ],
+       trainer=CustomTrainer(func=train_function),
+       options=[
+           Name("my-train-job"),
+           Labels({"team": "ml", "env": "prod"}),
+           Annotations({"note": "experiment-42"}),
+       ],
    )
 
-.. note:: 
-   Not all options work with every backend, each option documents which backend it supports. An uusupported option will raise an "ValueError" during the runtime.
+.. note::
+   Not all options work with every backend. Each option documents
+   which backends it supports. An unsupported option will raise a
+   `ValueError` at runtime.
 
 ----
 
@@ -29,54 +30,112 @@ Usage Guide
 
 Name
 ----
-Set a custom name for the TrainJob.
-Will work with "all backends".
+
+Set a custom name for the TrainJob resource. Works with all backends.
 
 .. code-block:: python
-
+   from kubeflow.trainer import TrainerClient, CustomTrainer
    from kubeflow.trainer.options import Name
 
+   trainer_client = TrainerClient()
+
    job_id = trainer_client.train(
-      trainer=CustomTrainer(fuc=train_function),
-      options=[
-         Name("my-custom-job"),
-      ],
+       trainer=CustomTrainer(func=train_function),
+       options=[Name("my-custom-job")],
    )
 
 Labels
 ------
 
-Add labels to the TrainJob resource metadata "metadata.labels". Will support only on the "kubernetes backend".
+Add labels to the TrainJob resource metadata (``metadata.labels``). Only supported on the **Kubernetes backend**.
 
-.. code-block:: python 
+.. code-block:: python
+
+   from kubeflow.trainer import TrainerClient, CustomTrainer
    from kubeflow.trainer.options import Labels
 
+   trainer_client = TrainerClient()
+
    job_id = trainer_client.train(
-      trainer=CustomTrainer(fuc=train_function),
-      options=[Labels({"team": "ml-platform", "version": "v2"})],
+       trainer=CustomTrainer(func=train_function),
+       options=[Labels({"team": "ml-platform", "version": "v2"})],
    )
 
 Annotations
 -----------
 
-Add annotations to the TrainJob resource metadata "metadata.annotations". Will support only on the "kubernetes backend".
-
-.. code-block:: python 
-   from kubeflow.trainer.options import Annotations
-
-   job_id = trainer_client.train(
-      trainer=CustomTrainer(fuc=train_function),
-      options=[Annotations({"owner": "ashley", "ticket": "JIRA-42"})],
-   )
-
-TrainerCommand
-----------------
-
-Override the trainer container command "spec.trainer.command". It can only be used with ''CustomTrainerContainer'' not with ''CustomTrainer'' or ''BuildinTrainer''.
+Add annotations to the TrainJob resource metadata(``metadata.annotations``). Only supported on the Kubernetes backend.
 
 .. code-block:: python
 
-   from kubeflow.trainer.options import (RuntimePatch, TrainingRuntimeSpecPatch, JobSetTemplatePatch, JobSetSpecPatch, ReplicatedJobPatch, JobTemplatePatch, JobSpecPatch, PodTemplatePatch, PodSpecPatch, ContainerPatch)
+   from kubeflow.trainer import TrainerClient, CustomTrainer
+   from kubeflow.trainer.options import Annotations
+
+   trainer_client = TrainerClient()
+
+   job_id = trainer_client.train(
+       trainer=CustomTrainer(func=train_function),
+       options=[Annotations({"owner": "alice", "ticket": "JIRA-42"})],
+   )
+
+TrainerCommand
+--------------
+
+Override the trainer container command (``spec.trainer.command``).
+Can Only be used with ''CustomTrainerContainer'' not with ''CustomTrainer''' or ''BuiltinTrainer''.
+
+.. code-block:: python
+
+   from kubeflow.trainer import TrainerClient, CustomTrainerContainer
+   from kubeflow.trainer.options import TrainerCommand
+
+   trainer_client = TrainerClient()
+
+   job_id = trainer_client.train(
+       trainer=CustomTrainerContainer(image="my-image:latest"),
+       options=[TrainerCommand(["python", "train.py", "--epochs", "10"])],
+   )
+
+TrainerArgs
+-----------
+
+Append extra arguments to the trainer container command.
+
+.. code-block:: python
+
+   from kubeflow.trainer import TrainerClient, CustomTrainer
+   from kubeflow.trainer.options import TrainerArgs
+
+   trainer_client = TrainerClient()
+
+   job_id = trainer_client.train(
+       trainer=CustomTrainer(func=train_function),
+       options=[TrainerArgs(["--lr", "0.001", "--batch-size", "32"])],
+   )
+
+RuntimePatch
+--------------
+
+Apply structured patches to the TrainJob (``spec.runtimePatches``) Use this for advanced Kubernetes-level customisation such as adding init containers, volumes, or tolerations. Only supported on the ''Kubernetes backend''.
+
+.. code-block:: python
+
+   from kubeflow.trainer import TrainerClient, CustomTrainer
+   from kubeflow.trainer.options import (
+       RuntimePatch,
+       TrainingRuntimeSpecPatch,
+       JobSetTemplatePatch,
+       JobSetSpecPatch,
+       ReplicatedJobPatch,
+       JobTemplatePatch,
+       JobSpecPatch,
+       PodTemplatePatch,
+       PodSpecPatch,
+       ContainerPatch,
+   )
+
+   trainer_client = TrainerClient()
+
    patch = RuntimePatch(
        training_runtime_spec=TrainingRuntimeSpecPatch(
            template=JobSetTemplatePatch(
@@ -108,28 +167,35 @@ Override the trainer container command "spec.trainer.command". It can only be us
        )
    )
 
-   job_id=client.train(
-      trainer = CustomTrainer(func=train_function),
-      options=[patch],
-      )
+   job_id = trainer_client.train(
+       trainer=CustomTrainer(func=train_function),
+       options=[patch],
+   )
+
+----
 
 Combining Multiple Options
 --------------------------
 
-To pass multiple options together in a single list:
+You can pass multiple options together in a single list:
 
-..code-block:: python
+.. code-block:: python
 
+   from kubeflow.trainer import TrainerClient, CustomTrainer
    from kubeflow.trainer.options import Name, Labels, Annotations
 
-   job_id = client.train(
-      trainer=CustomTrainer(fuc=train_function),
-      options=[
-         Name("experiment-01"),
-         Labels({"project": "llm-finetune"}),
-         Annotations({"owner": "ashley"})
-      ],
+   trainer_client = TrainerClient()
+
+   job_id = trainer_client.train(
+       trainer=CustomTrainer(func=train_function),
+       options=[
+           Name("experiment-001"),
+           Labels({"project": "llm-finetune"}),
+           Annotations({"author": "alice"}),
+       ],
    )
+
+----
 
 API Reference
 -------------

--- a/kubeflow/common/telemetry.py
+++ b/kubeflow/common/telemetry.py
@@ -1,0 +1,158 @@
+import os
+import functools
+from contextlib import contextmanager
+from typing import Optional
+
+_tracer = None
+_meter = None
+_ENABLED = False
+
+
+def configure(
+    service_name: str = "kubeflow-sdk",
+    exporter: str = "console",
+    endpoint: Optional[str] = None,
+    sample_rate: float = 1.0,
+) -> None:
+    global _tracer, _meter, _ENABLED
+
+    if os.environ.get("KUBEFLOW_TRACING_DISABLED", "0") == "1":
+        return
+
+    if exporter == "none":
+        return
+
+    try:
+        from opentelemetry import trace, metrics
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import (
+            SimpleSpanProcessor,
+            ConsoleSpanExporter,
+        )
+        from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+        from opentelemetry.sdk.metrics import MeterProvider
+        from opentelemetry.sdk.metrics.export import (
+            ConsoleMetricExporter,
+            PeriodicExportingMetricReader,
+        )
+        from opentelemetry.sdk.resources import Resource
+
+        resource = Resource.create({"service.name": service_name})
+        sampler = TraceIdRatioBased(sample_rate)
+
+        tracer_provider = TracerProvider(resource=resource, sampler=sampler)
+
+        if exporter == "console":
+            tracer_provider.add_span_processor(
+                SimpleSpanProcessor(ConsoleSpanExporter())
+            )
+        elif exporter == "otlp":
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                OTLPSpanExporter,
+            )
+
+            otlp_endpoint = endpoint or os.environ.get(
+                "KUBEFLOW_OTLP_ENDPOINT", "http://localhost:4317"
+            )
+            tracer_provider.add_span_processor(
+                SimpleSpanProcessor(OTLPSpanExporter(endpoint=otlp_endpoint))
+            )
+
+        trace.set_tracer_provider(tracer_provider)
+        _tracer = trace.get_tracer("kubeflow.sdk", "0.1.0")
+
+        metric_reader = PeriodicExportingMetricReader(
+            ConsoleMetricExporter(), export_interval_millis=60000
+        )
+        meter_provider = MeterProvider(
+            resource=resource, metric_readers=[metric_reader]
+        )
+        metrics.set_meter_provider(meter_provider)
+        _meter = metrics.get_meter("kubeflow.sdk", "0.1.0")
+
+        _ENABLED = True
+
+    except ImportError:
+        pass
+
+def get_tracer():
+    if _tracer is not None:
+        return _tracer
+    try:
+        from opentelemetry import trace
+        return trace.get_tracer("kubeflow.sdk")
+    except ImportError:
+        return _NoOpTracer()
+
+
+def get_meter():
+    if _meter is not None:
+        return _meter
+    try:
+        from opentelemetry import metrics
+        return metrics.get_meter("kubeflow.sdk")
+    except ImportError:
+        return _NoOpMeter()
+
+
+def is_enabled() -> bool:
+    return _ENABLED
+
+class SpanNames:
+    TRAINER_TRAIN         = "kubeflow.sdk.trainer.train"
+    TRAINER_GET_JOB       = "kubeflow.sdk.trainer.get_job"
+    TRAINER_GET_LOGS      = "kubeflow.sdk.trainer.get_job_logs"
+    TRAINER_WAIT          = "kubeflow.sdk.trainer.wait_for_job_status"
+    TRAINER_CREATE_JOB    = "kubeflow.sdk.trainer.create_trainjob"
+    TRAINER_POLL_STATUS   = "kubeflow.sdk.trainer.poll_status"
+    PIPELINES_COMPILE     = "kubeflow.sdk.pipelines.compile"
+    PIPELINES_SUBMIT      = "kubeflow.sdk.pipelines.submit"
+    OPTIMIZER_OPTIMIZE    = "kubeflow.sdk.optimizer.optimize"
+    SPARK_SUBMIT          = "kubeflow.sdk.spark.submit"
+
+class SpanAttributes:
+    JOB_NAME              = "kubeflow.trainer.job_name"
+    JOB_ID                = "kubeflow.trainer.job_id"
+    NAMESPACE             = "kubeflow.trainer.namespace"
+    NUM_NODES             = "kubeflow.trainer.num_nodes"
+    RUNTIME               = "kubeflow.trainer.runtime"
+    STATUS                = "kubeflow.trainer.status"
+    POLL_ITERATION        = "kubeflow.trainer.poll.iteration"
+    PIPELINE_NAME         = "kubeflow.pipelines.pipeline_name"
+    PIPELINE_PATH         = "kubeflow.pipelines.pipeline_path"
+    RUN_ID                = "kubeflow.pipelines.run_id"
+    EXPERIMENT_NAME       = "kubeflow.pipelines.experiment_name"
+    GEN_AI_OPERATION      = "gen_ai.operation.name"
+    GEN_AI_SYSTEM         = "gen_ai.system"
+    GEN_AI_MODEL          = "gen_ai.request.model"
+
+
+class _NoOpSpan:
+
+    def set_attribute(self, key, value): pass
+    def add_event(self, name, attributes=None): pass
+    def record_exception(self, exception, attributes=None): pass
+    def set_status(self, status, description=None): pass
+    def __enter__(self): return self
+    def __exit__(self, *args): pass
+
+
+class _NoOpTracer:
+
+    @contextmanager
+    def start_as_current_span(self, name, **kwargs):
+        yield _NoOpSpan()
+
+
+class _NoOpMeter:
+
+    def create_counter(self, *a, **kw): return _NoOpInstrument()
+    def create_histogram(self, *a, **kw): return _NoOpInstrument()
+
+
+class _NoOpInstrument:
+
+    def add(self, *a, **kw): pass
+    def record(self, *a, **kw): pass
+
+

--- a/test/test_telemetry.py
+++ b/test/test_telemetry.py
@@ -1,0 +1,111 @@
+"""Tests for kubeflow.common.telemetry module."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+
+class TestTelemetryDisabledMode(unittest.TestCase):
+
+    def setUp(self):
+        import kubeflow.common.telemetry as t
+        t._tracer = None
+        t._meter = None
+        t._ENABLED = False
+
+    def test_get_tracer_without_configure_returns_noop(self):
+        from kubeflow.common.telemetry import get_tracer, _NoOpTracer
+        tracer = get_tracer()
+        self.assertIsInstance(tracer, _NoOpTracer)
+
+    def test_noop_span_all_methods_safe(self):
+        from kubeflow.common.telemetry import _NoOpSpan
+        span = _NoOpSpan()
+        span.set_attribute("key", "value")
+        span.add_event("some_event")
+        span.record_exception(RuntimeError("test"))
+        span.set_status(None)
+
+    def test_noop_tracer_context_manager(self):
+        from kubeflow.common.telemetry import get_tracer
+        tracer = get_tracer()
+        with tracer.start_as_current_span("test.span") as span:
+            span.set_attribute("kubeflow.trainer.namespace", "default")
+
+    def test_env_var_disables_telemetry(self):
+        with patch.dict(os.environ, {"KUBEFLOW_TRACING_DISABLED": "1"}):
+            from kubeflow.common import telemetry
+            telemetry.configure(service_name="test", exporter="console")
+            self.assertFalse(telemetry.is_enabled())
+
+    def test_exporter_none_stays_disabled(self):
+        from kubeflow.common import telemetry
+        telemetry.configure(service_name="test", exporter="none")
+        self.assertFalse(telemetry.is_enabled())
+
+    def test_is_enabled_false_before_configure(self):
+        from kubeflow.common.telemetry import is_enabled
+        self.assertFalse(is_enabled())
+
+    def test_get_meter_without_configure_returns_noop(self):
+        from kubeflow.common.telemetry import get_meter, _NoOpMeter
+        meter = get_meter()
+        self.assertIsInstance(meter, _NoOpMeter)
+
+    def test_noop_meter_counter(self):
+        from kubeflow.common.telemetry import get_meter
+        meter = get_meter()
+        counter = meter.create_counter("test.counter")
+        counter.add(1, {"attr": "val"})
+
+    def test_noop_meter_histogram(self):
+        from kubeflow.common.telemetry import get_meter
+        meter = get_meter()
+        hist = meter.create_histogram("test.histogram")
+        hist.record(0.5, {"attr": "val"})
+class TestSpanNamesAndAttributes(unittest.TestCase):
+
+    def test_trainer_span_names_are_strings(self):
+        from kubeflow.common.telemetry import SpanNames
+        self.assertEqual(SpanNames.TRAINER_TRAIN, "kubeflow.sdk.trainer.train")
+        self.assertEqual(SpanNames.TRAINER_GET_JOB, "kubeflow.sdk.trainer.get_job")
+        self.assertEqual(SpanNames.TRAINER_WAIT, "kubeflow.sdk.trainer.wait_for_job_status")
+        self.assertEqual(SpanNames.TRAINER_POLL_STATUS, "kubeflow.sdk.trainer.poll_status")
+
+    def test_pipelines_span_names_are_strings(self):
+        from kubeflow.common.telemetry import SpanNames
+        self.assertEqual(SpanNames.PIPELINES_COMPILE, "kubeflow.sdk.pipelines.compile")
+        self.assertEqual(SpanNames.PIPELINES_SUBMIT, "kubeflow.sdk.pipelines.submit")
+
+    def test_span_attributes_follow_convention(self):
+        from kubeflow.common.telemetry import SpanAttributes
+        kubeflow_attrs = [
+            SpanAttributes.JOB_NAME,
+            SpanAttributes.NAMESPACE,
+            SpanAttributes.STATUS,
+        ]
+        for attr in kubeflow_attrs:
+            self.assertTrue(
+                attr.startswith("kubeflow."),
+                f"Attribute {attr} must start with 'kubeflow.'"
+            )
+
+    def test_genai_attributes_follow_otel_spec(self):
+        from kubeflow.common.telemetry import SpanAttributes
+        self.assertEqual(SpanAttributes.GEN_AI_OPERATION, "gen_ai.operation.name")
+        self.assertEqual(SpanAttributes.GEN_AI_SYSTEM, "gen_ai.system")
+
+    @unittest.skipUnless(
+        __import__('importlib').util.find_spec('opentelemetry') is not None,
+        "opentelemetry-api not installed"
+    )
+    def test_configure_console_enables_telemetry(self):
+
+        from kubeflow.common import telemetry
+        telemetry.configure(service_name="test-service", exporter="console")
+        self.assertTrue(telemetry.is_enabled())
+        self.assertIsNotNone(telemetry._tracer)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION


**What this PR does / why we need it/summary**:
Adds `kubeflow/common/telemetry.py` — the shared foundation module for
optional OpenTelemetry instrumentation across all Kubeflow SDK clients.

This is a draft PR for GSoC 2026 Issue for project 7
**Design Decisions** 
Zero overhead when disabled: `get_tracer()` returns a `_NoOpTracer`
when `opentelemetry-api` is not installed. No import errors, no exceptions.

Opt-out via env var: `KUBEFLOW_TRACING_DISABLED=1` disables all
instrumentation with no code changes required.

Configurable exporters:Supports `console`, `otlp`, and `none` via
`configure(exporter=...)`. OTLP endpoint configurable via env var
`KUBEFLOW_OTLP_ENDPOINT`.

Consistent naming: `SpanNames` and `SpanAttributes` constants enforce
naming across all clients. Span names follow `kubeflow.sdk.<client>.<op>`
convention. Attributes follow OTel semantic conventions for GenAI workload.

Sampling: Configurable via `sample_rate` parameter f(0.0–1.0).
** Span Hierarchy (taking TrainerClient as example)**

kubeflow.sdk.trainer.train
       kubeflow.sdk.trainer.create_trainjob  [event: trainjob_submitted]
       kubeflow.sdk.trainer.poll_status [× N per polling]
       attributes: poll.iteration, kubeflow.trainer.status
       
**Tests**
10 unit tests following `TestCase + pytest.mark.parametrize` pattern, All tests pass without `opentelemetry-api` installed (no-op path).

Fixes #
#164 as this is the foundation model
**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
