### PR TITLE
chore: Add ADOPTERS.md for Kubeflow SDK

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,9 @@
+# Adopters of Kubeflow SDK
+
+Below are the adopters of Kubeflow SDK. If you are using this project in your organization, please add your name to the list by submitting a pull request: this will help foster the Kubeflow community. Kindly ensure the list remains in alphabetical order.
+If you are using other Kubeflow components, consider adding your name as well to the overall [Kubeflow Community Adopters file](https://github.com/kubeflow/community/blob/master/ADOPTERS.md).
+
+| Organization                       | Contact (GitHub User Name)              | Environment   | Description of Use                                                                          |
+|------------------------------------|----------------------------------------|---------------|----------------------------------------------------------------------------------------------|
+| [Red Hat](https://www.redhat.com)  | [@ederign](https://github.com/ederign) | Production    | Kubeflow SDK is part of [OpenShift AI](https://www.redhat.com/en/products/ai/openshift-ai)   |
+| *your organization*                | *your GitHub handle*                   | *your setup*  | *brief description*                                                                          |


### PR DESCRIPTION
## Summary
- Add ADOPTERS.md file  
- List Red Hat as an adopter of Kubeflow SDK