### PR TITLE
fix : Safely parse fractional kubernetes cpu limits

### DIFF
--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -614,7 +614,7 @@ class KubernetesBackend(RuntimeBackend):
                     async_req=True,
                 )
                 logs = thread.get(common_constants.DEFAULT_TIMEOUT)
-                for line in logs.split("\n"):
+                for line in logs.splitlines():
                     yield line
         except multiprocessing.TimeoutError as e:
             raise TimeoutError(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

- Implemented `_cpu_kubernetes_to_spark` to correctly handle millicores (e.g. "500m") and decimal strings by parsing them to floats and rounding up to the nearest integer Spark core.
- Resolves crashes related to `ValueError: invalid literal for int()` during Spark Connect session creation.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
