### PR TITLE
fix(spark): correct stale spark_version default in build_spark_connect_cr docstring

### DIFF
--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -196,7 +196,7 @@ def build_spark_connect_cr(
     Args:
         name: Session name.
         namespace: Kubernetes namespace.
-        spark_version: Spark version (default: 3.4.1).
+        spark_version: Spark version (default: 4.0.1).
         num_executors: Number of executor instances (simple mode).
         resources_per_executor: Resource requirements per executor (simple mode).
         spark_conf: Spark configuration properties.


### PR DESCRIPTION

**What this PR does / why we need it**:

The `build_spark_connect_cr` docstring documents the `spark_version` default as
`3.4.1`, but the value actually applied is `constants.DEFAULT_SPARK_VERSION`:

```python
spark_version = spark_version or constants.DEFAULT_SPARK_VERSION
```

and `DEFAULT_SPARK_VERSION` is `"4.0.1"` (it was bumped from `3.4.1` to `4.0.1`
to match the spark-operator image, but this docstring line was not updated).
This corrects the documented default to `4.0.1` so it reflects the real
behavior. Documentation-only change; no runtime behavior is affected.

```diff
-        spark_version: Spark version (default: 3.4.1).
+        spark_version: Spark version (default: 4.0.1).
```

The runtime default this documents is already covered by the existing
`TestBuildSparkConnectCr::test_minimal_cr`, which asserts
`spark_connect.spec.spark_version == constants.DEFAULT_SPARK_VERSION`.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing

_(This PR is itself a docstring/doc correction; no separate external docs page
references the hardcoded default value.)_
