### PR TITLE
feat(trainer): add TPU utility to compute numNodes for multi-slice TPU

### DIFF
--- a/kubeflow/trainer/__init__.py
+++ b/kubeflow/trainer/__init__.py
@@ -22,7 +22,10 @@ from kubeflow.trainer.backends.container.types import (
     ContainerBackendConfig,
     TrainingRuntimeSource,
 )
-from kubeflow.trainer.backends.kubernetes.utils import update_trainjob_status
+from kubeflow.trainer.backends.kubernetes.utils import (
+    get_tpu_num_nodes,
+    update_trainjob_status,
+)
 from kubeflow.trainer.backends.localprocess.types import LocalProcessBackendConfig
 
 # Import the Kubeflow Trainer constants.
@@ -82,5 +85,6 @@ __all__ = [
     "ContainerBackendConfig",
     "KubernetesBackendConfig",
     "TrainingRuntimeSource",
+    "get_tpu_num_nodes",
     "update_trainjob_status",
 ]

--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -242,7 +242,13 @@ def get_resources_per_node(
 
     # Convert only standard resource keys and aliases to lowercase.
     # Extended resources (e.g., "example.com/Custom-NPU") preserve their original case.
-    standard_resources = {constants.CPU_LABEL, "memory", "gpu", "storage", "ephemeral-storage"}
+    standard_resources = {
+        constants.CPU_LABEL,
+        "memory",
+        "gpu",
+        "storage",
+        "ephemeral-storage",
+    }
     resource_aliases = {"gpu": "nvidia.com/gpu", "storage": "ephemeral-storage"}
 
     resources = {}
@@ -628,9 +634,11 @@ def get_optional_initializer_envs(
 
 
 def get_dataset_initializer(
-    dataset: types.HuggingFaceDatasetInitializer
-    | types.S3DatasetInitializer
-    | types.DataCacheInitializer,
+    dataset: (
+        types.HuggingFaceDatasetInitializer
+        | types.S3DatasetInitializer
+        | types.DataCacheInitializer
+    ),
 ) -> models.TrainerV1alpha1DatasetInitializer:
     """
     Get the TrainJob dataset initializer from the given config.
@@ -835,3 +843,69 @@ def update_trainjob_status(
     except Exception as e:
         _logger.warning("Unexpected error in update_trainjob_status: %s", e)
         return False
+
+
+def get_tpu_num_nodes(num_slices: int, topology: str, chips_per_host: int = 4) -> int:
+    """
+    Compute the total number of nodes (hosts) required across all TPU slices.
+
+    This utility function assists in configuring multi-slice TPU TrainJobs where the
+    user wants to scale their training job across multiple physical TPU slices. It calculates
+    the aggregate `num_nodes` based on the slice count and physical TPU topology dimensions.
+
+    Args:
+        num_slices: The number of TPU slices.
+        topology: The TPU topology string (e.g., "2x2", "2x4", "2x2x2", "2x2x4", "4x4").
+        chips_per_host: The number of TPU chips per VM host node. Defaults to 4.
+            Note that this depends on the VM type: e.g., ct6e-standard-4t has 4 chips per host,
+            and ct6e-standard-8t has 8 chips per host.
+
+    Returns:
+        The total number of nodes (hosts) across all slices.
+
+    Raises:
+        ValueError: If topology is empty, improperly formatted, or if the total chips
+                    in a slice is not evenly divisible by the chips_per_host.
+    """
+    if num_slices <= 0:
+        raise ValueError(f"num_slices must be positive, got: {num_slices}")
+
+    if chips_per_host <= 0:
+        raise ValueError(f"chips_per_host must be positive, got: {chips_per_host}")
+
+    if not topology:
+        raise ValueError("TPU topology must be specified.")
+
+    # Parse the topology dimensions (e.g. "2x2" or "2x2x2")
+    try:
+        dims = [int(d) for d in topology.lower().split("x")]
+    except ValueError:
+        raise ValueError(
+            f"Invalid topology format: '{topology}'. Must be formatted as 'AxB' or 'AxBxC' (e.g. '2x2', '2x2x2')."
+        ) from None
+
+    if len(dims) not in (2, 3):
+        raise ValueError(
+            f"Invalid topology format: '{topology}'. Must contain exactly 2 or 3 dimensions (e.g. '2x2', '2x2x2')."
+        )
+
+    if any(dim <= 0 for dim in dims):
+        raise ValueError(f"TPU topology dimensions must be positive, got: '{topology}'.")
+
+    # Calculate total TPU chips in a single slice
+    chips_per_slice = 1
+    for dim in dims:
+        chips_per_slice *= dim
+
+    # Validate and compute hosts per slice
+    if chips_per_slice < chips_per_host:
+        hosts_per_slice = 1
+    else:
+        # Multi-host slice (or full single-host slice) must be cleanly divisible
+        if chips_per_slice % chips_per_host != 0:
+            raise ValueError(
+                f"Total TPU chips in slice ({chips_per_slice}) must be cleanly divisible by chips_per_host ({chips_per_host})."
+            )
+        hosts_per_slice = chips_per_slice // chips_per_host
+
+    return num_slices * hosts_per_slice

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -340,7 +340,11 @@ def test_get_resources_per_node(test_case: TestCase):
         TestCase(
             name="packages with extras notation",
             config={
-                "packages_to_install": ["datasets", "transformers[torch]", "cloudpathlib[all]"],
+                "packages_to_install": [
+                    "datasets",
+                    "transformers[torch]",
+                    "cloudpathlib[all]",
+                ],
                 "pip_index_urls": constants.DEFAULT_PIP_INDEX_URLS,
                 "is_mpi": False,
             },
@@ -1230,13 +1234,23 @@ def _make_ca_file() -> str:
             name="ETA in seconds",
             expected_status=SUCCESS,
             config={"progress_percent": 50, "estimated_remaining_seconds": 3600},
-            expected_output={"result": True, "post_called": True, "progress": 50, "eta": 3600},
+            expected_output={
+                "result": True,
+                "post_called": True,
+                "progress": 50,
+                "eta": 3600,
+            },
         ),
         TestCase(
             name="negative ETA clamped to 0",
             expected_status=SUCCESS,
             config={"progress_percent": 50, "estimated_remaining_seconds": -30},
-            expected_output={"result": True, "post_called": True, "progress": 50, "eta": 0},
+            expected_output={
+                "result": True,
+                "post_called": True,
+                "progress": 50,
+                "eta": 0,
+            },
         ),
         TestCase(
             name="metrics included with correct count",
@@ -1311,7 +1325,11 @@ def _make_ca_file() -> str:
             name="CA cert used for TLS verification",
             expected_status=SUCCESS,
             config={"progress_percent": 50, "use_ca_cert": True},
-            expected_output={"result": True, "post_called": True, "verify_is_ca_path": True},
+            expected_output={
+                "result": True,
+                "post_called": True,
+                "verify_is_ca_path": True,
+            },
         ),
         TestCase(
             name="returns false on non-200 response",
@@ -1322,7 +1340,10 @@ def _make_ca_file() -> str:
         TestCase(
             name="returns false on network exception",
             expected_status=SUCCESS,
-            config={"progress_percent": 50, "mock_exception": ConnectionError("timeout")},
+            config={
+                "progress_percent": 50,
+                "mock_exception": ConnectionError("timeout"),
+            },
             expected_output={"result": False, "post_called": True},
         ),
         TestCase(
@@ -1490,4 +1511,186 @@ def test_update_trainjob_status(test_case: TestCase):
         os.unlink(token_path)
         if ca_path:
             os.unlink(ca_path)
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="tpu v5e single-slice 2x2",
+            expected_status=SUCCESS,
+            config={"num_slices": 1, "topology": "2x2"},
+            expected_output=1,
+        ),
+        TestCase(
+            name="tpu v5e single-slice 2x4",
+            expected_status=SUCCESS,
+            config={"num_slices": 1, "topology": "2x4"},
+            expected_output=2,
+        ),
+        TestCase(
+            name="tpu v5e single-slice 4x4",
+            expected_status=SUCCESS,
+            config={"num_slices": 1, "topology": "4x4"},
+            expected_output=4,
+        ),
+        TestCase(
+            name="tpu v5e multi-slice 2x2",
+            expected_status=SUCCESS,
+            config={"num_slices": 2, "topology": "2x2"},
+            expected_output=2,
+        ),
+        TestCase(
+            name="tpu v5e multi-slice 2x4",
+            expected_status=SUCCESS,
+            config={"num_slices": 4, "topology": "2x4"},
+            expected_output=8,
+        ),
+        TestCase(
+            name="tpu v5e multi-slice 4x4",
+            expected_status=SUCCESS,
+            config={"num_slices": 2, "topology": "4x4"},
+            expected_output=8,
+        ),
+        TestCase(
+            name="tpu v4/v5p 3D single-slice 2x2x2",
+            expected_status=SUCCESS,
+            config={"num_slices": 1, "topology": "2x2x2"},
+            expected_output=2,
+        ),
+        TestCase(
+            name="tpu v4/v5p 3D multi-slice 2x2x2",
+            expected_status=SUCCESS,
+            config={"num_slices": 3, "topology": "2x2x2"},
+            expected_output=6,
+        ),
+        TestCase(
+            name="tpu v4/v5p 3D single-slice 2x2x4",
+            expected_status=SUCCESS,
+            config={"num_slices": 1, "topology": "2x2x4"},
+            expected_output=4,
+        ),
+        TestCase(
+            name="tpu v4/v5p 3D multi-slice 2x2x4",
+            expected_status=SUCCESS,
+            config={"num_slices": 2, "topology": "2x2x4"},
+            expected_output=8,
+        ),
+        TestCase(
+            name="case insensitivity 2D",
+            expected_status=SUCCESS,
+            config={"num_slices": 2, "topology": "2X4"},
+            expected_output=4,
+        ),
+        TestCase(
+            name="case insensitivity 3D",
+            expected_status=SUCCESS,
+            config={"num_slices": 1, "topology": "2X2X2"},
+            expected_output=2,
+        ),
+        TestCase(
+            name="custom chips per host override",
+            expected_status=SUCCESS,
+            config={"num_slices": 2, "topology": "4x4", "chips_per_host": 8},
+            expected_output=4,
+        ),
+        TestCase(
+            name="fractional TPU single-slice 1x1 on 4-chip host",
+            expected_status=SUCCESS,
+            config={"num_slices": 1, "topology": "1x1", "chips_per_host": 4},
+            expected_output=1,
+        ),
+        TestCase(
+            name="fractional TPU multi-slice 2x2 on 8-chip host",
+            expected_status=SUCCESS,
+            config={"num_slices": 2, "topology": "2x2", "chips_per_host": 8},
+            expected_output=2,
+        ),
+        TestCase(
+            name="empty topology raises ValueError",
+            expected_status=FAILED,
+            config={"num_slices": 1, "topology": ""},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid topology format raises ValueError",
+            expected_status=FAILED,
+            config={"num_slices": 1, "topology": "invalid-topo"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="incomplete topology format raises ValueError",
+            expected_status=FAILED,
+            config={"num_slices": 1, "topology": "2x"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="indivisible topology layout raises ValueError",
+            expected_status=FAILED,
+            config={"num_slices": 1, "topology": "2x3"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="negative slices raises ValueError",
+            expected_status=FAILED,
+            config={"num_slices": -1, "topology": "2x2"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="zero slices raises ValueError",
+            expected_status=FAILED,
+            config={"num_slices": 0, "topology": "2x2"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="negative chips per host raises ValueError",
+            expected_status=FAILED,
+            config={"num_slices": 1, "topology": "2x2", "chips_per_host": -4},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="zero chips per host raises ValueError",
+            expected_status=FAILED,
+            config={"num_slices": 1, "topology": "2x2", "chips_per_host": 0},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="4D topology dimensions raises ValueError",
+            expected_status=FAILED,
+            config={"num_slices": 1, "topology": "2x2x2x2"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="zero topology dimensions raises ValueError",
+            expected_status=FAILED,
+            config={"num_slices": 1, "topology": "2x0x2"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="negative topology dimensions raises ValueError",
+            expected_status=FAILED,
+            config={"num_slices": 1, "topology": "2x-2"},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_get_tpu_num_nodes(test_case: TestCase):
+    print("Executing test:", test_case.name)
+    try:
+        kwargs = {
+            "num_slices": test_case.config["num_slices"],
+            "topology": test_case.config["topology"],
+        }
+        if "chips_per_host" in test_case.config:
+            kwargs["chips_per_host"] = test_case.config["chips_per_host"]
+
+        num_nodes = utils.get_tpu_num_nodes(**kwargs)
+
+        assert test_case.expected_status == SUCCESS
+        assert num_nodes == test_case.expected_output
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert isinstance(e, test_case.expected_error)
     print("test execution complete")

--- a/kubeflow/trainer/options/kubernetes.py
+++ b/kubeflow/trainer/options/kubernetes.py
@@ -164,6 +164,9 @@ class ReplicatedJobPatch:
         template: Job template patches.
     """
 
+    # TODO: Once upstream Kubeflow Training Operator RuntimePatches support setting
+    # Replicas for ReplicatedJobs, extend this dataclass with a `replicas` field
+    # and add a corresponding `NumReplicas` option to easily configure TrainJobs.
     name: str
     template: JobTemplatePatch | None = None
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce the `get_tpu_num_nodes` utility function in the Trainer backend to calculate VM host/node requirements for multi-slice TPU TrainJobs based on the user-specified slice count and physical TPU topology.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Issue #https://github.com/kubeflow/trainer/issues/3407

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
