### PR TITLE
feat: add OpenTelemetry telemetry module for SDK instrumentation (#164)

### DIFF
--- a/kubeflow/common/telemetry.py
+++ b/kubeflow/common/telemetry.py
@@ -1,0 +1,119 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from opentelemetry.metrics import Meter
+    from opentelemetry.trace import Span, Tracer
+
+logger = logging.getLogger(__name__)
+
+# Instrumentation identity. The version tracks the SDK version that introduced
+# telemetry support and is bumped when the instrumentation surface changes
+# (new span names, attribute renames, metric additions).
+_INSTRUMENTATION_NAME = "kubeflow.sdk"
+_INSTRUMENTATION_VERSION = "0.5.0"
+
+# Module-level singletons. Populated exactly once by _setup().
+_tracer: Tracer | None = None
+_meter: Meter | None = None
+_initialized: bool = False
+
+
+def _setup() -> None:
+    """Lazily initialize OTel tracer and meter if the API is installed.
+
+    This function is called on first use of :func:`get_tracer` or
+    :func:`get_meter`. It attempts to import ``opentelemetry`` exactly once.
+    If the import fails, ``_tracer`` and ``_meter`` remain ``None`` and all
+    subsequent calls to :func:`sdk_span` become zero-cost no-ops.
+
+    The tracer and meter are obtained via the global ``TracerProvider`` and
+    ``MeterProvider``. If the user has not configured a provider (i.e. they
+    installed ``opentelemetry-api`` but not ``opentelemetry-sdk``), the API
+    returns built-in no-op implementations — so this module never needs its
+    own stub classes.
+    """
+    global _tracer, _meter, _initialized  # noqa: PLW0603
+    if _initialized:
+        return
+    _initialized = True
+
+    try:
+        from opentelemetry import metrics, trace
+
+        _tracer = trace.get_tracer(_INSTRUMENTATION_NAME, _INSTRUMENTATION_VERSION)
+        _meter = metrics.get_meter(_INSTRUMENTATION_NAME, _INSTRUMENTATION_VERSION)
+    except ImportError:
+        logger.debug(
+            "opentelemetry-api is not installed. Install it with: pip install 'kubeflow[telemetry]'"
+        )
+        _tracer = None
+        _meter = None
+
+
+def get_tracer() -> Tracer | None:
+    """Return the SDK's OTel tracer, or ``None`` if OTel is unavailable."""
+    _setup()
+    return _tracer
+
+
+def get_meter() -> Meter | None:
+    """Return the SDK's OTel meter, or ``None`` if OTel is unavailable."""
+    _setup()
+    return _meter
+
+
+@contextmanager
+def sdk_span(
+    name: str,
+    attributes: dict[str, Any] | None = None,
+) -> Iterator[Span | None]:
+    """Context manager that creates an OTel span if available, or no-ops.
+
+    When ``opentelemetry-api`` is installed, this creates a span via
+    ``tracer.start_as_current_span`` — meaning it is automatically set as
+    the current span in the OTel context, and any child spans created
+    inside the ``with`` block will be parented to it.
+
+    When OTel is not installed, this yields ``None`` with no overhead.
+    Callers must guard attribute-setting calls with ``if span:``::
+
+        with sdk_span("kubeflow.trainer.train") as span:
+            result = do_work()
+            if span:
+                span.set_attribute("kubeflow.trainjob.name", result.name)
+
+    Args:
+        name: The span name. Should follow the ``kubeflow.<client>.<operation>``
+            convention (e.g. ``kubeflow.trainer.train``).
+        attributes: Initial span attributes. Keys should use the ``kubeflow.*``
+            namespace prefix.
+
+    Yields:
+        The active ``Span`` instance, or ``None`` if OTel is not available.
+    """
+    tracer = get_tracer()
+    if tracer is None:
+        yield None
+        return
+    with tracer.start_as_current_span(name, attributes=attributes) as span:
+        yield span

--- a/kubeflow/common/telemetry_test.py
+++ b/kubeflow/common/telemetry_test.py
@@ -1,0 +1,263 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the telemetry module.
+
+Tests verify two scenarios:
+1. OTel is installed: spans are created with correct names and attributes.
+2. OTel is absent: all operations no-op without errors.
+
+Since ``opentelemetry-api`` is an optional dependency and may not be installed
+in the dev environment, the "OTel installed" tests inject fake modules into
+``sys.modules`` rather than using ``unittest.mock.patch`` on the real package.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+import kubeflow.common.telemetry as telemetry
+
+
+@pytest.fixture(autouse=True)
+def _reset_telemetry_state():
+    """Reset module-level state before each test.
+
+    The telemetry module uses a module-level ``_initialized`` flag to ensure
+    ``_setup()`` runs only once. Tests need a clean slate each time, so we
+    reset the flag and singletons before every test.
+    """
+    telemetry._initialized = False
+    telemetry._tracer = None
+    telemetry._meter = None
+    yield
+    telemetry._initialized = False
+    telemetry._tracer = None
+    telemetry._meter = None
+
+
+@pytest.fixture()
+def mock_otel():
+    """Inject fake opentelemetry modules into sys.modules.
+
+    This fixture creates mock ``opentelemetry``, ``opentelemetry.trace``, and
+    ``opentelemetry.metrics`` modules with controllable ``get_tracer`` and
+    ``get_meter`` functions. It cleans up sys.modules after the test.
+
+    Yields a dict with ``tracer``, ``meter``, ``get_tracer``, and ``get_meter``
+    mocks for assertions.
+    """
+    mock_tracer = MagicMock(name="mock_tracer")
+    mock_meter = MagicMock(name="mock_meter")
+
+    mock_trace_mod = MagicMock()
+    mock_trace_mod.get_tracer = MagicMock(return_value=mock_tracer)
+
+    mock_metrics_mod = MagicMock()
+    mock_metrics_mod.get_meter = MagicMock(return_value=mock_meter)
+
+    mock_otel_mod = MagicMock()
+    mock_otel_mod.trace = mock_trace_mod
+    mock_otel_mod.metrics = mock_metrics_mod
+
+    # Save any existing entries so we can restore them.
+    saved = {}
+    otel_keys = ["opentelemetry", "opentelemetry.trace", "opentelemetry.metrics"]
+    for key in otel_keys:
+        if key in sys.modules:
+            saved[key] = sys.modules[key]
+
+    sys.modules["opentelemetry"] = mock_otel_mod
+    sys.modules["opentelemetry.trace"] = mock_trace_mod
+    sys.modules["opentelemetry.metrics"] = mock_metrics_mod
+
+    yield {
+        "tracer": mock_tracer,
+        "meter": mock_meter,
+        "get_tracer": mock_trace_mod.get_tracer,
+        "get_meter": mock_metrics_mod.get_meter,
+    }
+
+    # Restore original state.
+    for key in otel_keys:
+        if key in saved:
+            sys.modules[key] = saved[key]
+        else:
+            sys.modules.pop(key, None)
+
+
+@pytest.fixture()
+def mock_no_otel():
+    """Ensure opentelemetry is NOT importable.
+
+    Temporarily removes any opentelemetry entries from sys.modules and installs
+    an import hook that blocks the import.
+    """
+    saved = {}
+    otel_keys = [k for k in sys.modules if k.startswith("opentelemetry")]
+    for key in otel_keys:
+        saved[key] = sys.modules.pop(key)
+
+    original_import = (
+        __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+    )
+
+    def blocking_import(name, *args, **kwargs):
+        if name.startswith("opentelemetry"):
+            raise ImportError(f"No module named '{name}'")
+        return original_import(name, *args, **kwargs)
+
+    if isinstance(__builtins__, dict):
+        __builtins__["__import__"] = blocking_import
+    else:
+        __builtins__.__import__ = blocking_import
+
+    yield
+
+    if isinstance(__builtins__, dict):
+        __builtins__["__import__"] = original_import
+    else:
+        __builtins__.__import__ = original_import
+
+    for key, mod in saved.items():
+        sys.modules[key] = mod
+
+
+class TestSetupWithOTel:
+    """Tests for when opentelemetry-api is installed."""
+
+    def test_setup_creates_tracer_and_meter(self, mock_otel):
+        """_setup() should create a tracer and meter from the OTel API."""
+        telemetry._setup()
+
+        mock_otel["get_tracer"].assert_called_once_with("kubeflow.sdk", "0.5.0")
+        mock_otel["get_meter"].assert_called_once_with("kubeflow.sdk", "0.5.0")
+        assert telemetry._tracer is mock_otel["tracer"]
+        assert telemetry._meter is mock_otel["meter"]
+
+    def test_setup_runs_only_once(self, mock_otel):
+        """_setup() should only attempt the import once, even if called multiple times."""
+        telemetry._setup()
+        telemetry._setup()
+        telemetry._setup()
+
+        mock_otel["get_tracer"].assert_called_once()
+
+    def test_get_tracer_returns_tracer(self, mock_otel):
+        """get_tracer() should return the OTel tracer."""
+        result = telemetry.get_tracer()
+        assert result is mock_otel["tracer"]
+
+    def test_get_meter_returns_meter(self, mock_otel):
+        """get_meter() should return the OTel meter."""
+        result = telemetry.get_meter()
+        assert result is mock_otel["meter"]
+
+
+class TestSetupWithoutOTel:
+    """Tests for when opentelemetry-api is NOT installed."""
+
+    def test_setup_without_otel_sets_none(self, mock_no_otel):
+        """When OTel is missing, _setup() should set tracer and meter to None."""
+        telemetry._setup()
+
+        assert telemetry._tracer is None
+        assert telemetry._meter is None
+        assert telemetry._initialized is True
+
+    def test_get_tracer_returns_none_without_otel(self, mock_no_otel):
+        """get_tracer() should return None when OTel is not installed."""
+        assert telemetry.get_tracer() is None
+
+    def test_get_meter_returns_none_without_otel(self, mock_no_otel):
+        """get_meter() should return None when OTel is not installed."""
+        assert telemetry.get_meter() is None
+
+
+class TestSdkSpan:
+    """Tests for the sdk_span context manager."""
+
+    def test_sdk_span_creates_span_with_otel(self, mock_otel):
+        """sdk_span() should create a real span when OTel is available."""
+        mock_span = MagicMock()
+        mock_otel["tracer"].start_as_current_span.return_value.__enter__ = MagicMock(
+            return_value=mock_span
+        )
+        mock_otel["tracer"].start_as_current_span.return_value.__exit__ = MagicMock(
+            return_value=False
+        )
+
+        with telemetry.sdk_span(
+            "kubeflow.trainer.train",
+            attributes={"kubeflow.namespace": "default"},
+        ) as span:
+            assert span is mock_span
+
+        mock_otel["tracer"].start_as_current_span.assert_called_once_with(
+            "kubeflow.trainer.train",
+            attributes={"kubeflow.namespace": "default"},
+        )
+
+    def test_sdk_span_yields_none_without_otel(self):
+        """sdk_span() should yield None and not error when OTel is absent."""
+        telemetry._initialized = True
+        telemetry._tracer = None
+
+        with telemetry.sdk_span("kubeflow.trainer.train") as span:
+            assert span is None
+
+    def test_sdk_span_allows_attribute_setting_on_span(self, mock_otel):
+        """Callers should be able to set attributes on the yielded span."""
+        mock_span = MagicMock()
+        mock_otel["tracer"].start_as_current_span.return_value.__enter__ = MagicMock(
+            return_value=mock_span
+        )
+        mock_otel["tracer"].start_as_current_span.return_value.__exit__ = MagicMock(
+            return_value=False
+        )
+
+        with telemetry.sdk_span("kubeflow.trainer.train") as span:
+            if span:
+                span.set_attribute("kubeflow.trainjob.name", "my-job")
+
+        mock_span.set_attribute.assert_called_once_with("kubeflow.trainjob.name", "my-job")
+
+    def test_sdk_span_no_error_when_setting_attributes_without_otel(self):
+        """The ``if span:`` guard pattern should safely skip when OTel is absent."""
+        telemetry._initialized = True
+        telemetry._tracer = None
+
+        # This must not raise.
+        with telemetry.sdk_span("kubeflow.trainer.train") as span:
+            if span:
+                span.set_attribute("kubeflow.trainjob.name", "my-job")
+
+    def test_sdk_span_with_no_attributes(self, mock_otel):
+        """sdk_span() should work when called without attributes."""
+        mock_span = MagicMock()
+        mock_otel["tracer"].start_as_current_span.return_value.__enter__ = MagicMock(
+            return_value=mock_span
+        )
+        mock_otel["tracer"].start_as_current_span.return_value.__exit__ = MagicMock(
+            return_value=False
+        )
+
+        with telemetry.sdk_span("kubeflow.trainer.list_jobs") as span:
+            assert span is mock_span
+
+        mock_otel["tracer"].start_as_current_span.assert_called_once_with(
+            "kubeflow.trainer.list_jobs",
+            attributes=None,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ spark = [
   "kubeflow-spark-api>=2.4.0",
 ]
 hub = ["model-registry>=0.3.6"]
+telemetry = ["opentelemetry-api>=1.40.0"]
 
 [dependency-groups]
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -694,7 +694,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -981,6 +981,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1025,6 +1037,9 @@ spark = [
     { name = "kubeflow-spark-api" },
     { name = "pyspark-connect" },
 ]
+telemetry = [
+    { name = "opentelemetry-api" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1065,11 +1080,12 @@ requires-dist = [
     { name = "kubeflow-trainer-api", specifier = ">=2.2.0" },
     { name = "kubernetes", specifier = ">=27.2.0" },
     { name = "model-registry", marker = "extra == 'hub'", specifier = ">=0.3.6" },
+    { name = "opentelemetry-api", marker = "extra == 'telemetry'", specifier = ">=1.40.0" },
     { name = "podman", marker = "extra == 'podman'", specifier = ">=5.6.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pyspark-connect", marker = "extra == 'spark'", specifier = "==4.0.1" },
 ]
-provides-extras = ["docker", "hub", "podman", "spark"]
+provides-extras = ["docker", "hub", "podman", "spark", "telemetry"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1669,6 +1685,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
 ]
 
 [[package]]
@@ -3104,4 +3133,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
     { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
     { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]


### PR DESCRIPTION
ref #164 
## description

Adds `kubeflow/common/telemetry.py` -  the foundational module for integrating OpenTelemetry into the Kubeflow SDK, as tracked in #164.

## why

The SDK currently has no structured observability. For example what if `TrainerClient.train()` takes 45 minutes or `OptimizerClient.optimize()` stalls across 50 trials, we currently have no way to pinpoint whether the bottleneck is K8s API calls, CRD validation, polling, or pod scheduling. This module is the first step toward vendor-neutral, opt-in distributed tracing and metrics across all SDK clients.

## design decisions

- **API-only dependency**: Following [OTel library instrumentation best practices](https://opentelemetry.io/docs/languages/python/libraries/), we depend only on `opentelemetry-api`, not `opentelemetry-sdk` or any exporter. Users choose their own SDK and export backend.
- **Zero overhead when disabled**: When `opentelemetry-api` is not installed, `_setup()` catches `ImportError` once and all subsequent `sdk_span()` calls yield `None` with no cost. No import-time side effects.
- **Module-level functions, not a class**: OTel tracers and meters are process-global singletons — a wrapper class would add indirection with no benefit. This mirrors how `opentelemetry.trace.get_tracer()` itself works.
- **Follows existing optional dependency pattern**: Same approach as `ModelRegistryClient` with `model-registry` and `SparkClient` with `pyspark-connect`.

## usage

```python
from kubeflow.common.telemetry import sdk_span

def train(self, ...):
    with sdk_span("kubeflow.trainer.train", attributes={
        "kubeflow.namespace": self.namespace,
    }) as span:
        # ... existing logic ...
        if span:
            span.set_attribute("kubeflow.trainjob.name", name)
```

## next steps

This is the foundation for client-by-client instrumentation. Later I plan to instrument `TrainerClient` operations in `KubernetesBackend` using `sdk_span()`.