### PR TITLE
feat(ci): Replace Trivy CVE scanning with uv audit + OSV-Scanner

### DIFF
--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -1,0 +1,235 @@
+name: OSV-Scanner Vulnerability Scan
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  osv-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install OSV-Scanner
+        # Bump cadence: check https://github.com/google/osv-scanner/releases monthly
+        # Dependabot cannot bump curl-installed binaries — update version + checksum manually
+        run: |
+          OSV_VERSION="2.3.8"
+          EXPECTED_SHA="bc98e15319ed0d515e3f9235287ba53cdc5535d576d24fd573978ecfe9ab92dc"
+          curl -fsSL "https://github.com/google/osv-scanner/releases/download/v${OSV_VERSION}/osv-scanner_linux_amd64" -o osv-scanner
+          ACTUAL_SHA=$(sha256sum osv-scanner | awk '{print $1}')
+          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+            echo "::error::OSV-Scanner checksum mismatch! Expected ${EXPECTED_SHA}, got ${ACTUAL_SHA}"
+            exit 1
+          fi
+          chmod +x osv-scanner
+          sudo mv osv-scanner /usr/local/bin/
+
+      - name: Run OSV-Scanner (SARIF for Security Tab)
+        # continue-on-error so a SARIF failure doesn't block the JSON scan + auto-fix below
+        continue-on-error: true
+        run: |
+          rc=0
+          osv-scanner scan \
+            --format sarif \
+            --output osv-results.sarif \
+            -L uv.lock || rc=$?
+          # Exit code 1 = vulns found (expected), 0 = clean. Any other code is a real failure.
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+            echo "::error::OSV-Scanner failed with unexpected exit code $rc"
+            exit 1
+          fi
+
+      - name: Upload SARIF to GitHub Security tab
+        if: always() && hashFiles('osv-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: osv-results.sarif
+          category: kubeflow-sdk-osv-scanner
+
+      - name: Run OSV-Scanner (JSON for auto-fix)
+        run: |
+          rc=0
+          osv-scanner scan \
+            --format json \
+            --output osv-results.json \
+            -L uv.lock || rc=$?
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+            echo "::error::OSV-Scanner failed with unexpected exit code $rc"
+            exit 1
+          fi
+          # Validate JSON output is parseable before downstream steps consume it
+          if [ -f osv-results.json ] && [ -s osv-results.json ]; then
+            jq empty osv-results.json
+          fi
+
+      - name: Process vulnerabilities and apply fixes
+        id: fixer
+        run: |
+          if [ ! -f osv-results.json ] || [ ! -s osv-results.json ]; then
+            echo "No scan results found."
+            echo "updates_found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          CURRENT_DATE=$(date +%Y-%m-%d)
+
+          # Extract fixable vulnerabilities: package name, current version, fix version, advisory ID, URL
+          # The OSV JSON embeds full advisory objects; fixed versions are in affected[].ranges[].events
+          # Use group_by + last to deduplicate: keep the highest fix version per package+advisory pair
+          FIX_DATA=$(jq -r '
+            [
+              .results[]?.packages[]? |
+              .package as $pkg |
+              .vulnerabilities[]? |
+              . as $vuln |
+              .affected[]? |
+              select(.package.name == $pkg.name) |
+              .ranges[]? |
+              .events[] |
+              select(.fixed != null) |
+              {
+                pkg: $pkg.name,
+                ver: $pkg.version,
+                fix: .fixed,
+                id: $vuln.id,
+                url: ($vuln.references[0].url // "https://osv.dev/vulnerability/\($vuln.id)")
+              }
+            ] |
+            group_by([.pkg, .id]) |
+            map(sort_by(.fix | split(".") | map(tonumber? // 0)) | last) |
+            .[] |
+            "\(.pkg)|\(.ver)|\(.fix)|\(.id)|\(.url)"
+          ' osv-results.json 2>/dev/null | sort -u)
+
+          if [ -z "$FIX_DATA" ]; then
+            echo "No fixable vulnerabilities found."
+            echo "updates_found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Fixable vulnerabilities found:"
+          echo "$FIX_DATA"
+          echo ""
+
+          rm -f applied_fixes.txt
+
+          while IFS='|' read -r pkg current_ver fix_ver advisory_id advisory_url; do
+            [ -z "$pkg" ] && continue
+
+            echo ""
+            echo "=== Processing: $pkg $current_ver -> $fix_ver ($advisory_id) ==="
+
+            # Try natural upgrade first
+            echo "Attempting: uv lock --upgrade-package $pkg"
+            LOCK_RC=0
+            uv lock --upgrade-package "$pkg" 2>&1 || LOCK_RC=$?
+            if [ "$LOCK_RC" -ne 0 ]; then
+              echo "Warning: uv lock failed for $pkg (exit code $LOCK_RC), skipping"
+              continue
+            fi
+
+            # Check resulting version
+            TREE_RC=0
+            TREE_OUTPUT=$(uv tree --package "$pkg" 2>&1) || TREE_RC=$?
+            if [ "$TREE_RC" -ne 0 ]; then
+              echo "Warning: uv tree failed for $pkg (exit code $TREE_RC), skipping"
+              continue
+            fi
+            EXTRACT_RC=0
+            NATURAL_VER=$(echo "$TREE_OUTPUT" | uv run python3 .github/scripts/extract_version.py "$pkg") || EXTRACT_RC=$?
+            if [ "$EXTRACT_RC" -ne 0 ]; then
+              echo "Warning: Could not parse version for $pkg from uv tree output, skipping"
+              continue
+            fi
+
+            if [ -z "$NATURAL_VER" ]; then
+              echo "Warning: Could not determine version for $pkg after upgrade"
+              continue
+            fi
+
+            echo "Natural upgrade resulted in version: $NATURAL_VER"
+
+            # Compare: does natural version meet the fix?
+            # compare_versions.py exits: 0 = upgrade needed, 1 = sufficient, 2 = parse error
+            CMP_EXIT=0
+            uv run python3 .github/scripts/compare_versions.py "$NATURAL_VER" "$fix_ver" || CMP_EXIT=$?
+
+            if [ "$CMP_EXIT" -eq 2 ]; then
+              echo "Warning: Could not parse versions for $pkg ($NATURAL_VER vs $fix_ver), skipping"
+              continue
+            elif [ "$CMP_EXIT" -eq 0 ]; then
+              # NATURAL_VER < fix_ver — natural upgrade insufficient, add override
+              echo "Natural upgrade insufficient ($NATURAL_VER < $fix_ver). Adding override..."
+              uv run python3 .github/scripts/update_overrides.py "$pkg" "${pkg}==${fix_ver}" "$CURRENT_DATE" "$advisory_url"
+              LOCK_RC=0
+              uv lock --upgrade-package "$pkg" 2>&1 || LOCK_RC=$?
+              if [ "$LOCK_RC" -ne 0 ]; then
+                echo "Warning: uv lock failed after adding override for $pkg (exit code $LOCK_RC), skipping"
+                continue
+              fi
+              printf '%s\n' "- ${pkg}==${fix_ver} (override) | [$advisory_id]($advisory_url)" >> applied_fixes.txt
+            else
+              # NATURAL_VER >= fix_ver — natural upgrade worked
+              echo "Natural upgrade sufficient ($NATURAL_VER >= $fix_ver)"
+              printf '%s\n' "- ${pkg}==${NATURAL_VER} (upgraded) | [$advisory_id]($advisory_url)" >> applied_fixes.txt
+            fi
+          done <<< "$FIX_DATA"
+
+          if [ ! -s applied_fixes.txt ]; then
+            echo "No fixes were applied."
+            echo "updates_found=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "updates_found=true" >> $GITHUB_OUTPUT
+          {
+            echo "fix_details<<EOF"
+            cat applied_fixes.txt
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.fixer.outputs.updates_found == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "fix: nightly automated dependency update for security vulnerabilities"
+          title: "fix: nightly security dependency updates"
+          add-paths: |
+            pyproject.toml
+            uv.lock
+          body: |
+            ## Security Update
+
+            This is an automated PR triggered by the nightly OSV-Scanner security scan.
+
+            The following dependencies were updated to resolve known vulnerabilities:
+
+            | Package & Version | Advisory Link |
+            | :--- | :--- |
+            ${{ steps.fixer.outputs.fix_details }}
+
+            **Verification:** Updated via `uv lock --upgrade-package` or `override-dependencies`.
+
+            > **Note:** This PR was created with `GITHUB_TOKEN`, which does not trigger `pull_request` workflows.
+            > CI checks will not run automatically. Push an empty commit (`git commit --allow-empty -m "trigger CI"`)
+            > to kick off CI before merging.
+            >
+            > **TODO:** Migrate to a GitHub App token via `actions/create-github-app-token` to trigger CI automatically.
+          branch: security-nightly-updates
+          delete-branch: true
+          labels: |
+            "area/security"

--- a/.github/workflows/validate-lockfile.yaml
+++ b/.github/workflows/validate-lockfile.yaml
@@ -1,0 +1,257 @@
+name: Validate Lockfile Security
+
+on:
+  pull_request:
+    paths:
+      - 'uv.lock'
+      - 'pyproject.toml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-security-regressions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          path: pr-code
+
+      - name: Checkout base branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.base_ref }}
+          path: base-code
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Verify lockfile is in sync with pyproject.toml
+        run: |
+          cd pr-code
+          echo "Checking if uv.lock is in sync with pyproject.toml..."
+          if ! uv lock --check; then
+            echo "::error title=Lockfile Out of Sync::uv.lock is out of sync with pyproject.toml. Please run 'uv lock' and commit the changes."
+            echo ""
+            echo "ERROR: uv.lock is out of sync with pyproject.toml"
+            echo "This means pyproject.toml was modified but 'uv lock' was not run."
+            echo ""
+            echo "To fix this:"
+            echo "  1. Run: uv lock"
+            echo "  2. Commit the updated uv.lock file"
+            echo "  3. Push your changes"
+            echo ""
+            exit 1
+          fi
+          echo "Lockfile is in sync"
+
+      - name: Audit PR branch lockfile
+        run: |
+          cd pr-code
+          # NOTE: uv audit is experimental (preview feature) and its text output format may
+          # change without notice. If the parsing in the compare step breaks after a uv upgrade,
+          # check the output format or consider switching to osv-scanner JSON output.
+          # Both tools query the same OSV.dev database, but filtering and version-range logic
+          # differ between uv audit (preview) and OSV-Scanner — results may not be identical.
+          rc=0
+          uv audit --preview-features > ../audit-pr.txt 2>&1 || rc=$?
+          cat ../audit-pr.txt
+          # Exit code 1 = vulns found (expected). Non-zero, non-1 = tool failure.
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+            echo "::error::uv audit failed on PR branch with exit code $rc"
+            exit 1
+          fi
+
+      - name: Audit base branch lockfile
+        run: |
+          cd base-code
+          rc=0
+          uv audit --preview-features > ../audit-base.txt 2>&1 || rc=$?
+          cat ../audit-base.txt
+          if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+            echo "::error::uv audit failed on base branch with exit code $rc"
+            exit 1
+          fi
+
+      - name: Compare scans and detect regressions
+        id: compare
+        run: |
+          echo "=== Comparing vulnerability scans ==="
+
+          # Extract advisory ID, package name, and version from uv audit text output
+          extract_vuln_details() {
+            local file="$1"
+            local current_pkg=""
+            local current_ver=""
+            while IFS= read -r line; do
+              # Match package header: "aiohttp 3.13.3 has N known vulnerabilities:"
+              if echo "$line" | grep -qP '^[a-zA-Z].*has \d+ known vulnerabilit'; then
+                current_pkg=$(echo "$line" | awk '{print $1}')
+                current_ver=$(echo "$line" | awk '{print $2}')
+              fi
+              # Match advisory line: "- GHSA-xxxx-xxxx-xxxx: ..." or "- PYSEC-xxxx-xxxx: ..." etc.
+              if echo "$line" | grep -qP '^\- [A-Z]+-'; then
+                local advisory_id=$(echo "$line" | grep -oP '(?<=^- )[A-Z]+-[a-zA-Z0-9-]+')
+                echo "${advisory_id}|${current_pkg}|${current_ver}"
+              fi
+            done < "$file"
+          }
+
+          BASE_VULNS=$(extract_vuln_details audit-base.txt | sort -u)
+          PR_VULNS=$(extract_vuln_details audit-pr.txt | sort -u)
+
+          # Count
+          if [ -z "$BASE_VULNS" ]; then BASE_COUNT=0; else BASE_COUNT=$(echo "$BASE_VULNS" | wc -l); fi
+          if [ -z "$PR_VULNS" ]; then PR_COUNT=0; else PR_COUNT=$(echo "$PR_VULNS" | wc -l); fi
+
+          echo "Base branch vulnerabilities: $BASE_COUNT"
+          echo "PR branch vulnerabilities: $PR_COUNT"
+
+          # Find NEW vulns (in PR but not in base) — compare by advisory_id|package
+          if [ -n "$PR_VULNS" ]; then
+            BASE_KEYS=$(echo "$BASE_VULNS" | cut -d'|' -f1,2 | sort -u)
+            NEW_VULNS=""
+            while IFS='|' read -r advisory_id pkg ver; do
+              KEY="${advisory_id}|${pkg}"
+              if ! echo "$BASE_KEYS" | grep -qxF "$KEY"; then
+                NEW_VULNS="${NEW_VULNS}${advisory_id}|${pkg}|${ver}\n"
+              fi
+            done <<< "$PR_VULNS"
+            NEW_VULNS=$(echo -e "$NEW_VULNS" | sed '/^$/d')
+          else
+            NEW_VULNS=""
+          fi
+
+          if [ -n "$NEW_VULNS" ]; then
+            echo ""
+            echo "NEW vulnerabilities detected:"
+            echo "$NEW_VULNS"
+            echo ""
+            echo "::warning title=Security Alert::This PR introduces new vulnerabilities. Review the bot comment below."
+            echo "new_cves_found=true" >> $GITHUB_OUTPUT
+
+            # Build markdown table
+            echo "new_cves<<EOF" >> $GITHUB_OUTPUT
+            echo "| Advisory ID | Package | Version |" >> $GITHUB_OUTPUT
+            echo "| :--- | :--- | :--- |" >> $GITHUB_OUTPUT
+
+            while IFS='|' read -r advisory_id pkg ver; do
+              [ -z "$advisory_id" ] && continue
+              # Look up advisory URL from the PR audit output, anchored to the advisory line
+              ADVISORY=$(grep -P "^- ${advisory_id}:" audit-pr.txt | grep -oP 'https://\S+' | head -1 || true)
+              if [ -n "$ADVISORY" ]; then
+                echo "| [$advisory_id]($ADVISORY) | $pkg | $ver |" >> $GITHUB_OUTPUT
+              else
+                echo "| $advisory_id | $pkg | $ver |" >> $GITHUB_OUTPUT
+              fi
+            done <<< "$NEW_VULNS"
+
+            echo "EOF" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "No new vulnerabilities introduced by this PR"
+            echo "new_cves_found=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Comment on PR with regression details
+        id: comment
+        continue-on-error: true
+        if: always() && steps.compare.outputs.new_cves_found == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const newCves = `${{ steps.compare.outputs.new_cves }}`;
+            const commentMarker = '<!-- lockfile-security-check -->';
+            const body = [
+              commentMarker,
+              '## Security Regression Detected',
+              '',
+              'This PR introduces new vulnerabilities that are not present in the base branch:',
+              '',
+              newCves,
+              '',
+              '### Why This Warning Appears',
+              `The lockfile changes in this PR would introduce vulnerabilities. The base branch (\`${{ github.base_ref }}\`) does not have these advisories.`,
+              '',
+              '> **Note:** This check is informational and does not block merging.',
+              '',
+              '### How to Fix',
+              '1. Run `uv lock --upgrade-package <package>` for each affected package',
+              '2. If the package is a transitive dependency, try upgrading its parent packages',
+              '3. If upgrades don\'t resolve it, consider:',
+              '   - Finding an alternative dependency without vulnerabilities',
+              '   - Consulting with the security team for risk assessment',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const existingComment = comments.find(comment =>
+              comment.body.includes(commentMarker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                comment_id: existingComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: body
+              });
+            }
+
+      - name: Fallback alert if PR comment failed
+        if: always() && steps.compare.outputs.new_cves_found == 'true' && steps.comment.outcome == 'failure'
+        run: |
+          echo "::warning::Failed to post security regression comment on PR. See details in step summary."
+          {
+            echo "## Security Regression Detected"
+            echo ""
+            echo "> The PR comment could not be posted (API failure). Review the regression details below."
+            echo ""
+            echo '${{ steps.compare.outputs.new_cves }}'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Delete security comment when resolved
+        continue-on-error: true
+        if: success() && steps.compare.outputs.new_cves_found == 'false'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const commentMarker = '<!-- lockfile-security-check -->';
+
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const existingComment = comments.find(comment =>
+              comment.body.includes(commentMarker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.deleteComment({
+                comment_id: existingComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              console.log('Security comment deleted - vulnerabilities resolved!');
+            }


### PR DESCRIPTION
## Summary

Replaces the Trivy-based CVE scanning workflows (removed in #427) with two new tools, as proposed in #478:

- **`validate-lockfile.yaml`**: Non-blocking PR check using `uv audit` that diffs vulnerabilities between PR and base branch. Posts an informational comment if new vulns are introduced — does not block merging.
- **`osv-scanner.yaml`**: Nightly scan using OSV-Scanner CLI (v2.3.8) with SARIF upload to the GitHub Security tab and auto-fix PRs. Integrates with existing `.github/scripts/` utilities (`update_overrides.py`, `compare_versions.py`, `extract_version.py`) and the `cleanup-overrides` workflow for the full fix lifecycle.
- **`osv-scanner.toml`**: Minimal config for suppressing false positives with expiry dates.

### Design decisions
- Both `uv audit` and OSV-Scanner query the same OSV.dev database — coverage is identical for Python/PyPI
- `uv audit` is used for the PR check because it's zero-dependency (bundled with `uv`), but it is experimental — a note in the workflow documents the fallback path (switch to OSV-Scanner JSON) if the text output format changes
- Both workflows are **non-blocking** — engineers can always merge PRs
- The nightly auto-fix flow tries `uv lock --upgrade-package` first, then falls back to `override-dependencies` via the existing `update_overrides.py` script when natural upgrades can't reach the fix version
- OSV-Scanner binary version is pinned (v2.3.8) — Dependabot won't auto-bump this, so manual updates are needed

Closes #478

## Test plan
- [ ] Verify `validate-lockfile.yaml` triggers on PRs that modify `uv.lock` or `pyproject.toml`
- [ ] Verify PR comment is posted when new vulns are introduced and deleted when resolved
- [ ] Trigger `osv-scanner.yaml` via `workflow_dispatch` and verify SARIF appears in Security tab
- [ ] Verify nightly auto-fix creates a PR when fixable vulns exist
- [ ] Confirm neither workflow blocks PR merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)