### PR TITLE
chore: rename SparkConnectInfo pod_name to driver_pod_name

### DIFF
--- a/examples/spark/demo_existing_sparkconnect.py
+++ b/examples/spark/demo_existing_sparkconnect.py
@@ -138,7 +138,7 @@ if sessions:
     print("\n# Session Details:")
     print(f"   Name: {info.name}")
     print(f"   State: {info.state.value}")
-    print(f"   Server Pod: {info.driver_pod_name}")
+    print(f"   Driver Pod: {info.driver_pod_name}")
     print(f"   Service: {info.service_name}")
     print(f"   Service URL: {info.service_url}")
 

--- a/examples/spark/demo_existing_sparkconnect.py
+++ b/examples/spark/demo_existing_sparkconnect.py
@@ -219,7 +219,7 @@ print("\nSession details:")
 print(f"   name: {info.name}")
 print(f"   namespace: {info.namespace}")
 print(f"   state: {info.state.value}")
-print(f"   server_pod_name: {info.driver_pod_name}")
+print(f"   driver_pod_name: {info.driver_pod_name}")
 print(f"   service_name: {info.service_name}")
 print(f"   created_at: {info.created_at}")
 

--- a/examples/spark/demo_existing_sparkconnect.py
+++ b/examples/spark/demo_existing_sparkconnect.py
@@ -138,7 +138,7 @@ if sessions:
     print("\n# Session Details:")
     print(f"   Name: {info.name}")
     print(f"   State: {info.state.value}")
-    print(f"   Server Pod: {info.pod_name}")
+    print(f"   Server Pod: {info.driver_pod_name}")
     print(f"   Service: {info.service_name}")
     print(f"   Service URL: {info.service_url}")
 
@@ -219,7 +219,7 @@ print("\nSession details:")
 print(f"   name: {info.name}")
 print(f"   namespace: {info.namespace}")
 print(f"   state: {info.state.value}")
-print(f"   server_pod_name: {info.server_pod_name}")
+print(f"   server_pod_name: {info.driver_pod_name}")
 print(f"   service_name: {info.service_name}")
 print(f"   created_at: {info.created_at}")
 

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -333,8 +333,8 @@ class KubernetesBackend(RuntimeBackend):
             port = int(port_str) if port_str else random.randint(15002, 16002)
         # Prefer pod when available (bypasses Service/EndpointSlice); then try svc names
         candidates: list[tuple[str, str]] = []
-        if info.pod_name:
-            candidates.append(("pod", info.pod_name))
+        if info.driver_pod_name:
+            candidates.append(("pod", info.driver_pod_name))
         for svc in [f"{info.name}-svc", info.service_name, f"{info.name}-server"]:
             if svc and not any(c[0] == "svc" and c[1] == svc for c in candidates):
                 candidates.append(("svc", svc))
@@ -590,15 +590,15 @@ class KubernetesBackend(RuntimeBackend):
         """Get logs from a SparkConnect session."""
         info = self.get_session(name)
 
-        if not info.pod_name:
+        if not info.driver_pod_name:
             raise RuntimeError(
-                f"No server pod for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
+                f"No driver pod for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
             )
 
         try:
             if follow:
                 thread = self.core_api.read_namespaced_pod_log(
-                    name=info.pod_name,
+                    name=info.driver_pod_name,
                     namespace=self.namespace,
                     follow=True,
                     _preload_content=False,
@@ -609,7 +609,7 @@ class KubernetesBackend(RuntimeBackend):
                     yield line.decode("utf-8").rstrip("\n")
             else:
                 thread = self.core_api.read_namespaced_pod_log(
-                    name=info.pod_name,
+                    name=info.driver_pod_name,
                     namespace=self.namespace,
                     async_req=True,
                 )

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -484,7 +484,7 @@ def test_get_session_logs(kubernetes_backend, test_case):
 
         # Mock get_session so execution always reaches the log-reading code path.
         pod_name = test_case.config.get("pod_name", f"{test_case.config['name']}-0")
-        kubernetes_backend.get_session = Mock(return_value=Mock(pod_name=pod_name))
+        kubernetes_backend.get_session = Mock(return_value=Mock(driver_pod_name=pod_name))
 
         logs = list(kubernetes_backend.get_session_logs(test_case.config["name"], follow=False))
 

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -298,7 +298,7 @@ def get_spark_connect_info_from_cr(
         name=spark_connect_cr.metadata.name,
         namespace=spark_connect_cr.metadata.namespace,
         state=state,
-        pod_name=server_status.pod_name if server_status else None,
+        driver_pod_name=server_status.pod_name if server_status else None,
         pod_ip=server_status.pod_ip if server_status else None,
         service_name=server_status.service_name if server_status else None,
         creation_timestamp=spark_connect_cr.metadata.creation_timestamp,

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -326,7 +326,7 @@ class TestGetSparkConnectInfoFromCr:
         assert info.name == "my-session"
         assert info.namespace == "default"
         assert info.state == SparkConnectState.READY
-        assert info.pod_name == "my-session-server-0"
+        assert info.driver_pod_name == "my-session-server-0"
         assert info.pod_ip == "10.0.0.5"
         assert info.service_name == "my-session-svc"
         assert info.creation_timestamp is not None
@@ -393,7 +393,7 @@ class TestGetSparkConnectInfoFromCr:
         info = get_spark_connect_info_from_cr(spark_connect_cr)
 
         assert info.state == SparkConnectState.PROVISIONING
-        assert info.pod_name is None
+        assert info.driver_pod_name is None
 
     def test_invalid_cr_missing_name_raises_error(self, minimal_spec):
         """Test that CR without name in metadata raises ValueError."""

--- a/kubeflow/spark/types/types.py
+++ b/kubeflow/spark/types/types.py
@@ -38,7 +38,7 @@ class SparkConnectInfo:
         namespace: Kubernetes namespace. Included in SparkConnectInfo for standalone usage
             and passing info between components without requiring SparkClient context.
         state: Current state of the session.
-        pod_name: Name of the server pod.
+        driver_pod_name: Name of the driver pod.
         pod_ip: IP address of the server pod.
         service_name: Name of the Kubernetes service.
         creation_timestamp: Timestamp when the session was created.
@@ -47,7 +47,7 @@ class SparkConnectInfo:
     name: str
     namespace: str
     state: SparkConnectState
-    pod_name: str | None = None
+    driver_pod_name: str | None = None
     pod_ip: str | None = None
     service_name: str | None = None
     creation_timestamp: datetime | None = None

--- a/kubeflow/spark/types/types_test.py
+++ b/kubeflow/spark/types/types_test.py
@@ -54,7 +54,7 @@ class TestSparkConnectInfo:
         assert info.name == "test-session"
         assert info.namespace == "default"
         assert info.state == SparkConnectState.READY
-        assert info.pod_name is None
+        assert info.driver_pod_name is None
         assert info.pod_ip is None
         assert info.service_name is None
         assert info.creation_timestamp is None
@@ -66,7 +66,7 @@ class TestSparkConnectInfo:
             name="full-session",
             namespace="spark-ns",
             state=SparkConnectState.READY,
-            pod_name="spark-connect-server-0",
+            driver_pod_name="spark-connect-server-0",
             pod_ip="10.0.0.5",
             service_name="spark-connect-svc",
             creation_timestamp=created,
@@ -74,7 +74,7 @@ class TestSparkConnectInfo:
         assert info.name == "full-session"
         assert info.namespace == "spark-ns"
         assert info.state == SparkConnectState.READY
-        assert info.pod_name == "spark-connect-server-0"
+        assert info.driver_pod_name == "spark-connect-server-0"
         assert info.pod_ip == "10.0.0.5"
         assert info.service_name == "spark-connect-svc"
         assert info.creation_timestamp == created


### PR DESCRIPTION
## Summary

Rename the `SparkConnectInfo` field `pod_name` to `driver_pod_name` for consistency with the `SparkJob` model.

## Changes

- Rename `SparkConnectInfo.pod_name` to `driver_pod_name`
- Update backend implementation to use the new field
- Update utility functions
- Update unit tests
- Update Spark Connect example

## Motivation

This change aligns the naming used by `SparkConnectInfo` with `SparkJob`, providing a consistent SDK API for driver pod information.

This is a refactoring only. No functional behavior has changed.

## Testing

```bash
uv run pytest kubeflow/spark/backends/kubernetes/backend_test.py
uv run pytest kubeflow/spark/backends/kubernetes/utils_test.py
uv run pytest kubeflow/spark/types/types_test.py
```

## References
Follow-up from the KEP-107 review discussion: https://github.com/kubeflow/sdk/pull/524#discussion_r3484396099