### PR TITLE
feat(docs): add AI policy reference to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,13 @@
 This guide explains how to contribute to the Kubeflow SDK project.
 For the Kubeflow SDK documentation, please check [the official Kubeflow documentation](https://www.kubeflow.org/docs/components/).
 
+## AI Assistant Tooling
+
+The Kubeflow community allows the use of AI assistant tooling for contributions.
+Before using AI agents, please review the
+[Kubeflow AI Policy](https://www.kubeflow.org/docs/about/ai_policy/) to understand
+the guidelines and responsibilities for such contributions.
+
 ## Requirements
 - [Supported Python version](./pyproject.toml#L4)
 - [pre-commit](https://pre-commit.com/)


### PR DESCRIPTION
## Summary
- Adds an "AI Assistant Tooling" section to `CONTRIBUTING.md` directing contributors to review the [Kubeflow AI Policy](https://www.kubeflow.org/docs/about/ai_policy/) before using AI agents for contributions.
- Mirrors the same note added to kubeflow/trainer in https://github.com/kubeflow/trainer/pull/3493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)