### PR TITLE
fix(deps): pin below kubernetes 36.0.0 (multiple client regressions)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "kubernetes>=27.2.0,!=36.0.0",  # 36.0.0 has multiple regressions; see kubernetes-client/python#2592, #2596
+  "kubernetes>=27.2.0,<36.0.0",  # 36.0.0 has multiple regressions; see kubernetes-client/python#2592, #2596
   "pydantic>=2.10.0",
   "kubeflow-trainer-api>=2.2.0",
   "kubeflow-katib-api>=0.19.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1063,7 +1063,7 @@ requires-dist = [
     { name = "kubeflow-katib-api", specifier = ">=0.19.0" },
     { name = "kubeflow-spark-api", marker = "extra == 'spark'", specifier = ">=2.4.0" },
     { name = "kubeflow-trainer-api", specifier = ">=2.2.0" },
-    { name = "kubernetes", specifier = ">=27.2.0,!=36.0.0" },
+    { name = "kubernetes", specifier = ">=27.2.0,<36.0.0" },
     { name = "model-registry", marker = "extra == 'hub'", specifier = ">=0.3.6" },
     { name = "podman", marker = "extra == 'podman'", specifier = ">=5.6.0" },
     { name = "pydantic", specifier = ">=2.10.0" },


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a followup to https://github.com/kubeflow/sdk/pull/507 to pin kubernetes python client to `<36.0.0`.

There has been a recent `36.0.1` release which has been breaking the tests again because it does not address the error with `read_namespaced_pod_log`.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
