### PR TITLE
chore(docs): update wait_for_run_status timeout default in KEP-125

### DIFF
--- a/docs/proposals/125-kfp-client/README.md
+++ b/docs/proposals/125-kfp-client/README.md
@@ -679,7 +679,7 @@ def wait_for_run_status(
     run: str | Run,
     *,
     status: set[str] = {constants.RUN_COMPLETE},
-    timeout: int | None = None,
+    timeout: int = 600,
     polling_interval: int = 5,
     callbacks: list[Callable[[types.Run], None]] | None = None,
 ) -> Run:
@@ -691,7 +691,7 @@ def wait_for_run_status(
 
 - **`callbacks` —** Called with the final `Run` object when the wait ends (on any stop condition). Replaces the `raise_on_failure` flag. Callbacks can inspect `run.state` and raise or log as needed.
 
-- **`timeout` —** If set (seconds), `TimeoutError` if the window expires before a stop condition. If omitted, poll until a stop condition.
+- **`timeout` —** Maximum seconds to wait. `TimeoutError` if the window expires before a stop condition. Defaults to 600 (10 minutes), matching `TrainerClient.wait_for_job_status`.
 
 **Example:** You asked for `{"running"}` but the run `failed` first → wait stops immediately; any provided callbacks receive the `Run` object.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This is an update to existing KEP-125 following conversation in: https://github.com/kubeflow/pipelines/pull/13405#discussion_r3389139253

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

N/A

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
