### PR TITLE
fix(trainer): stream localprocess logs to the caller

### DIFF
--- a/kubeflow/trainer/backends/localprocess/job.py
+++ b/kubeflow/trainer/backends/localprocess/job.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections.abc import Iterator
 from datetime import datetime
 import logging
 import os
@@ -149,30 +150,32 @@ class LocalJob(threading.Thread):
     def returncode(self):
         return self._returncode
 
-    def logs(self, follow=False) -> list[str]:
+    def logs(self, follow: bool = False) -> list[str] | Iterator[str]:
+        """Get stdout for the local job.
+
+        Args:
+            follow: Whether to stream logs in realtime as they are produced.
+
+        Returns:
+            Buffered stdout lines when ``follow`` is disabled. Otherwise, an
+            iterator that yields stdout lines as they become available.
+        """
         if not follow:
             return self._stdout.splitlines()
 
-        try:
-            for chunk in self.stream_logs():
-                print(chunk, end="", flush=True)  # stream to console live
-        except StopIteration:
-            pass
+        return self.stream_logs()
 
-        return self._stdout.splitlines()
-
-    def stream_logs(self):
-        """Generator that yields new output lines as they come in."""
-        last_index = 0
-        while self.is_alive() or last_index < len(self._stdout):
+    def stream_logs(self) -> Iterator[str]:
+        """Yield newly available stdout lines as they are written by the process."""
+        emitted_line_count = 0
+        while self.is_alive() or emitted_line_count < len(self._stdout.splitlines()):
             self._output_updated.wait(timeout=1)
             with self._lock:
-                data = self._stdout
-                new_data = data[last_index:]
-                last_index = len(data)
+                lines = self._stdout.splitlines()
+                new_lines = lines[emitted_line_count:]
+                emitted_line_count = len(lines)
                 self._output_updated.clear()
-            if new_data:
-                yield new_data
+            yield from new_lines
 
     @property
     def creation_time(self):

--- a/kubeflow/trainer/backends/localprocess/job_test.py
+++ b/kubeflow/trainer/backends/localprocess/job_test.py
@@ -1,0 +1,53 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+
+from kubeflow.trainer.backends.localprocess.job import LocalJob
+from kubeflow.trainer.test.common import SUCCESS, TestCase
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="return buffered lines when follow is disabled",
+            expected_status=SUCCESS,
+            config={"follow": False},
+            expected_output=["line-1", "line-2"],
+        ),
+        TestCase(
+            name="return streaming lines without printing when follow is enabled",
+            expected_status=SUCCESS,
+            config={"follow": True},
+            expected_output=["line-1", "line-2"],
+        ),
+    ],
+)
+def test_logs(test_case: TestCase):
+    """Test LocalJob.logs()."""
+    job = LocalJob(name="test-job", command=["echo", "unused"])
+    job._stdout = "line-1\nline-2\n"
+
+    if test_case.config["follow"]:
+        with (
+            patch.object(job, "stream_logs", return_value=iter(test_case.expected_output)),
+            patch("builtins.print") as mock_print,
+        ):
+            assert list(job.logs(follow=True)) == test_case.expected_output
+        mock_print.assert_not_called()
+    else:
+        assert job.logs() == test_case.expected_output


### PR DESCRIPTION
What this PR does / why we need it

`LocalJob.logs(follow=True)` was a bit busted. It printed inside the SDK and only yielded after the job finished, so callers got duplicate output and no real streaming.

This returns `stream_logs()` to the caller, keeps `follow=False` as-is, and adds regression tests.

Repro:
```python
from kubeflow.trainer.backends.localprocess.job import LocalJob

job = LocalJob(
    name="demo",
    command=["python3", "-c", "import time; print("line1", flush=True); time.sleep(0.2); print("line2", flush=True)"],
)
job.start()
for line in job.logs(follow=True):
    print(line, end="")
```

Before this fix, output was printed from inside the SDK and nothing was yielded until the process exited. After this fix, the caller gets log chunks as they show up.

Which issue(s) this PR fixes

Fixes #435

Checklist

- [ ] Docs included if any changes are user facing