### PR TITLE
fix(docs): correct broken tune cross-reference in Quickstart

### DIFF
--- a/docs/source/getting-started/quickstart.rst
+++ b/docs/source/getting-started/quickstart.rst
@@ -133,4 +133,4 @@ What's Next?
 ------------
 
 - :doc:`../train/index` - Learn about distributed training, GPUs, and more
-- :doc:`../tune/index` - Automatically tune hyperparameters
+- :doc:`../optimize/index` - Automatically tune hyperparameters


### PR DESCRIPTION

**What this PR does / why we need it**:

The "What's Next?" list at the bottom of the Getting Started > Quickstart page
links to `:doc:`../tune/index``, but there is no `tune/` docs directory. The
hyperparameter-tuning docs live under `docs/source/optimize/` (its `index.rst`
is titled "Hyperparameter Tuning"), and the rest of the site references them
correctly (the top-level `toctree` and the "Katib" link in `index.rst` both use
`optimize/index`).

Because `../tune/index` resolves to nothing, the Sphinx build emits:

```
docs/source/getting-started/quickstart.rst:136: WARNING: unknown document: '../tune/index' [ref.doc]
```

and the link renders dead on the published site.

This changes the single stale reference to point at the page that actually
exists:

```diff
-- :doc:`../tune/index` - Automatically tune hyperparameters
+- :doc:`../optimize/index` - Automatically tune hyperparameters
```

The bullet's description ("Automatically tune hyperparameters") is unchanged and
still accurate, since `optimize/index.rst` is the "Hyperparameter Tuning" page.
It is the only reference to `tune/index` in the docs, and the sibling bullet on
the line above already uses the valid `:doc:`../train/index``.

Verified by building the docs (`sphinx-build -b html docs/source docs/_build/html`):
the `unknown document: '../tune/index'` warning is present before the change and
gone after it.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #
N/A

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
