### PR TITLE
fix: improve Trainer control-plane ConfigMap warning message

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -80,7 +80,9 @@ class KubernetesBackend(RuntimeBackend):
             logger.warning(
                 "Trainer control-plane version info is not available: "
                 f"unable to read 'kubeflow_trainer_version' from ConfigMap "
-                f"'{config_map_name}' in namespace '{system_namespace}': {e}"
+                f"'{config_map_name}' in namespace '{system_namespace}': {e}. "
+                "If your Trainer control plane is installed in a different namespace, "
+                "set the KUBEFLOW_SYSTEM_NAMESPACE environment variable accordingly."
             )
             return
 

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -81,7 +81,7 @@ class KubernetesBackend(RuntimeBackend):
                 "Trainer control-plane version info is not available: "
                 f"unable to read 'kubeflow_trainer_version' from ConfigMap "
                 f"'{config_map_name}' in namespace '{system_namespace}': {e}. "
-                "If your Trainer control plane is installed in a different namespace, "
+                "If your Trainer control-plane is installed in a different namespace, "
                 "set the KUBEFLOW_SYSTEM_NAMESPACE environment variable accordingly."
             )
             return

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -803,6 +803,7 @@ def _run_verify_backend_with_core_api(core_api: Mock) -> tuple[list[str], int]:
                     "Trainer control-plane version info is not available",
                     "kubeflow-trainer-public",
                     "ConfigMap not found",
+                    "KUBEFLOW_SYSTEM_NAMESPACE",
                 ],
             },
         ),


### PR DESCRIPTION
## What this PR does

Improves the warning message shown when the Trainer control-plane ConfigMap cannot be read.

The warning now informs users that they can configure the control-plane namespace using the `KUBEFLOW_SYSTEM_NAMESPACE` environment variable if the Trainer control plane is installed in a different namespace.

The corresponding test has also been updated to verify the new guidance.

## Which issue(s) this PR fixes

Fixes #529