### PR TITLE
fix(deps): exclude kubernetes 36.0.0 to avoid multiple client regressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "kubernetes>=27.2.0",
+  "kubernetes>=27.2.0,!=36.0.0",  # 36.0.0 has multiple regressions; see kubernetes-client/python#2592, #2596
   "pydantic>=2.10.0",
   "kubeflow-trainer-api>=2.2.0",
   "kubeflow-katib-api>=0.19.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -694,7 +694,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1063,7 +1063,7 @@ requires-dist = [
     { name = "kubeflow-katib-api", specifier = ">=0.19.0" },
     { name = "kubeflow-spark-api", marker = "extra == 'spark'", specifier = ">=2.4.0" },
     { name = "kubeflow-trainer-api", specifier = ">=2.2.0" },
-    { name = "kubernetes", specifier = ">=27.2.0" },
+    { name = "kubernetes", specifier = ">=27.2.0,!=36.0.0" },
     { name = "model-registry", marker = "extra == 'hub'", specifier = ">=0.3.6" },
     { name = "podman", marker = "extra == 'podman'", specifier = ">=5.6.0" },
     { name = "pydantic", specifier = ">=2.10.0" },


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubernetes==36.0.0` introduced several independent regressions that break CI for projects depending on the SDK. This PR constrains the dependency to `kubernetes>=27.2.0,!=36.0.0`.

Two distinct v36.0.0 regressions are confirmed:

1. **In-cluster authentication.** v36 stores the in-cluster ServiceAccount bearer token under the wrong `Configuration` key, so `load_incluster_config()` produces a client that sends requests with no `Authorization` header. The [Spark example E2E tests](https://github.com/kubeflow/sdk/pull/160#issuecomment-4539567060) fail on `SparkConnect` creation with `HTTP 403 Forbidden: User "system:anonymous" cannot create resource "sparkconnects" ... namespace "spark-test"`. Tracked upstream in kubernetes-client/python#2592.

2. **`read_namespaced_pod_log`.** v36 changed this method's signature/return handling. Streaming logs via `Watch.stream(read_namespaced_pod_log, ...)` now raises `ApiTypeError: Got an unexpected keyword argument 'watch'`. This breaks Kubeflow Trainer's [notebook E2E](https://github.com/kubeflow/trainer/pull/3359#issuecomment-4527185324), which installs the SDK from git. Tracked upstream in kubernetes-client/python#2596.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
