### PR TITLE
feat(hub): add upload-artifact utility

### DIFF
--- a/kubeflow/hub/__init__.py
+++ b/kubeflow/hub/__init__.py
@@ -13,6 +13,13 @@
 # limitations under the License.
 
 from kubeflow.hub.api.model_registry_client import ModelRegistryClient
-from kubeflow.hub.types.types import StorageConfig
+from kubeflow.hub.storage import upload_artifact
+from kubeflow.hub.types.types import OCIUploadParams, S3UploadParams, StorageConfig
 
-__all__ = ["ModelRegistryClient", "StorageConfig"]
+__all__ = [
+    "ModelRegistryClient",
+    "StorageConfig",
+    "S3UploadParams",
+    "OCIUploadParams",
+    "upload_artifact",
+]

--- a/kubeflow/hub/storage.py
+++ b/kubeflow/hub/storage.py
@@ -1,0 +1,137 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Standalone storage utilities for uploading model artifacts."""
+
+from __future__ import annotations
+
+from kubeflow.hub.types.types import OCIUploadParams, S3UploadParams
+
+
+def upload_artifact(
+    model_files_path: str,
+    *,
+    upload_params: S3UploadParams | OCIUploadParams,
+) -> str:
+    """Upload a model artifact to object storage and return its URI.
+
+    This is a decoupled upload utility - it does not register anything in a
+    model registry. The returned URI can be passed to any registry client's
+    ``register_model`` call.
+
+    Args:
+        model_files_path: Local path to the model file or directory to upload.
+            Directories are uploaded recursively.
+
+    Keyword Args:
+        upload_params: An :class:`S3UploadParams` or :class:`OCIUploadParams`
+            instance describing the target storage location and credentials.
+
+    Returns:
+        The URI of the uploaded artifact, e.g.
+        ``"s3://my-bucket/fraud-detector/v1"`` or
+        ``"oci://ghcr.io/my-org/models/fraud-detector:v1"``.
+
+    Raises:
+        ImportError: If the required storage backend library is not installed.
+            Install the hub extra with ``pip install 'kubeflow[hub]'``.
+        TypeError: If ``upload_params`` is not a recognised params type.
+
+    Example::
+
+        from kubeflow.hub import upload_artifact, S3UploadParams, ModelRegistryClient
+
+        uri = upload_artifact(
+            "/path/to/model",
+            upload_params=S3UploadParams(
+                bucket_name="ml-models",
+                s3_prefix="fraud-detector/v1",
+            ),
+        )
+
+        client = ModelRegistryClient("https://registry.example.com")
+        client.register_model(
+            name="fraud-detector",
+            uri=uri,
+            version="v1.0.0",
+            model_format_name="sklearn",
+        )
+    """
+    if isinstance(upload_params, S3UploadParams):
+        return _upload_to_s3(model_files_path, upload_params)
+    if isinstance(upload_params, OCIUploadParams):
+        return _upload_to_oci(model_files_path, upload_params)
+    raise TypeError(
+        f"upload_params must be S3UploadParams or OCIUploadParams, "
+        f"got {type(upload_params).__name__}"
+    )
+
+
+def _upload_to_s3(path: str, params: S3UploadParams) -> str:
+    """Upload to S3-compatible storage."""
+    try:
+        from model_registry.utils import (
+            _connect_to_s3,
+            _s3_creds,
+            _upload_to_s3 as _mr_upload_to_s3,
+        )
+    except ImportError as e:
+        raise ImportError(
+            "S3 upload requires the model-registry package with S3 support.\n"
+            "Install it with:  pip install 'kubeflow[hub]'"
+        ) from e
+
+    endpoint_url, access_key_id, secret_access_key, region = _s3_creds(
+        params.endpoint_url,
+        params.access_key_id,
+        params.secret_access_key,
+        params.region,
+    )
+    s3, transfer_config = _connect_to_s3(
+        endpoint_url=endpoint_url,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        multipart_threshold=params.multipart_threshold,
+        multipart_chunksize=params.multipart_chunksize,
+        max_pool_connections=params.max_pool_connections,
+    )
+    return _mr_upload_to_s3(
+        path=path,
+        path_prefix=params.s3_prefix,
+        bucket=params.bucket_name,
+        s3=s3,
+        endpoint_url=endpoint_url,
+        region=region,
+        transfer_config=transfer_config,
+    )
+
+
+def _upload_to_oci(path: str, params: OCIUploadParams) -> str:
+    """Upload to an OCI registry."""
+    try:
+        from model_registry.utils import save_to_oci_registry
+    except ImportError as e:
+        raise ImportError(
+            "OCI upload requires the model-registry package with OCI support.\n"
+            "Install it with:  pip install 'kubeflow[hub]'"
+        ) from e
+
+    return save_to_oci_registry(
+        model_uri=params.model_uri,
+        model_files_path=path,
+        author=params.author,
+        model_description=params.model_description,
+        model_title=params.model_title,
+        custom_oci_backend=params.custom_oci_backend,
+    )

--- a/kubeflow/hub/storage.py
+++ b/kubeflow/hub/storage.py
@@ -128,10 +128,7 @@ def _upload_to_oci(path: str, params: OCIUploadParams) -> str:
         ) from e
 
     return save_to_oci_registry(
-        model_uri=params.model_uri,
+        base_image=params.base_image,
+        oci_ref=params.oci_ref,
         model_files_path=path,
-        author=params.author,
-        model_description=params.model_description,
-        model_title=params.model_title,
-        custom_oci_backend=params.custom_oci_backend,
     )

--- a/kubeflow/hub/storage_test.py
+++ b/kubeflow/hub/storage_test.py
@@ -1,0 +1,67 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for standalone storage utilities."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from pydantic import ValidationError
+import pytest
+
+from kubeflow.hub.storage import upload_artifact
+from kubeflow.hub.types import OCIUploadParams, S3UploadParams
+
+
+def test_upload_artifact_delegates_to_s3(monkeypatch):
+    """Test upload_artifact delegates S3 uploads to the S3 implementation."""
+    mock_upload = Mock(return_value="s3://bucket/prefix")
+    monkeypatch.setattr("kubeflow.hub.storage._upload_to_s3", mock_upload)
+
+    params = S3UploadParams(bucket_name="bucket", s3_prefix="prefix")
+    result = upload_artifact("/tmp/model", upload_params=params)
+
+    assert result == "s3://bucket/prefix"
+    mock_upload.assert_called_once_with("/tmp/model", params)
+
+
+def test_upload_artifact_delegates_to_oci(monkeypatch):
+    """Test upload_artifact delegates OCI uploads to the OCI implementation."""
+    mock_upload = Mock(return_value="oci://registry.example.com/model:v1")
+    monkeypatch.setattr("kubeflow.hub.storage._upload_to_oci", mock_upload)
+
+    params = OCIUploadParams(model_uri="registry.example.com/model:v1")
+    result = upload_artifact("/tmp/model", upload_params=params)
+
+    assert result == "oci://registry.example.com/model:v1"
+    mock_upload.assert_called_once_with("/tmp/model", params)
+
+
+def test_upload_artifact_raises_type_error_for_unknown_upload_params():
+    """Test upload_artifact rejects unsupported upload parameter types."""
+    with pytest.raises(TypeError, match="upload_params must be"):
+        upload_artifact("/tmp/model", upload_params=object())  # type: ignore[arg-type]
+
+
+def test_s3_upload_params_requires_bucket_name():
+    """Test S3UploadParams validates required fields."""
+    with pytest.raises(ValidationError):
+        S3UploadParams(s3_prefix="prefix")
+
+
+def test_oci_upload_params_requires_model_uri():
+    """Test OCIUploadParams validates required fields."""
+    with pytest.raises(ValidationError):
+        OCIUploadParams()

--- a/kubeflow/hub/storage_test.py
+++ b/kubeflow/hub/storage_test.py
@@ -42,7 +42,7 @@ def test_upload_artifact_delegates_to_oci(monkeypatch):
     mock_upload = Mock(return_value="oci://registry.example.com/model:v1")
     monkeypatch.setattr("kubeflow.hub.storage._upload_to_oci", mock_upload)
 
-    params = OCIUploadParams(model_uri="registry.example.com/model:v1")
+    params = OCIUploadParams(base_image="python:3.11", oci_ref="registry.example.com/model:v1")
     result = upload_artifact("/tmp/model", upload_params=params)
 
     assert result == "oci://registry.example.com/model:v1"
@@ -58,10 +58,10 @@ def test_upload_artifact_raises_type_error_for_unknown_upload_params():
 def test_s3_upload_params_requires_bucket_name():
     """Test S3UploadParams validates required fields."""
     with pytest.raises(ValidationError):
-        S3UploadParams(s3_prefix="prefix")
+        S3UploadParams(s3_prefix="prefix")  # type: ignore[call-arg]
 
 
-def test_oci_upload_params_requires_model_uri():
+def test_oci_upload_params_requires_base_image_and_oci_ref():
     """Test OCIUploadParams validates required fields."""
     with pytest.raises(ValidationError):
-        OCIUploadParams()
+        OCIUploadParams()  # type: ignore[call-arg]

--- a/kubeflow/hub/types/__init__.py
+++ b/kubeflow/hub/types/__init__.py
@@ -1,0 +1,3 @@
+from kubeflow.hub.types.types import OCIUploadParams, S3UploadParams, StorageConfig
+
+__all__ = ["StorageConfig", "S3UploadParams", "OCIUploadParams"]

--- a/kubeflow/hub/types/types.py
+++ b/kubeflow/hub/types/types.py
@@ -15,6 +15,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel
 
 
 @dataclass
@@ -59,3 +62,27 @@ class StorageConfig:
     storage_key: str | None = None
     storage_path: str | None = None
     service_account_name: str | None = None
+
+
+class S3UploadParams(BaseModel):
+    """Parameters for uploading a model artifact to S3-compatible storage."""
+
+    bucket_name: str
+    s3_prefix: str
+    endpoint_url: str | None = None
+    access_key_id: str | None = None
+    secret_access_key: str | None = None
+    region: str | None = None
+    multipart_threshold: int = 1024 * 1024
+    multipart_chunksize: int = 1024 * 1024
+    max_pool_connections: int = 10
+
+
+class OCIUploadParams(BaseModel):
+    """Parameters for uploading a model artifact to an OCI registry."""
+
+    model_uri: str  # e.g. "ghcr.io/my-org/models/fraud-detector:v1"
+    author: str | None = None
+    model_description: str | None = None
+    model_title: str | None = None
+    custom_oci_backend: Any | None = None  # matches OCIParams.custom_oci_backend

--- a/kubeflow/hub/types/types.py
+++ b/kubeflow/hub/types/types.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
 
 from pydantic import BaseModel
 
@@ -81,8 +80,5 @@ class S3UploadParams(BaseModel):
 class OCIUploadParams(BaseModel):
     """Parameters for uploading a model artifact to an OCI registry."""
 
-    model_uri: str  # e.g. "ghcr.io/my-org/models/fraud-detector:v1"
-    author: str | None = None
-    model_description: str | None = None
-    model_title: str | None = None
-    custom_oci_backend: Any | None = None  # matches OCIParams.custom_oci_backend
+    base_image: str  # e.g. "python:3.11"
+    oci_ref: str  # e.g. "ghcr.io/my-org/models/fraud-detector:v1"


### PR DESCRIPTION
## Summary

Adds a decoupled `upload_artifact` utility for uploading model artifacts to S3 or OCI without registering them in a model registry, as described in #475.

- New `kubeflow/hub/storage.py` with `upload_artifact` and standalone S3 upload helper
- New `S3UploadParams` and `OCIUploadParams` Pydantic types in `kubeflow/hub/types/`
- Unit tests in `kubeflow/hub/storage_test.py`
- Exported from `kubeflow.hub`

Fixes #475

## Test plan

- [x] `uv run pytest -q kubeflow/hub/storage_test.py`
- [x] `uv run ruff check` / pre-commit on changed hub files
