### PR TITLE
fix(ci): fix --preview-features flag usage in uv audit

### DIFF
--- a/.github/workflows/validate-lockfile.yaml
+++ b/.github/workflows/validate-lockfile.yaml
@@ -56,13 +56,15 @@ jobs:
       - name: Audit PR branch lockfile
         run: |
           cd pr-code
-          # NOTE: uv audit is experimental (preview feature) and its text output format may
-          # change without notice. If the parsing in the compare step breaks after a uv upgrade,
-          # check the output format or consider switching to osv-scanner JSON output.
+          # NOTE: uv audit text output format may change without notice. If the parsing
+          # in the compare step breaks after a uv upgrade, check the output format or
+          # consider switching to osv-scanner JSON output.
           # Both tools query the same OSV.dev database, but filtering and version-range logic
-          # differ between uv audit (preview) and OSV-Scanner — results may not be identical.
+          # differ between uv audit and OSV-Scanner — results may not be identical.
+          # --preview-features requires naming the feature to opt into ("audit")
+          # to suppress the experimental warning.
           rc=0
-          uv audit --preview-features > ../audit-pr.txt 2>&1 || rc=$?
+          uv audit --preview-features audit > ../audit-pr.txt 2>&1 || rc=$?
           cat ../audit-pr.txt
           # Exit code 1 = vulns found (expected). Non-zero, non-1 = tool failure.
           if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
@@ -74,7 +76,7 @@ jobs:
         run: |
           cd base-code
           rc=0
-          uv audit --preview-features > ../audit-base.txt 2>&1 || rc=$?
+          uv audit --preview-features audit > ../audit-base.txt 2>&1 || rc=$?
           cat ../audit-base.txt
           if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
             echo "::error::uv audit failed on base branch with exit code $rc"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

  The `validate-lockfile.yaml` workflow fails on every run with exit code 2 because
  `uv audit` is invoked with `--preview-features` as a bare flag. The flag requires
  a value naming the feature to opt into: `--preview-features audit`.

  ## Changes

  - Fixed both `uv audit` invocations to use `--preview-features audit`
  - Added comment explaining why `audit` is needed after `--preview-features`

  ## How to verify

  The workflow should now pass on PRs that modify `uv.lock` or `pyproject.toml`.


**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
