### PR TITLE
fix(spark): use .svc short form for Spark Connect URL

### DIFF
--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -690,7 +690,7 @@ def test_get_session_logs(kubernetes_backend, test_case):
             name="in-cluster returns svc URL and no process",
             expected_status=SUCCESS,
             config={"in_cluster": True},
-            expected_output={"url_contains": "svc.cluster.local", "proc_is_none": True},
+            expected_output={"url_contains": ".svc:", "proc_is_none": True},
         ),
         TestCase(
             name="out-of-cluster starts port-forward and returns localhost URL",

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -411,12 +411,15 @@ def build_service_url(info: SparkConnectInfo) -> str:
     for readiness (wait_for_ready), by which point the operator has populated
     this field in the same atomic status write that set the Ready state.
 
+    The ".svc" short form is resolved through the pod's DNS search path, so it
+    works unchanged on clusters that use a cluster domain other than the default
+    "cluster.local".
+
     Args:
         info: SparkConnectInfo with service details.
 
     Returns:
-        Spark Connect URL
-        (e.g., "sc://my-session-server.default.svc.cluster.local:15002").
+        Spark Connect URL (e.g., "sc://my-session-server.default.svc:15002").
 
     Raises:
         RuntimeError: If ``info.service_name`` is not populated. An empty value
@@ -429,10 +432,7 @@ def build_service_url(info: SparkConnectInfo) -> str:
             "status.server.serviceName is not populated yet. The session is not "
             "ready to accept in-cluster connections."
         )
-    return (
-        f"sc://{info.service_name}.{info.namespace}.svc.cluster.local"
-        f":{constants.SPARK_CONNECT_PORT}"
-    )
+    return f"sc://{info.service_name}.{info.namespace}.svc:{constants.SPARK_CONNECT_PORT}"
 
 
 def get_spark_connect_driver_spec(

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -441,7 +441,7 @@ def test_validate_spark_connect_url(test_case: TestCase) -> None:
                     service_name="my-session-server",
                 ),
             },
-            expected_output="sc://my-session-server.spark.svc.cluster.local:15002",
+            expected_output="sc://my-session-server.spark.svc:15002",
         ),
         TestCase(
             name="build service url from custom service name",
@@ -454,7 +454,7 @@ def test_validate_spark_connect_url(test_case: TestCase) -> None:
                     service_name="custom-endpoint",
                 ),
             },
-            expected_output="sc://custom-endpoint.spark.svc.cluster.local:15002",
+            expected_output="sc://custom-endpoint.spark.svc:15002",
         ),
         TestCase(
             name="build service url without service name raises",

--- a/test/e2e/spark/run_in_cluster.py
+++ b/test/e2e/spark/run_in_cluster.py
@@ -29,7 +29,7 @@ def run_example_in_cluster(
     """Run an example script in-cluster via a Kubernetes Job.
 
     The Job pod has KUBERNETES_SERVICE_HOST set, so SparkClient uses the
-    in-cluster URL (sc://...svc.cluster.local) and no port-forward.
+    in-cluster URL (sc://...svc) and no port-forward.
 
     Args:
         example_script_name: Script filename (e.g. spark_connect_simple.py).

--- a/test/e2e/spark/test_spark_examples.py
+++ b/test/e2e/spark/test_spark_examples.py
@@ -36,7 +36,7 @@ EXAMPLES_DIR = Path(__file__).parent.parent.parent.parent / "examples" / "spark"
 EXAMPLE_TIMEOUT_SEC = 600
 WATCHER_INTERVAL_SEC = 5.0
 
-# In-cluster: run example as K8s Job so client uses sc://...svc.cluster.local (no port-forward).
+# In-cluster: run example as K8s Job so client uses sc://...svc (no port-forward).
 USE_IN_CLUSTER = os.environ.get("SPARK_E2E_RUN_IN_CLUSTER") == "1"
 RUNNER_IMAGE = os.environ.get("SPARK_E2E_RUNNER_IMAGE", "")
 


### PR DESCRIPTION
`build_service_url()` in `kubeflow/spark/backends/kubernetes/utils.py` emits Spark Connect URLs used inside the cluster with the FQDN suffix `.svc.cluster.local`, producing URLs like `sc://my-session-server.spark.svc.cluster.local:15002`. The cluster DNS short form `.svc` resolves to the same Service in any standard cluster and matches the format used in KEP-107 examples (`sc://spark-cluster.spark-system.svc:15002`). This switches the format to `sc://{service}.{namespace}.svc:{port}` and aligns the unit and backend tests. Two e2e docstrings (`test/e2e/spark/run_in_cluster.py`, `test/e2e/spark/test_spark_examples.py`) that referenced the old hostname are also refreshed.

`<service>.<namespace>.svc` sits below the default `ndots:5` threshold, so it is resolved through the pod's DNS search list rather than as an absolute name. That makes it correct on clusters installed with a cluster domain other than `cluster.local`, where the previous hardcoded suffix does not resolve.

Rebased on main. All 283 spark tests and 688 tests in the full python suite pass. `ruff check` and `ruff format` are clean on the changed files.

Fixes #490