### PR TITLE
fix: migrate deprecated Pydantic v1 class Config with ConfigDict for pydantic v2 compatabilty

### DIFF
--- a/kubeflow/common/types.py
+++ b/kubeflow/common/types.py
@@ -14,7 +14,7 @@
 
 
 from kubernetes import client
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class KubernetesBackendConfig(BaseModel):
@@ -23,5 +23,4 @@ class KubernetesBackendConfig(BaseModel):
     context: str | None = None
     client_configuration: client.Configuration | None = None
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/kubeflow/trainer/backends/localprocess/types.py
+++ b/kubeflow/trainer/backends/localprocess/types.py
@@ -16,7 +16,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from kubeflow.trainer.backends.localprocess.job import LocalJob
 from kubeflow.trainer.types import types
@@ -35,8 +35,7 @@ class LocalBackendStep(BaseModel):
     step_name: str
     job: LocalJob
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class LocalBackendJobs(BaseModel):
@@ -46,5 +45,4 @@ class LocalBackendJobs(BaseModel):
     created: datetime | None = None
     completed: datetime | None = None
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)


### PR DESCRIPTION
### fix: replace deprecated Pydantic v1 `class Config` with `ConfigDict`

## Description

Replaces all instances of the deprecated Pydantic v1 `class Config` pattern with the Pydantic v2 equivalent `model_config = ConfigDict(...)`.

This resolves the `PydanticDeprecatedSince20` warnings that appear when using these models with Pydantic v2.

## Changes

| File | Class | Change |
|------|-------|--------|
| `kubeflow/common/types.py` | `KubernetesBackendConfig` | `class Config` → `model_config = ConfigDict(arbitrary_types_allowed=True)` |
| `kubeflow/trainer/backends/localprocess/types.py` | `LocalBackendStep` | Same |
| `kubeflow/trainer/backends/localprocess/types.py` | `LocalBackendJobs` | Same |

## Verification

- Ruff linting passes on all edited files
- Python syntax verified via `py_compile`
- Project requires `pydantic >= 2.10.0` so `ConfigDict` is available

