### PR TITLE
fix: Safely parse fractional kubernetes cpu limits

### DIFF
--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -14,6 +14,7 @@
 
 """Utility functions for Kubernetes Spark backend."""
 
+import math
 import re
 from typing import Any
 from urllib.parse import urlparse
@@ -71,6 +72,21 @@ def _memory_kubernetes_to_spark(memory: str) -> str:
     return num + spark_suffix
 
 
+def _cpu_kubernetes_to_spark(cpu: str) -> int:
+    """Convert Kubernetes CPU request to integer Spark cores (rounded up).
+
+    Spark expects integer cores. Kubernetes allows fractional CPUs (e.g., "500m", "1.5").
+    """
+    if not cpu:
+        return 1
+    try:
+        if cpu.endswith("m"):
+            return math.ceil(float(cpu[:-1]) / 1000)
+        return math.ceil(float(cpu))
+    except ValueError:
+        return 1
+
+
 def build_service_url(info: SparkConnectInfo) -> str:
     """Build Spark Connect URL from session info.
 
@@ -102,7 +118,7 @@ def get_server_spec_from_driver(
     if driver:
         if driver.resources:
             if "cpu" in driver.resources:
-                cores = int(driver.resources["cpu"])
+                cores = _cpu_kubernetes_to_spark(driver.resources["cpu"])
             if "memory" in driver.resources:
                 memory = _memory_kubernetes_to_spark(driver.resources["memory"])
 
@@ -162,7 +178,7 @@ def get_executor_spec_from_executor(
 
     if resource_dict:
         if "cpu" in resource_dict:
-            cores = int(resource_dict["cpu"])
+            cores = _cpu_kubernetes_to_spark(resource_dict["cpu"])
         if "memory" in resource_dict:
             memory = _memory_kubernetes_to_spark(resource_dict["memory"])
 

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -19,6 +19,7 @@ import pytest
 
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.utils import (
+    _cpu_kubernetes_to_spark,
     _memory_kubernetes_to_spark,
     build_service_url,
     build_spark_connect_cr,
@@ -46,6 +47,27 @@ class TestMemoryKubernetesToSpark:
     )
     def test_conversion(self, k8s_memory: str, expected_spark: str) -> None:
         assert _memory_kubernetes_to_spark(k8s_memory) == expected_spark
+
+
+class TestCpuKubernetesToSpark:
+    """Tests for _cpu_kubernetes_to_spark."""
+
+    @pytest.mark.parametrize(
+        "k8s_cpu,expected_spark",
+        [
+            ("500m", 1),
+            ("1500m", 2),
+            ("1", 1),
+            ("1.5", 2),
+            ("2", 2),
+            ("0.1", 1),
+            ("", 1),
+            (None, 1),
+            ("invalid", 1),
+        ],
+    )
+    def test_conversion(self, k8s_cpu: str, expected_spark: int) -> None:
+        assert _cpu_kubernetes_to_spark(k8s_cpu) == expected_spark
 
 
 class TestGenerateSessionName:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

## Problem:
When defining custom driver or executor options in the Spark client, allocating CPU limits via `resources={"cpu": "500m"}` or using decimal values like `"1.5"` routinely crashes logic in `utils.py`. The backend was explicitly casting this configuration metric directly to an integer `int(resource_dict["cpu"])`, which triggers an immediate `ValueError` for fractional millicore definitions (e.g. `500m`).

## Fix:

Fix : #466 

Implemented a custom parser utility `_cpu_kubernetes_to_spark` that safely handles fractional limits. It parses decimal values and standard Kubernetes `"m"` suffixes into floats, and computes the mathematical ceiling (`math.ceil`) so that PySpark allocates the next highest whole number of JVM threads/cores successfully.


**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
