### PR TITLE
fix(spark): align Spark Connect service-name fallback with operator default

### DIFF
--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -448,6 +448,11 @@ class KubernetesBackend(RuntimeBackend):
         Returns:
             (connect_url, port_forward_process or None). Caller may keep process reference;
             process exits when the Python process exits.
+
+        Raises:
+            RuntimeError: If the session reports no port-forward target, if
+                build_service_url cannot resolve an in-cluster host, or if
+                port-forward fails for every candidate.
         """
         if os.environ.get("KUBERNETES_SERVICE_HOST"):
             url = build_service_url(info)
@@ -457,19 +462,20 @@ class KubernetesBackend(RuntimeBackend):
         if port is None:
             port_str = os.environ.get("SPARK_CONNECT_LOCAL_PORT")
             port = int(port_str) if port_str else random.randint(15002, 16002)
-        # Prefer pod when available (bypasses Service/EndpointSlice); then try svc names
+        # Prefer pod when available (bypasses Service/EndpointSlice); then try svc name
         candidates: list[tuple[str, str]] = []
         if info.driver_pod_name:
             candidates.append(("pod", info.driver_pod_name))
-        for svc in [f"{info.name}-svc", info.service_name, f"{info.name}-server"]:
-            if svc and not any(c[0] == "svc" and c[1] == svc for c in candidates):
-                candidates.append(("svc", svc))
-        seen: set[str] = set()
+        if info.service_name:
+            candidates.append(("svc", info.service_name))
+        if not candidates:
+            raise RuntimeError(
+                f"No port-forward target for {info.namespace}/{info.name}: neither "
+                "status.server.podName nor status.server.serviceName is populated. "
+                "The session is not ready."
+            )
         for kind, target in candidates:
             key = f"{kind}/{target}"
-            if key in seen:
-                continue
-            seen.add(key)
             # Use 127.0.0.1 instead of localhost to force IPv4 (gRPC may prefer IPv6 which can fail)
             url = f"sc://127.0.0.1:{port}"
             cmd = [

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -744,6 +744,20 @@ def test_get_connect_url(kubernetes_backend, test_case):
     print("test execution complete")
 
 
+def test_get_connect_url_raises_when_no_target(kubernetes_backend):
+    """get_connect_url raises when neither pod_name nor service_name is populated."""
+    info = SparkConnectInfo(
+        name="test-session",
+        namespace="default",
+        state=SparkConnectState.READY,
+    )
+    with (
+        patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": ""}, clear=False),
+        pytest.raises(RuntimeError, match="No port-forward target"),
+    ):
+        kubernetes_backend.get_connect_url(info)
+
+
 @pytest.mark.parametrize(
     "test_case",
     [

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -698,16 +698,23 @@ def test_get_session_logs(kubernetes_backend, test_case):
             config={"in_cluster": False},
             expected_output={"url": "sc://127.0.0.1:15002", "proc_is_none": False},
         ),
+        TestCase(
+            name="out-of-cluster without pod or service name raises",
+            expected_status=FAILED,
+            config={"in_cluster": False, "service_name": None},
+            expected_error=RuntimeError,
+            expected_output="No port-forward target",
+        ),
     ],
 )
 def test_get_connect_url(kubernetes_backend, test_case):
-    """Test get_connect_url for in-cluster and port-forward scenarios."""
+    """Test get_connect_url for in-cluster, port-forward, and not-ready scenarios."""
     print("Executing test:", test_case.name)
     info = SparkConnectInfo(
         name="test-session",
         namespace="default",
         state=SparkConnectState.READY,
-        service_name="test-session-svc",
+        service_name=test_case.config.get("service_name", "test-session-server"),
     )
 
     if test_case.config["in_cluster"]:
@@ -729,6 +736,14 @@ def test_get_connect_url(kubernetes_backend, test_case):
             patch("kubeflow.spark.backends.kubernetes.backend.time.sleep"),
             patch.object(kubernetes_backend, "_wait_for_connect_port", return_value=True),
         ):
+            if test_case.expected_status == FAILED:
+                with pytest.raises(
+                    test_case.expected_error,
+                    match=test_case.expected_output,
+                ):
+                    kubernetes_backend.get_connect_url(info)
+                print("test execution complete")
+                return
             url, proc = kubernetes_backend.get_connect_url(info)
 
     if "url_contains" in test_case.expected_output:
@@ -742,20 +757,6 @@ def test_get_connect_url(kubernetes_backend, test_case):
         assert proc is mock_popen
 
     print("test execution complete")
-
-
-def test_get_connect_url_raises_when_no_target(kubernetes_backend):
-    """get_connect_url raises when neither pod_name nor service_name is populated."""
-    info = SparkConnectInfo(
-        name="test-session",
-        namespace="default",
-        state=SparkConnectState.READY,
-    )
-    with (
-        patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": ""}, clear=False),
-        pytest.raises(RuntimeError, match="No port-forward target"),
-    ):
-        kubernetes_backend.get_connect_url(info)
 
 
 @pytest.mark.parametrize(

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -328,16 +328,37 @@ def validate_spark_connect_url(url: str) -> bool:
 
 
 def build_service_url(info: SparkConnectInfo) -> str:
-    """Build Spark Connect URL from session info.
+    """Build the in-cluster Spark Connect URL from session info.
+
+    Relies on the operator-reported Service name. The operator records the
+    actual Service name (default "<name>-server" or a user-customized name via
+    .spec.server.service) in Status.Server.ServiceName, so this is correct for
+    both default and customized Services. Callers are expected to have waited
+    for readiness (wait_for_ready), by which point the operator has populated
+    this field in the same atomic status write that set the Ready state.
 
     Args:
         info: SparkConnectInfo with service details.
 
     Returns:
-        Spark Connect URL (e.g., "sc://service-name:15002").
+        Spark Connect URL
+        (e.g., "sc://my-session-server.default.svc.cluster.local:15002").
+
+    Raises:
+        RuntimeError: If ``info.service_name`` is not populated. An empty value
+            means the session is not ready yet, not a name we should guess;
+            callers should wait for readiness before building the URL.
     """
-    service = info.service_name or f"{info.name}-svc"
-    return f"sc://{service}.{info.namespace}.svc.cluster.local:{constants.SPARK_CONNECT_PORT}"
+    if not info.service_name:
+        raise RuntimeError(
+            f"Cannot build Spark Connect URL for {info.namespace}/{info.name}: "
+            "status.server.serviceName is not populated yet. The session is not "
+            "ready to accept in-cluster connections."
+        )
+    return (
+        f"sc://{info.service_name}.{info.namespace}.svc.cluster.local"
+        f":{constants.SPARK_CONNECT_PORT}"
+    )
 
 
 def get_spark_connect_driver_spec(

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -245,21 +245,34 @@ def test_validate_spark_connect_url(test_case: TestCase) -> None:
     "test_case",
     [
         TestCase(
-            name="build service url with service name",
+            name="build service url from operator default service name",
             expected_status=SUCCESS,
             config={
                 "info": SparkConnectInfo(
                     name="my-session",
                     namespace="spark",
                     state=SparkConnectState.READY,
-                    service_name="my-session-svc",
+                    service_name="my-session-server",
                 ),
             },
-            expected_output="sc://my-session-svc.spark.svc.cluster.local:15002",
+            expected_output="sc://my-session-server.spark.svc.cluster.local:15002",
         ),
         TestCase(
-            name="build service url without service name",
+            name="build service url from custom service name",
             expected_status=SUCCESS,
+            config={
+                "info": SparkConnectInfo(
+                    name="my-session",
+                    namespace="spark",
+                    state=SparkConnectState.READY,
+                    service_name="custom-endpoint",
+                ),
+            },
+            expected_output="sc://custom-endpoint.spark.svc.cluster.local:15002",
+        ),
+        TestCase(
+            name="build service url without service name raises",
+            expected_status=FAILED,
             config={
                 "info": SparkConnectInfo(
                     name="my-session",
@@ -267,7 +280,8 @@ def test_validate_spark_connect_url(test_case: TestCase) -> None:
                     state=SparkConnectState.READY,
                 ),
             },
-            expected_output="my-session-svc",
+            expected_error=RuntimeError,
+            expected_output="not populated",
         ),
     ],
 )
@@ -276,14 +290,14 @@ def test_build_service_url(test_case: TestCase) -> None:
 
     print("Executing test:", test_case.name)
 
-    url = build_service_url(test_case.config["info"])
-
-    assert test_case.expected_status == SUCCESS
-
-    if test_case.name == "build service url with service name":
-        assert url == test_case.expected_output
-    elif test_case.name == "build service url without service name":
-        assert test_case.expected_output in url
+    if test_case.expected_status == SUCCESS:
+        assert build_service_url(test_case.config["info"]) == test_case.expected_output
+    else:
+        with pytest.raises(
+            test_case.expected_error,
+            match=test_case.expected_output,
+        ):
+            build_service_url(test_case.config["info"])
 
     print("test execution complete")
 


### PR DESCRIPTION
*What this PR does / why we need it*:

The in-cluster fallback built `<name>-svc`, but the operator names the service `<name>-server`, so the URL didn't resolve when `service_name` wasn't populated yet (the reconciliation race). Switched the fallback to `-server`, and also dropped the stale `-svc` candidate from the out-of-cluster port-forward list in `backend.py`.

Fixes #515