### PR TITLE
fix: don't silently fall back to current context namespace

### DIFF
--- a/kubeflow/common/utils.py
+++ b/kubeflow/common/utils.py
@@ -26,17 +26,24 @@ def get_default_target_namespace(context: str | None = None) -> str:
     if not is_running_in_k8s():
         try:
             all_contexts, current_context = config.list_kube_config_contexts()
-            # If context is set, we should get namespace from it.
-            if context:
+            # If a context is explicitly requested, honor only that context. Fall
+            # back to the default namespace rather than silently using the current
+            # context's namespace when the requested context is missing or has no
+            # namespace set. Use "is not None" so an explicit empty string is still
+            # treated as an explicit request instead of falling through to the
+            # current context.
+            if context is not None:
                 for c in all_contexts:
                     if isinstance(c, dict) and c.get("name") == context:
-                        return c["context"]["namespace"]
+                        namespace = c.get("context", {}).get("namespace")
+                        return namespace if namespace else constants.DEFAULT_NAMESPACE
+                return constants.DEFAULT_NAMESPACE
             # Otherwise, try to get namespace from the current context.
             return current_context["context"]["namespace"]
         except Exception:
             return constants.DEFAULT_NAMESPACE
     with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace") as f:
-        return f.readline()
+        return f.readline().strip()
 
 
 def validate_wait_for_job_status(polling_interval: int, timeout: int) -> None:

--- a/kubeflow/common/utils_test.py
+++ b/kubeflow/common/utils_test.py
@@ -11,10 +11,130 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest.mock import mock_open, patch
+
 import pytest
 
-from kubeflow.common import utils
+from kubeflow.common import constants, utils
 from kubeflow.trainer.test.common import SUCCESS, TestCase
+
+
+def _context(name: str, namespace: str | None) -> dict:
+    inner: dict = {"cluster": f"{name}-cluster", "user": f"{name}-user"}
+    if namespace is not None:
+        inner["namespace"] = namespace
+    return {"name": name, "context": inner}
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="explicit context returns its namespace",
+            expected_status=SUCCESS,
+            config={
+                "context": "prod",
+                "all_contexts": [_context("dev", "dev-ns"), _context("prod", "prod-ns")],
+                "current_context": _context("dev", "dev-ns"),
+            },
+            expected_output="prod-ns",
+        ),
+        TestCase(
+            name="explicit context without namespace falls back to default",
+            expected_status=SUCCESS,
+            config={
+                "context": "prod",
+                "all_contexts": [_context("prod", None)],
+                "current_context": _context("dev", "dev-ns"),
+            },
+            expected_output=constants.DEFAULT_NAMESPACE,
+        ),
+        TestCase(
+            name="explicit context with empty namespace falls back to default",
+            expected_status=SUCCESS,
+            config={
+                "context": "prod",
+                "all_contexts": [_context("prod", "")],
+                "current_context": _context("dev", "dev-ns"),
+            },
+            expected_output=constants.DEFAULT_NAMESPACE,
+        ),
+        TestCase(
+            name="unknown context falls back to default instead of current context",
+            expected_status=SUCCESS,
+            config={
+                "context": "missing",
+                "all_contexts": [_context("dev", "dev-ns")],
+                "current_context": _context("dev", "dev-ns"),
+            },
+            expected_output=constants.DEFAULT_NAMESPACE,
+        ),
+        TestCase(
+            name="explicit empty context is honored, not the current context",
+            expected_status=SUCCESS,
+            config={
+                "context": "",
+                "all_contexts": [_context("dev", "dev-ns")],
+                "current_context": _context("dev", "dev-ns"),
+            },
+            expected_output=constants.DEFAULT_NAMESPACE,
+        ),
+        TestCase(
+            name="no context uses the current context namespace",
+            expected_status=SUCCESS,
+            config={
+                "context": None,
+                "all_contexts": [_context("dev", "dev-ns")],
+                "current_context": _context("dev", "dev-ns"),
+            },
+            expected_output="dev-ns",
+        ),
+        TestCase(
+            name="kube config error falls back to default",
+            expected_status=SUCCESS,
+            config={"context": None, "raises": Exception("no kube config")},
+            expected_output=constants.DEFAULT_NAMESPACE,
+        ),
+    ],
+)
+def test_get_default_target_namespace_out_of_cluster(test_case: TestCase):
+    print("Executing test:", test_case.name)
+
+    if "raises" in test_case.config:
+        list_contexts = patch(
+            "kubernetes.config.list_kube_config_contexts",
+            side_effect=test_case.config["raises"],
+        )
+    else:
+        list_contexts = patch(
+            "kubernetes.config.list_kube_config_contexts",
+            return_value=(
+                test_case.config["all_contexts"],
+                test_case.config["current_context"],
+            ),
+        )
+
+    with (
+        patch("kubeflow.common.utils.is_running_in_k8s", return_value=False),
+        list_contexts,
+    ):
+        namespace = utils.get_default_target_namespace(test_case.config["context"])
+
+    assert test_case.expected_status == SUCCESS
+    assert namespace == test_case.expected_output
+    print("test execution complete")
+
+
+def test_get_default_target_namespace_in_cluster_strips_newline():
+    """In-cluster the namespace is read from the service account file and trimmed."""
+
+    with (
+        patch("kubeflow.common.utils.is_running_in_k8s", return_value=True),
+        patch("builtins.open", mock_open(read_data="my-namespace\n")),
+    ):
+        namespace = utils.get_default_target_namespace()
+
+    assert namespace == "my-namespace"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**What this PR does / why we need it**:

`get_default_target_namespace()` in `kubeflow/common/utils.py` is used by both the
Trainer and Optimizer Kubernetes backends to choose the namespace when a caller
passes none. When the caller does pass an explicit `context=`, the function did
not honor it: if that context was not found, or existed but had no `namespace`
set, it silently returned the *current* kube context's namespace instead. The
missing-namespace case raised `KeyError`, which the broad `except` swallowed,
also landing on the current/default context. Either way the user's explicit
`context=` intent was ignored, so a job could be created in the wrong namespace.

This resolves the requested context's namespace safely and falls back to
`constants.DEFAULT_NAMESPACE` when that context is absent or has no namespace,
instead of using the current context. The no-context path is unchanged. It also
strips the trailing newline from the in-cluster service-account namespace read,
matching the canonical Kubernetes pattern. Adds the first unit tests for
`kubeflow/common/utils.py` (mocks only, no network).

**Which issue(s) this PR fixes**:

Fixes #

(No tracking issue - self-identified correctness fix. Happy to file one first if
preferred.)

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing

(Not user-facing: internal default-namespace resolution only; no API or docs
change.)
