### PR TITLE
feat: inject W3C trace context into TrainJob annotations

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -318,6 +318,10 @@ class KubernetesBackend(RuntimeBackend):
             runtime_patches=runtime_patches,
         )
 
+        # Propagate W3C trace context into CRD annotations so that traces
+        # started by the SDK can be correlated with controller-side spans.
+        annotations = utils.inject_trace_context(annotations)
+
         # Build the TrainJob.
         train_job = models.TrainerV1alpha1TrainJob(
             apiVersion=constants.API_VERSION,

--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -656,3 +656,39 @@ def get_model_initializer(
         )
 
     raise ValueError(f"Model initializer type is invalid: {type(model)}")
+
+
+# Annotation key prefix for W3C trace context propagation.
+_TRACE_ANNOTATION_PREFIX = "opentelemetry.io/"
+
+
+def inject_trace_context(
+    annotations: dict[str, str] | None,
+) -> dict[str, str] | None:
+    """Inject W3C trace context into annotations when OpenTelemetry is available.
+
+    Uses the global OTel propagator to inject ``traceparent`` / ``tracestate``
+    headers into a carrier dict, then merges them into *annotations* under the
+    ``opentelemetry.io/`` key prefix.
+
+    Returns *annotations* unchanged when the ``opentelemetry`` package is not
+    installed or when no active span context exists.
+    """
+    try:
+        from opentelemetry.propagate import inject
+    except ImportError:
+        return annotations
+
+    carrier: dict[str, str] = {}
+    inject(carrier)
+
+    if not carrier:
+        return annotations
+
+    if annotations is None:
+        annotations = {}
+
+    for key, value in carrier.items():
+        annotations[f"{_TRACE_ANNOTATION_PREFIX}{key}"] = value
+
+    return annotations

--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -661,6 +661,10 @@ def get_model_initializer(
 # Annotation key prefix for W3C trace context propagation.
 _TRACE_ANNOTATION_PREFIX = "opentelemetry.io/"
 
+# Only propagate W3C Trace Context headers — not baggage or other
+# propagator-injected keys that could carry PII or unbounded values.
+_W3C_TRACE_HEADERS = frozenset({"traceparent", "tracestate"})
+
 
 def inject_trace_context(
     annotations: dict[str, str] | None,
@@ -668,8 +672,10 @@ def inject_trace_context(
     """Inject W3C trace context into annotations when OpenTelemetry is available.
 
     Uses the global OTel propagator to inject ``traceparent`` / ``tracestate``
-    headers into a carrier dict, then merges them into *annotations* under the
-    ``opentelemetry.io/`` key prefix.
+    headers into a carrier dict, then merges only those two keys into
+    *annotations* under the ``opentelemetry.io/`` key prefix.
+
+    Existing ``opentelemetry.io/*`` annotations are not overwritten.
 
     Returns *annotations* unchanged when the ``opentelemetry`` package is not
     installed or when no active span context exists.
@@ -689,6 +695,10 @@ def inject_trace_context(
         annotations = {}
 
     for key, value in carrier.items():
-        annotations[f"{_TRACE_ANNOTATION_PREFIX}{key}"] = value
+        if key not in _W3C_TRACE_HEADERS:
+            continue
+        annotation_key = f"{_TRACE_ANNOTATION_PREFIX}{key}"
+        if annotation_key not in annotations:
+            annotations[annotation_key] = value
 
     return annotations

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock, patch
+
 from kubeflow_trainer_api import models
 import pytest
 
@@ -845,3 +847,82 @@ def test_get_args_from_dataset_preprocess_config(test_case: TestCase):
         assert test_case.expected_status == FAILED
         assert type(e) is test_case.expected_error
     print("test execution complete")
+
+
+# -------------------------------------------------------
+# inject_trace_context
+# -------------------------------------------------------
+
+SAMPLE_TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+SAMPLE_TRACESTATE = "congo=t61rcWkgMzE"
+
+
+def _mock_otel_propagate(carrier_updates: dict[str, str]) -> MagicMock:
+    """Return a mock ``opentelemetry.propagate`` module whose ``inject`` writes
+    *carrier_updates* into the carrier dict supplied by the caller."""
+    mod = MagicMock()
+    mod.inject = lambda carrier: carrier.update(carrier_updates)
+    return mod
+
+
+class TestInjectTraceContext:
+    def test_passthrough_without_otel(self):
+        """Annotations returned unchanged when opentelemetry is not installed."""
+        existing = {"user-key": "user-value"}
+        result = utils.inject_trace_context(existing)
+        assert result is existing
+
+    def test_none_passthrough_without_otel(self):
+        """None returned when annotations is None and opentelemetry is absent."""
+        assert utils.inject_trace_context(None) is None
+
+    def test_no_active_context(self):
+        """No annotations added when OTel is present but no span is active."""
+        mock_mod = _mock_otel_propagate({})
+        with patch.dict(
+            "sys.modules",
+            {"opentelemetry": MagicMock(), "opentelemetry.propagate": mock_mod},
+        ):
+            result = utils.inject_trace_context({"user": "val"})
+        assert result == {"user": "val"}
+
+    def test_injects_traceparent(self):
+        """traceparent is injected under the opentelemetry.io/ prefix."""
+        mock_mod = _mock_otel_propagate({"traceparent": SAMPLE_TRACEPARENT})
+        with patch.dict(
+            "sys.modules",
+            {"opentelemetry": MagicMock(), "opentelemetry.propagate": mock_mod},
+        ):
+            result = utils.inject_trace_context(None)
+        assert result == {
+            "opentelemetry.io/traceparent": SAMPLE_TRACEPARENT,
+        }
+
+    def test_injects_traceparent_and_tracestate(self):
+        """Both traceparent and tracestate are injected when present."""
+        mock_mod = _mock_otel_propagate(
+            {"traceparent": SAMPLE_TRACEPARENT, "tracestate": SAMPLE_TRACESTATE}
+        )
+        with patch.dict(
+            "sys.modules",
+            {"opentelemetry": MagicMock(), "opentelemetry.propagate": mock_mod},
+        ):
+            result = utils.inject_trace_context({"app": "trainer"})
+        assert result == {
+            "app": "trainer",
+            "opentelemetry.io/traceparent": SAMPLE_TRACEPARENT,
+            "opentelemetry.io/tracestate": SAMPLE_TRACESTATE,
+        }
+
+    def test_preserves_existing_annotations(self):
+        """User-supplied annotations are not overwritten."""
+        mock_mod = _mock_otel_propagate({"traceparent": SAMPLE_TRACEPARENT})
+        original = {"team": "ml-platform", "created-by": "sdk"}
+        with patch.dict(
+            "sys.modules",
+            {"opentelemetry": MagicMock(), "opentelemetry.propagate": mock_mod},
+        ):
+            result = utils.inject_trace_context(original)
+        assert result["team"] == "ml-platform"
+        assert result["created-by"] == "sdk"
+        assert result["opentelemetry.io/traceparent"] == SAMPLE_TRACEPARENT

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -869,12 +869,14 @@ class TestInjectTraceContext:
     def test_passthrough_without_otel(self):
         """Annotations returned unchanged when opentelemetry is not installed."""
         existing = {"user-key": "user-value"}
-        result = utils.inject_trace_context(existing)
+        with patch.dict("sys.modules", {"opentelemetry.propagate": None}):
+            result = utils.inject_trace_context(existing)
         assert result is existing
 
     def test_none_passthrough_without_otel(self):
         """None returned when annotations is None and opentelemetry is absent."""
-        assert utils.inject_trace_context(None) is None
+        with patch.dict("sys.modules", {"opentelemetry.propagate": None}):
+            assert utils.inject_trace_context(None) is None
 
     def test_no_active_context(self):
         """No annotations added when OTel is present but no span is active."""
@@ -926,3 +928,30 @@ class TestInjectTraceContext:
         assert result["team"] == "ml-platform"
         assert result["created-by"] == "sdk"
         assert result["opentelemetry.io/traceparent"] == SAMPLE_TRACEPARENT
+
+    def test_does_not_overwrite_existing_trace_annotations(self):
+        """Pre-set opentelemetry.io/* annotations are preserved."""
+        custom_tp = "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"
+        mock_mod = _mock_otel_propagate({"traceparent": SAMPLE_TRACEPARENT})
+        original = {"opentelemetry.io/traceparent": custom_tp}
+        with patch.dict(
+            "sys.modules",
+            {"opentelemetry": MagicMock(), "opentelemetry.propagate": mock_mod},
+        ):
+            result = utils.inject_trace_context(original)
+        assert result["opentelemetry.io/traceparent"] == custom_tp
+
+    def test_filters_non_w3c_headers(self):
+        """Only traceparent/tracestate are injected — baggage is dropped."""
+        mock_mod = _mock_otel_propagate(
+            {"traceparent": SAMPLE_TRACEPARENT, "baggage": "userId=12345"}
+        )
+        with patch.dict(
+            "sys.modules",
+            {"opentelemetry": MagicMock(), "opentelemetry.propagate": mock_mod},
+        ):
+            result = utils.inject_trace_context(None)
+        assert result == {
+            "opentelemetry.io/traceparent": SAMPLE_TRACEPARENT,
+        }
+        assert "opentelemetry.io/baggage" not in result


### PR DESCRIPTION
Addresses #446.

When `opentelemetry-api` is installed, `train()` now injects the active W3C trace context (`traceparent`, `tracestate`) into TrainJob annotations under the `opentelemetry.io/` prefix. This lets traces started by the SDK propagate to the training controller and worker pods.

The implementation uses a lazy import with a fallback — when the package isn't installed (the common case today), the function is a no-op that returns annotations unchanged with zero overhead. The `opentelemetry.io/` annotation prefix follows the same convention Tekton Pipelines uses for CRD-level context propagation.

**Changes:**

- `inject_trace_context()` in `utils.py` — uses the global OTel propagator to write trace headers into a carrier dict, then merges them as prefixed annotations
- One-line call in `KubernetesBackend.train()` right before TrainJob construction
- 6 unit tests covering all branches (no OTel, no active context, injection, preservation of existing annotations)

No new required dependencies. A follow-up could add `opentelemetry-api` as an optional extra (`pip install kubeflow[telemetry]`).

Relates to #164