### PR TITLE
fix(trainer): changed ValueError to raise RuntimeError in localprocess and container in backends #433

### DIFF
--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -501,13 +501,13 @@ class ContainerBackend(RuntimeBackend):
             List of container dictionaries for this job
 
         Raises:
-            ValueError: If no containers found for the job
+            RuntimeError: If no containers found for the job
         """
         filters = {"label": [f"{self.label_prefix}/trainjob-name={name}"]}
         containers = self._adapter.list_containers(filters=filters)
 
         if not containers:
-            raise ValueError(f"No TrainJob with name {name}")
+            raise RuntimeError(f"No TrainJob with name {name}")
 
         return containers
 
@@ -669,19 +669,19 @@ class ContainerBackend(RuntimeBackend):
             TrainJob object
 
         Raises:
-            ValueError: If network metadata is missing or runtime not found
+            RuntimeError: If network metadata is missing or runtime not found
         """
         if not containers:
-            raise ValueError(f"No containers found for TrainJob {job_name}")
+            raise RuntimeError(f"No containers found for TrainJob {job_name}")
 
         # Get metadata from network
         network_id = containers[0]["labels"].get(f"{self.label_prefix}/network-id")
         if not network_id:
-            raise ValueError(f"TrainJob {job_name} is missing network metadata")
+            raise RuntimeError(f"TrainJob {job_name} is missing network metadata")
 
         network_info = self._adapter.get_network(network_id)
         if not network_info:
-            raise ValueError(f"TrainJob {job_name} network not found")
+            raise RuntimeError(f"TrainJob {job_name} network not found")
 
         network_labels = network_info.get("labels", {})
         runtime_name = network_labels.get(f"{self.label_prefix}/runtime-name")
@@ -690,10 +690,10 @@ class ContainerBackend(RuntimeBackend):
         try:
             job_runtime = self.get_runtime(runtime_name) if runtime_name else None
         except Exception as e:
-            raise ValueError(f"Runtime {runtime_name} not found for job {job_name}") from e
+            raise RuntimeError(f"Runtime {runtime_name} not found for job {job_name}") from e
 
         if not job_runtime:
-            raise ValueError(f"Runtime {runtime_name} not found for job {job_name}")
+            raise RuntimeError(f"Runtime {runtime_name} not found for job {job_name}")
 
         # Parse creation timestamp from first container
         created_str = containers[0].get("created", "")

--- a/kubeflow/trainer/backends/container/backend_test.py
+++ b/kubeflow/trainer/backends/container/backend_test.py
@@ -746,7 +746,7 @@ def test_list_jobs(container_backend, test_case):
             name="get nonexistent job",
             expected_status=FAILED,
             config={"job_name": "nonexistent-job"},
-            expected_error=ValueError,
+            expected_error=RuntimeError,
         ),
     ],
 )

--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -57,14 +57,14 @@ class LocalProcessBackend(RuntimeBackend):
             None,
         )
         if not runtime:
-            raise ValueError(f"Runtime '{name}' not found.")
+            raise RuntimeError(f"Runtime '{name}' not found.")
 
         return runtime
 
     def get_runtime_packages(self, runtime: types.Runtime):
         local_runtime = next((rt for rt in local_runtimes if rt.name == runtime.name), None)
         if not local_runtime:
-            raise ValueError(f"Runtime '{runtime.name}' not found.")
+            raise RuntimeError(f"Runtime '{runtime.name}' not found.")
 
         return local_runtime.trainer.packages
 
@@ -169,7 +169,7 @@ class LocalProcessBackend(RuntimeBackend):
     def get_job(self, name: str) -> types.TrainJob:
         _job = next((j for j in self.__local_jobs if j.name == name), None)
         if _job is None:
-            raise ValueError(f"No TrainJob with name {name}")
+            raise RuntimeError(f"No TrainJob with name {name}")
 
         # check and set the correct job status to match `TrainerClient` supported statuses
         status = self.__get_job_status(_job)
@@ -198,7 +198,7 @@ class LocalProcessBackend(RuntimeBackend):
     ) -> Iterator[str]:
         _job = [j for j in self.__local_jobs if j.name == name]
         if not _job:
-            raise ValueError(f"No TrainJob with name {name}")
+            raise RuntimeError(f"No TrainJob with name {name}")
 
         want_all_steps = step == constants.NODE + "-0"
 
@@ -234,7 +234,7 @@ class LocalProcessBackend(RuntimeBackend):
         _job = next((_job for _job in self.__local_jobs if _job.name == name), None)
 
         if _job is None:
-            raise ValueError(f"No TrainJob with name {name}")
+            raise RuntimeError(f"No TrainJob with name {name}")
 
         for _ in range(round(timeout / polling_interval)):
             # Get current job status
@@ -258,7 +258,7 @@ class LocalProcessBackend(RuntimeBackend):
         # find job first.
         _job = next((j for j in self.__local_jobs if j.name == name), None)
         if _job is None:
-            raise ValueError(f"No TrainJob with name {name}")
+            raise RuntimeError(f"No TrainJob with name {name}")
 
         # cancel all nested step jobs in target job
         _ = [step.job.cancel() for step in _job.steps]

--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -123,7 +123,7 @@ def test_list_runtimes(local_backend, test_case):
             name="get_nonexistent_runtime",
             expected_status=FAILED,
             config={"runtime_name": "nonexistent-runtime"},
-            expected_error=ValueError,
+            expected_error=RuntimeError,
         ),
     ],
 )
@@ -172,7 +172,7 @@ def test_get_runtime(local_backend, test_case):
                     ),
                 ),
             },
-            expected_error=ValueError,
+            expected_error=RuntimeError,
         ),
     ],
 )
@@ -373,7 +373,7 @@ def test_train(local_backend, mock_train_environment, test_case):
             name="get_nonexistent_job",
             expected_status=FAILED,
             config={"job_name": "nonexistent-job"},
-            expected_error=ValueError,
+            expected_error=RuntimeError,
         ),
     ],
 )
@@ -410,7 +410,7 @@ def test_list_jobs(local_backend, test_case):
             name="get_logs_nonexistent_job",
             expected_status=FAILED,
             config={"job_name": "nonexistent-job", "step": "train"},
-            expected_error=ValueError,
+            expected_error=RuntimeError,
         ),
     ],
 )
@@ -457,6 +457,12 @@ def test_get_job_logs(local_backend, test_case):
             config={"name": BASIC_TRAIN_JOB_NAME, "timeout": 10, "polling_interval": -1},
             expected_error=ValueError,
         ),
+        TestCase(
+            name="wait_for_nonexistent_job",
+            expected_status=FAILED,
+            config={"name": "nonexistent-job"},
+            expected_error=RuntimeError,
+        ),
     ],
 )
 def test_wait_for_job_status(local_backend, test_case):
@@ -473,7 +479,7 @@ def test_wait_for_job_status(local_backend, test_case):
             name="delete_nonexistent_job",
             expected_status=FAILED,
             config={"job_name": "nonexistent-job"},
-            expected_error=ValueError,
+            expected_error=RuntimeError,
         ),
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
- get_job, get_job_logs, wait_for_job_status, delete_job in LocalProcess 
  backend now raise RuntimeError for job-not-found
- _get_job_containers and __get_trainjob_from_containers in Container 
  backend now raise RuntimeError for job/network/runtime not found
- Keep ValueError for input validation (polling_interval > timeout)

Fixes #
#433 

