### PR TITLE
feat: add shared exception hierarchy for Kubeflow SDK

### DIFF
--- a/kubeflow/common/__init__.py
+++ b/kubeflow/common/__init__.py
@@ -1,0 +1,15 @@
+from .exceptions import (
+    KubeflowError,
+    NameResolutionError,
+    CompilationError,
+    RunFailedError,
+    KubeflowTimeoutError,
+)
+
+__all__ = [
+    "KubeflowError",
+    "NameResolutionError",
+    "CompilationError",
+    "RunFailedError",
+    "KubeflowTimeoutError",
+]

--- a/kubeflow/common/__init__.py
+++ b/kubeflow/common/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .exceptions import (
     KubeflowError,
     NameResolutionError,

--- a/kubeflow/common/exceptions.py
+++ b/kubeflow/common/exceptions.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 class KubeflowError(Exception):
     """Base class for all Kubeflow SDK errors."""
     pass
@@ -18,6 +32,6 @@ class RunFailedError(KubeflowError):
     pass
 
 
-class KubeflowTimeoutError(KubeflowError):
+class KubeflowTimeoutError(KubeflowError, TimeoutError):
     """Raised when a wait operation exceeds its timeout."""
     pass

--- a/kubeflow/common/exceptions.py
+++ b/kubeflow/common/exceptions.py
@@ -1,0 +1,23 @@
+class KubeflowError(Exception):
+    """Base class for all Kubeflow SDK errors."""
+    pass
+
+
+class NameResolutionError(KubeflowError):
+    """Raised when a resource cannot be found by name."""
+    pass
+
+
+class CompilationError(KubeflowError):
+    """Raised when pipeline or job compilation fails."""
+    pass
+
+
+class RunFailedError(KubeflowError):
+    """Raised when a run or job reaches a failed state."""
+    pass
+
+
+class KubeflowTimeoutError(KubeflowError):
+    """Raised when a wait operation exceeds its timeout."""
+    pass


### PR DESCRIPTION
Introduce a shared exception module (kubeflow.common.exceptions) with a base KubeflowError and a minimal set of specific exceptions.
This lays the foundation for consistent and precise error handling across SDK clients. Migration of existing clients will be done in follow-up PRs.

#458 