### PR TITLE
fix(deps): Bump Kubeflow Trainer API to 2.1 version

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -1,7 +1,6 @@
 name: E2E Test
 
-on:
-  pull_request
+on: pull_request
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-version: ["1.30.0", "1.31.0", "1.32.3", "1.33.1"]
+        kubernetes-version: ["1.32.3", "1.33.1", "1.34.0", "1.35.0"]
         trainer-ref: ["master"]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,17 +28,13 @@ classifiers = [
 dependencies = [
   "kubernetes>=27.2.0",
   "pydantic>=2.10.0",
-  "kubeflow-trainer-api>=2.0.0",
+  "kubeflow-trainer-api>=2.0.0,<2.2.0",
   "kubeflow-katib-api>=0.19.0",
 ]
 
 [project.optional-dependencies]
-docker = [
-  "docker>=6.1.3",
-]
-podman = [
-  "podman>=5.6.0"
-]
+docker = ["docker>=6.1.3"]
+podman = ["podman>=5.6.0"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 
 [[package]]
@@ -471,7 +471,7 @@ dev = [
 requires-dist = [
     { name = "docker", marker = "extra == 'docker'", specifier = ">=6.1.3" },
     { name = "kubeflow-katib-api", specifier = ">=0.19.0" },
-    { name = "kubeflow-trainer-api", specifier = ">=2.0.0" },
+    { name = "kubeflow-trainer-api", specifier = ">=2.0.0,<2.2.0" },
     { name = "kubernetes", specifier = ">=27.2.0" },
     { name = "podman", marker = "extra == 'podman'", specifier = ">=5.6.0" },
     { name = "pydantic", specifier = ">=2.10.0" },


### PR DESCRIPTION
KF Trainer v2.2 introduced several breaking changes that makes Kubeflow SDK 0.3 release unusable with the `kubeflow-trainer-api=2.2.0` package.
We should not allow to install `2.2.0` version.

Error:
```
if ml_policy.torch and ml_policy.torch.num_proc_per_node: 
AttributeError: 'dict' object has no attribute 'num_proc_per_node'
```


/assign @astefanutti @kramaranya @Fiona-Waters @abhijeet-dhumal @szaher @akshaychitneni 