### PR TITLE
feat(trainer): add envFrom option for kubernetes backend

### DIFF
--- a/docs/source/train/options.rst
+++ b/docs/source/train/options.rst
@@ -21,6 +21,10 @@ Options Reference
    :members:
    :show-inheritance:
 
+.. autoclass:: kubeflow.trainer.options.TrainerEnvFrom
+   :members:
+   :show-inheritance:
+
 .. autoclass:: kubeflow.trainer.options.RuntimePatch
    :members:
    :show-inheritance:

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -794,6 +794,9 @@ class KubernetesBackend(RuntimeBackend):
                 trainer_cr.command = trainer_overrides["command"]
             if "args" in trainer_overrides:
                 trainer_cr.args = trainer_overrides["args"]
+            # trainer env overrides needs to be appended to the variables defined in trainer.env
+            if "env" in trainer_overrides:
+                trainer_cr.env = (trainer_cr.env or []) + trainer_overrides["env"]
 
         # Convert runtime patches dicts to native model objects.
         runtime_patch_models = None

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -46,6 +46,7 @@ from kubeflow.trainer.options import (
     PodTemplatePatch,
     ReplicatedJobPatch,
     RuntimePatch,
+    TrainerEnvFrom,
     TrainingRuntimeSpecPatch,
 )
 from kubeflow.trainer.test.common import (
@@ -1344,6 +1345,71 @@ def test_get_runtime_packages(kubernetes_backend, test_case):
                         ),
                     ),
                 ],
+            ),
+        ),
+        TestCase(
+            name="train with envFrom",
+            expected_status=SUCCESS,
+            config={
+                "options": [
+                    TrainerEnvFrom.secret("MY_SECRET", secret_name="mysecret", key="mysecretkey")
+                ],
+            },
+            expected_output=get_train_job(
+                runtime_name=TORCH_RUNTIME,
+                train_job_name=BASIC_TRAIN_JOB_NAME,
+                train_job_trainer=models.TrainerV1alpha1Trainer(
+                    env=[
+                        models.IoK8sApiCoreV1EnvVar(
+                            name="MY_SECRET",
+                            valueFrom=models.IoK8sApiCoreV1EnvVarSource(
+                                secretKeyRef=models.IoK8sApiCoreV1SecretKeySelector(
+                                    name="mysecret", key="mysecretkey"
+                                )
+                            ),
+                        )
+                    ]
+                ),
+            ),
+        ),
+        TestCase(
+            name="train with envFrom and trainer env",
+            expected_status=SUCCESS,
+            config={
+                "options": [
+                    TrainerEnvFrom.secret("MY_SECRET", secret_name="mysecret", key="mysecretkey")
+                ],
+                "trainer": types.CustomTrainer(
+                    func=lambda: print("Hello World"),
+                    func_args={"learning_rate": 0.001, "batch_size": 32},
+                    packages_to_install=["torch", "numpy"],
+                    pip_index_urls=constants.DEFAULT_PIP_INDEX_URLS,
+                    num_nodes=2,
+                    env={
+                        "TEST_ENV": "test_value",
+                        "ANOTHER_ENV": "another_value",
+                    },
+                ),
+            },
+            expected_output=get_train_job(
+                runtime_name=TORCH_RUNTIME,
+                train_job_name=BASIC_TRAIN_JOB_NAME,
+                train_job_trainer=get_custom_trainer(
+                    pip_index_urls=constants.DEFAULT_PIP_INDEX_URLS,
+                    packages_to_install=["torch", "numpy"],
+                    env=[
+                        models.IoK8sApiCoreV1EnvVar(name="TEST_ENV", value="test_value"),
+                        models.IoK8sApiCoreV1EnvVar(name="ANOTHER_ENV", value="another_value"),
+                        models.IoK8sApiCoreV1EnvVar(
+                            name="MY_SECRET",
+                            valueFrom=models.IoK8sApiCoreV1EnvVarSource(
+                                secretKeyRef=models.IoK8sApiCoreV1SecretKeySelector(
+                                    name="mysecret", key="mysecretkey"
+                                )
+                            ),
+                        ),
+                    ],
+                ),
             ),
         ),
     ],

--- a/kubeflow/trainer/options/__init__.py
+++ b/kubeflow/trainer/options/__init__.py
@@ -36,6 +36,7 @@ from kubeflow.trainer.options.kubernetes import (
     RuntimePatch,
     TrainerArgs,
     TrainerCommand,
+    TrainerEnvFrom,
     TrainingRuntimeSpecPatch,
 )
 
@@ -56,5 +57,6 @@ __all__ = [
     "RuntimePatch",
     "TrainerArgs",
     "TrainerCommand",
+    "TrainerEnvFrom",
     "TrainingRuntimeSpecPatch",
 ]

--- a/kubeflow/trainer/options/kubernetes.py
+++ b/kubeflow/trainer/options/kubernetes.py
@@ -478,7 +478,6 @@ class TrainerArgs:
         trainer_spec["args"] = self.args
 
 
-@dataclass
 class TrainerEnvFrom:
     """Used to add environment variables using kubernetes resources (secrets, configmaps, etc...)
     to the trainer container (.spec.trainer.env), these values will be merged with the TrainingRuntime's

--- a/kubeflow/trainer/options/kubernetes.py
+++ b/kubeflow/trainer/options/kubernetes.py
@@ -18,6 +18,8 @@ import dataclasses
 from dataclasses import dataclass
 from typing import Any
 
+from kubeflow_trainer_api import models
+
 from kubeflow.trainer.backends.base import RuntimeBackend
 from kubeflow.trainer.types.types import BuiltinTrainer, CustomTrainer, CustomTrainerContainer
 
@@ -474,3 +476,71 @@ class TrainerArgs:
         spec = job_spec.setdefault("spec", {})
         trainer_spec = spec.setdefault("trainer", {})
         trainer_spec["args"] = self.args
+
+
+@dataclass
+class TrainerEnvFrom:
+    """Used to add environment variables using kubernetes resources (secrets, configmaps, etc...)
+    to the trainer container (.spec.trainer.env), these values will be merged with the TrainingRuntime's
+    trainer environments as well as the clear values defined in trainer.env.
+
+    Can only be used with CustomTrainer and CustomTrainerContainer.
+
+    Supported backends:
+        - Kubernetes
+    """
+
+    _env_name: str
+    _value_from: models.IoK8sApiCoreV1EnvVarSource
+
+    def __init__(self, env_name: str, value_from: models.IoK8sApiCoreV1EnvVarSource) -> None:
+        if not env_name:
+            raise ValueError("env_name must be a non-empty string")
+        self._env_name = env_name
+        self._value_from = value_from
+
+    @classmethod
+    def secret(cls, env_name: str, *, secret_name: str, key: str) -> "TrainerEnvFrom":
+        """Create a TrainerEnvFrom sourced from a Kubernetes Secret."""
+        return cls(
+            env_name,
+            models.IoK8sApiCoreV1EnvVarSource(
+                secretKeyRef=models.IoK8sApiCoreV1SecretKeySelector(name=secret_name, key=key)
+            ),
+        )
+
+    @classmethod
+    def config_map(cls, env_name: str, *, config_map_name: str, key: str) -> "TrainerEnvFrom":
+        """Create a TrainerEnvFrom sourced from a Kubernetes ConfigMap."""
+        return cls(
+            env_name,
+            models.IoK8sApiCoreV1EnvVarSource(
+                configMapKeyRef=models.IoK8sApiCoreV1ConfigMapKeySelector(
+                    name=config_map_name, key=key
+                )
+            ),
+        )
+
+    def __call__(
+        self,
+        job_spec: dict[str, Any],
+        trainer: CustomTrainer | BuiltinTrainer | CustomTrainerContainer | None,
+        backend: RuntimeBackend,
+    ) -> None:
+        from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"TrainerEnvFrom option is not compatible with {type(backend).__name__}. "
+                "Supported backends: KubernetesBackend"
+            )
+        if trainer is not None and not isinstance(trainer, (CustomTrainer, CustomTrainerContainer)):
+            raise ValueError(
+                f"TrainerEnvFrom option is not compatible with {type(trainer).__name__}. "
+                "Supported trainers: CustomTrainer, CustomTrainerContainer"
+            )
+
+        spec = job_spec.setdefault("spec", {})
+        trainer_spec = spec.setdefault("trainer", {})
+        env = trainer_spec.setdefault("env", [])
+        env.append(models.IoK8sApiCoreV1EnvVar(name=self._env_name, valueFrom=self._value_from))

--- a/kubeflow/trainer/options/kubernetes_test.py
+++ b/kubeflow/trainer/options/kubernetes_test.py
@@ -14,6 +14,7 @@
 
 """Unit tests for Kubernetes options."""
 
+from kubeflow_trainer_api import models
 import pytest
 
 from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend
@@ -33,6 +34,7 @@ from kubeflow.trainer.options import (
     RuntimePatch,
     TrainerArgs,
     TrainerCommand,
+    TrainerEnvFrom,
     TrainingRuntimeSpecPatch,
 )
 
@@ -69,6 +71,17 @@ class TestKubernetesOptionBackendValidation:
             (Annotations, {"description": "test job"}),
             (TrainerCommand, ["python", "train.py"]),
             (TrainerArgs, ["--epochs", "10"]),
+            (
+                TrainerEnvFrom,
+                {
+                    "name": "MY_SECRET",
+                    "valueFrom": models.IoK8sApiCoreV1EnvVarSource(
+                        secretKeyRef=models.IoK8sApiCoreV1SecretKeySelector(
+                            name="mysecret", key="mysecretkey"
+                        )
+                    ),
+                },
+            ),
         ],
     )
     def test_kubernetes_options_reject_wrong_backend(
@@ -79,6 +92,8 @@ class TestKubernetesOptionBackendValidation:
             option = option_class(command=option_args)
         elif option_class == TrainerArgs:
             option = option_class(args=option_args)
+        elif option_class == TrainerEnvFrom:
+            option = option_class(env_name=option_args["name"], value_from=option_args["valueFrom"])
         else:
             option = option_class(option_args)
 
@@ -129,6 +144,33 @@ class TestKubernetesOptionApplication:
                 ["--epochs", "10"],
                 {"spec": {"trainer": {"args": ["--epochs", "10"]}}},
             ),
+            (
+                TrainerEnvFrom,
+                {
+                    "name": "MY_SECRET",
+                    "valueFrom": models.IoK8sApiCoreV1EnvVarSource(
+                        secretKeyRef=models.IoK8sApiCoreV1SecretKeySelector(
+                            name="mysecret", key="mysecretkey"
+                        )
+                    ),
+                },
+                {
+                    "spec": {
+                        "trainer": {
+                            "env": [
+                                models.IoK8sApiCoreV1EnvVar(
+                                    name="MY_SECRET",
+                                    valueFrom=models.IoK8sApiCoreV1EnvVarSource(
+                                        secretKeyRef=models.IoK8sApiCoreV1SecretKeySelector(
+                                            name="mysecret", key="mysecretkey"
+                                        )
+                                    ),
+                                )
+                            ]
+                        }
+                    }
+                },
+            ),
         ],
     )
     def test_option_application(
@@ -139,6 +181,8 @@ class TestKubernetesOptionApplication:
             option = option_class(command=option_args)
         elif option_class == TrainerArgs:
             option = option_class(args=option_args)
+        elif option_class == TrainerEnvFrom:
+            option = option_class(env_name=option_args["name"], value_from=option_args["valueFrom"])
         else:
             option = option_class(option_args)
 
@@ -159,9 +203,48 @@ class TestTrainerOptionValidation:
             (TrainerArgs, ["--epochs", "10"], "CustomTrainer", True),
             (TrainerCommand, ["python", "train.py"], "BuiltinTrainer", True),
             (TrainerArgs, ["--epochs", "10"], "BuiltinTrainer", True),
+            (
+                TrainerEnvFrom,
+                {
+                    "name": "MY_SECRET",
+                    "valueFrom": models.IoK8sApiCoreV1EnvVarSource(
+                        secretKeyRef=models.IoK8sApiCoreV1SecretKeySelector(
+                            name="mysecret", key="mysecretkey"
+                        )
+                    ),
+                },
+                "BuiltinTrainer",
+                True,
+            ),
             # Successful applications
             (TrainerCommand, ["python", "train.py"], "CustomTrainerContainer", False),
             (TrainerArgs, ["--epochs", "10"], "CustomTrainerContainer", False),
+            (
+                TrainerEnvFrom,
+                {
+                    "name": "MY_SECRET",
+                    "valueFrom": models.IoK8sApiCoreV1EnvVarSource(
+                        secretKeyRef=models.IoK8sApiCoreV1SecretKeySelector(
+                            name="mysecret", key="mysecretkey"
+                        )
+                    ),
+                },
+                "CustomTrainerContainer",
+                False,
+            ),
+            (
+                TrainerEnvFrom,
+                {
+                    "name": "MY_SECRET",
+                    "valueFrom": models.IoK8sApiCoreV1EnvVarSource(
+                        secretKeyRef=models.IoK8sApiCoreV1SecretKeySelector(
+                            name="mysecret", key="mysecretkey"
+                        )
+                    ),
+                },
+                "CustomTrainer",
+                False,
+            ),
         ],
     )
     def test_trainer_option_validation(
@@ -190,23 +273,35 @@ class TestTrainerOptionValidation:
         # Create option
         if option_class == TrainerCommand:
             option = option_class(command=option_args)
-        else:  # TrainerArgs
+        elif option_class == TrainerArgs:
             option = option_class(args=option_args)
+        else:  # TrainerEnvFrom
+            option = option_class(env_name=option_args["name"], value_from=option_args["valueFrom"])
 
         job_spec = {}
 
         if should_fail:
             with pytest.raises(ValueError) as exc_info:
                 option(job_spec, trainer, mock_kubernetes_backend)
-            assert "TrainerCommand can only be used with CustomTrainerContainer" in str(
-                exc_info.value
-            ) or "TrainerArgs can only be used with CustomTrainerContainer" in str(exc_info.value)
+            assert (
+                "TrainerCommand can only be used with CustomTrainerContainer" in str(exc_info.value)
+                or "TrainerArgs can only be used with CustomTrainerContainer" in str(exc_info.value)
+                or f"TrainerEnvFrom option is not compatible with {type(trainer).__name__}"
+                in str(exc_info.value)
+            )
         else:
             option(job_spec, trainer, mock_kubernetes_backend)
             if option_class == TrainerCommand:
                 assert job_spec["spec"]["trainer"]["command"] == option_args
-            else:
+            elif option_class == TrainerArgs:
                 assert job_spec["spec"]["trainer"]["args"] == option_args
+            else:
+                assert job_spec["spec"]["trainer"]["env"] == [
+                    models.IoK8sApiCoreV1EnvVar(
+                        name=option_args["name"],
+                        valueFrom=option_args["valueFrom"],
+                    )
+                ]
 
 
 class TestContainerPatch:


### PR DESCRIPTION
**What this PR does**:

This PR adds a TrainerEnfFrom option for the kubernetes backend that allows users to specify environment variables sourced from ConfigMaps or Secrets. The added variables will be concatenated with the ones added in trainer.env.

**Why we need it**

As discussed in the [slack thread](https://cloud-native.slack.com/archives/C0742LDFZ4K/p1776458696228949), we need this feature whenever we have to deal with secrets inside the `node` container.

One example could be using model_registry s3 upload to log the model after a train, you would need the access key id & secret key available as env var inside the training pod's `node` container.

**Opinionated changes**

Compared to the proposition in the [slack thread](https://cloud-native.slack.com/archives/C0742LDFZ4K/p1777066729285329?thread_ts=1776458696.228949&cid=C0742LDFZ4K), I did some opinionated changes:

1. I renamed TrainerEnv option class to TrainerEnvFrom as it is only dealing with valueFrom environment variables, classic value/name variables are set by the trainer.env property (therefore also renamed from_secret() -> secret() & from_config_map() -> config_map())
2. I decided to concat the values defined in trainer.env with the env defined by the options instead of just overriding it as I think both should coexist.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

No Issue was created as [we agreed that it was not needed](https://cloud-native.slack.com/archives/C0742LDFZ4K/p1777417189118369?thread_ts=1776458696.228949&cid=C0742LDFZ4K).

**Checklist:**

- [X] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing