### PR TITLE
chore: Add missing doc strings for spark client functions

### DIFF
--- a/kubeflow/spark/api/spark_client.py
+++ b/kubeflow/spark/api/spark_client.py
@@ -127,17 +127,52 @@ class SparkClient:
         )
 
     def list_sessions(self) -> list[SparkConnectInfo]:
-        """List all SparkConnect sessions."""
+        """List all SparkConnect sessions.
+
+        Returns:
+            List of SparkConnectInfo objects for all sessions in the namespace.
+        """
         return self.backend.list_sessions()
 
     def get_session(self, name: str) -> SparkConnectInfo:
-        """Get session info by name."""
+        """Get information about a specific SparkConnect session.
+
+        Args:
+            name: The name of the SparkConnect session to retrieve.
+
+        Returns:
+            SparkConnectInfo object containing session details.
+
+        Raises:
+            RuntimeError: If the session cannot be retrieved or found.
+            TimeoutError: If the request to the Kubernetes API times out.
+        """
         return self.backend.get_session(name)
 
     def delete_session(self, name: str) -> None:
-        """Delete a SparkConnect session."""
+        """Delete a SparkConnect session.
+
+        Args:
+            name: The name of the SparkConnect session to delete.
+
+        Raises:
+            RuntimeError: If the session cannot be deleted or found.
+            TimeoutError: If the request to the Kubernetes API times out.
+        """
         self.backend.delete_session(name)
 
     def get_session_logs(self, name: str, follow: bool = False) -> Iterator[str]:
-        """Get logs from a session."""
+        """Get logs from a SparkConnect session's server pod.
+
+        Args:
+            name: The name of the SparkConnect session.
+            follow: Whether to continuously follow the log stream. Defaults to False.
+
+        Returns:
+            An iterator over the log lines from the session's pod.
+
+        Raises:
+            RuntimeError: If the session has no pod or logs cannot be retrieved.
+            TimeoutError: If the request to the Kubernetes API times out.
+        """
         return self.backend.get_session_logs(name, follow=follow)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR updates the `SparkClient` public API methods (`list_sessions`, `get_session`, `delete_session`, and `get_session_logs`) to include complete Google-style docstrings. 
Previously, these methods were missing detailed parameter, return, and exception documentations. These changes ensure the docstrings now comprehensively detail `Args`, `Returns`, and `Raises` sections, aligning with the codebase's documentation standards.

**Which issue(s) this PR fixes** 

Fixes #462 


**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
