### PR TITLE
fix(trainer): use resource key as device for custom Kubernetes resources

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -44,8 +44,8 @@ def get_container_devices(
     Get the device type and device count for the given container.
     """
 
-    # If containers resource limits are empty, return Unknown.
-    if resources is None or resources.limits is None:
+    # If the container resource limits are empty, there is no device to report.
+    if resources is None or not resources.limits:
         return None
 
     # TODO (andreyvelich): We should discuss how to get container device type.
@@ -75,7 +75,15 @@ def get_container_devices(
         device = constants.CPU_LABEL
         device_count = resources.limits[constants.CPU_LABEL].actual_instance
     else:
-        raise Exception(f"Unknown device type in the container resources: {resources.limits}")
+        # Device plugins advertise extended resources as "<domain>/<resource>", e.g.
+        # "rdma/hca_shared_devices_a". There is no generic name for those, so use the
+        # resource key itself as the device. Sorting keeps the choice stable when a
+        # container requests more than one.
+        custom_keys = sorted(k for k in resources.limits if "/" in k)
+        if not custom_keys:
+            raise Exception(f"Unknown device type in the container resources: {resources.limits}")
+        device = custom_keys[0]
+        device_count = resources.limits[device].actual_instance
     if device_count is None:
         raise Exception(f"Failed to get device count for resources: {resources.limits}")
 

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -82,6 +82,85 @@ def _build_runtime() -> types.Runtime:
             },
             expected_output=("npu", "2.0"),
         ),
+        TestCase(
+            name="custom resource limit falls back to the resource key",
+            expected_status=SUCCESS,
+            config={
+                "resources": models.IoK8sApiCoreV1ResourceRequirements(
+                    limits={
+                        "rdma/hca_shared_devices_a": models.IoK8sApimachineryPkgApiResourceQuantity(
+                            1
+                        ),
+                    }
+                )
+            },
+            expected_output=("rdma/hca_shared_devices_a", "1.0"),
+        ),
+        TestCase(
+            name="custom resource is preferred over plain resource in fallback",
+            expected_status=SUCCESS,
+            config={
+                "resources": models.IoK8sApiCoreV1ResourceRequirements(
+                    limits={
+                        "memory": models.IoK8sApimachineryPkgApiResourceQuantity("1Gi"),
+                        "rdma/hca_shared_devices_a": models.IoK8sApimachineryPkgApiResourceQuantity(
+                            1
+                        ),
+                    }
+                )
+            },
+            expected_output=("rdma/hca_shared_devices_a", "1.0"),
+        ),
+        TestCase(
+            name="multiple custom resources pick the first in sorted order",
+            expected_status=SUCCESS,
+            config={
+                "resources": models.IoK8sApiCoreV1ResourceRequirements(
+                    limits={
+                        "rdma/hca_shared_devices_b": models.IoK8sApimachineryPkgApiResourceQuantity(
+                            2
+                        ),
+                        "rdma/hca_shared_devices_a": models.IoK8sApimachineryPkgApiResourceQuantity(
+                            1
+                        ),
+                    }
+                )
+            },
+            expected_output=("rdma/hca_shared_devices_a", "1.0"),
+        ),
+        TestCase(
+            name="unrecognized resource without a custom key still raises",
+            expected_status=FAILED,
+            config={
+                "resources": models.IoK8sApiCoreV1ResourceRequirements(
+                    limits={
+                        "memory": models.IoK8sApimachineryPkgApiResourceQuantity("1Gi"),
+                    }
+                )
+            },
+            expected_error=Exception,
+        ),
+        TestCase(
+            name="cpu limit takes priority over custom resource",
+            expected_status=SUCCESS,
+            config={
+                "resources": models.IoK8sApiCoreV1ResourceRequirements(
+                    limits={
+                        constants.CPU_LABEL: models.IoK8sApimachineryPkgApiResourceQuantity(4),
+                        "rdma/hca_shared_devices_a": models.IoK8sApimachineryPkgApiResourceQuantity(
+                            1
+                        ),
+                    }
+                )
+            },
+            expected_output=("cpu", "4.0"),
+        ),
+        TestCase(
+            name="empty limits returns None",
+            expected_status=SUCCESS,
+            config={"resources": models.IoK8sApiCoreV1ResourceRequirements(limits={})},
+            expected_output=None,
+        ),
     ],
 )
 def test_get_container_devices(test_case: TestCase):


### PR DESCRIPTION
**What this PR does / why we need it**:

get_container_devices raises an exception when container limits contain a resource it does not recognize, such as rdma/hca_shared_devices_a from a device plugin. As a result get_job, list_jobs, wait_for_job_status and get_job_logs all fail for a TrainJob that runs fine on the cluster.

This change adds a narrow fallback for that case: when the limits contain an extended-resource key (one containing `/`), that key is used directly as the device, following the direction in the issue discussion. Keys are sorted so the choice is deterministic when a container requests more than one. Anything else still raises as it did before, so a container with only a `memory` limit is not reported as a `memory` device. The priority order for known accelerators is unchanged, so cpu plus a custom resource still reports cpu. Empty limits now return None instead of raising.

Rebased on main.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #516

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing