### PR TITLE
fix(trainer): don't report Complete when all container statuses are Unknown

### DIFF
--- a/kubeflow/trainer/backends/container/utils.py
+++ b/kubeflow/trainer/backends/container/utils.py
@@ -158,7 +158,8 @@ def aggregate_status_from_containers(container_statuses: list[str]) -> str:
         return constants.TRAINJOB_FAILED
     if constants.TRAINJOB_RUNNING in container_statuses:
         return constants.TRAINJOB_RUNNING
-    if all(s == constants.TRAINJOB_COMPLETE for s in container_statuses if s != UNKNOWN):
+    known_statuses = [s for s in container_statuses if s != UNKNOWN]
+    if known_statuses and all(s == constants.TRAINJOB_COMPLETE for s in known_statuses):
         return constants.TRAINJOB_COMPLETE
     if any(s == constants.TRAINJOB_CREATED for s in container_statuses):
         return constants.TRAINJOB_CREATED

--- a/kubeflow/trainer/backends/container/utils_test.py
+++ b/kubeflow/trainer/backends/container/utils_test.py
@@ -14,7 +14,9 @@
 
 import pytest
 
+from kubeflow.common.constants import UNKNOWN
 from kubeflow.trainer.backends.container import utils as container_utils
+from kubeflow.trainer.constants import constants
 from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
 from kubeflow.trainer.types import types
 
@@ -106,4 +108,59 @@ def test_build_pip_install_cmd(test_case: TestCase):
     except Exception as e:
         assert test_case.expected_status == FAILED
         assert type(e) is test_case.expected_error
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="empty list is not complete",
+            expected_status=SUCCESS,
+            config={"statuses": []},
+            expected_output=UNKNOWN,
+        ),
+        TestCase(
+            name="all unknown is not complete",
+            expected_status=SUCCESS,
+            config={"statuses": [UNKNOWN, UNKNOWN]},
+            expected_output=UNKNOWN,
+        ),
+        TestCase(
+            name="all complete is complete",
+            expected_status=SUCCESS,
+            config={"statuses": [constants.TRAINJOB_COMPLETE, constants.TRAINJOB_COMPLETE]},
+            expected_output=constants.TRAINJOB_COMPLETE,
+        ),
+        TestCase(
+            name="complete with unknown is complete",
+            expected_status=SUCCESS,
+            config={"statuses": [constants.TRAINJOB_COMPLETE, UNKNOWN]},
+            expected_output=constants.TRAINJOB_COMPLETE,
+        ),
+        TestCase(
+            name="failed takes precedence",
+            expected_status=SUCCESS,
+            config={"statuses": [constants.TRAINJOB_COMPLETE, constants.TRAINJOB_FAILED]},
+            expected_output=constants.TRAINJOB_FAILED,
+        ),
+        TestCase(
+            name="running takes precedence over complete",
+            expected_status=SUCCESS,
+            config={"statuses": [constants.TRAINJOB_RUNNING, constants.TRAINJOB_COMPLETE]},
+            expected_output=constants.TRAINJOB_RUNNING,
+        ),
+        TestCase(
+            name="created with unknown is created",
+            expected_status=SUCCESS,
+            config={"statuses": [constants.TRAINJOB_CREATED, UNKNOWN]},
+            expected_output=constants.TRAINJOB_CREATED,
+        ),
+    ],
+)
+def test_aggregate_status_from_containers(test_case: TestCase):
+    """Test aggregation of container statuses into a TrainJob status."""
+    print("Executing test:", test_case.name)
+    result = container_utils.aggregate_status_from_containers(test_case.config["statuses"])
+    assert result == test_case.expected_output
     print("test execution complete")


### PR DESCRIPTION
## What this does

Fixes a false positive `Complete` status in the container backend.

`aggregate_status_from_containers()` ran `all()` over container statuses filtered to exclude `UNKNOWN`:

```python
if all(s == constants.TRAINJOB_COMPLETE for s in container_statuses if s != UNKNOWN):
    return constants.TRAINJOB_COMPLETE
```

When the list is empty or every status is `UNKNOWN`, the filtered sequence is empty, so `all([])` returns `True` and the job is reported `Complete`.

This is reachable through `aggregate_container_statuses()`: `get_container_status()` returns `UNKNOWN` whenever the adapter raises while inspecting a container. A job whose containers cannot be read therefore reports `Complete` to `get_job()`, `list_jobs()`, `wait_for_job_status()` and `get_job_logs()`.

## The fix

Require at least one known status and every known status to be `Complete` before returning `Complete`. Empty or all `UNKNOWN` inputs now aggregate to `Unknown`. `Failed` and `Running` precedence and the `Created` fallback are unchanged.

## Testing

* Added parametrized unit tests for `aggregate_status_from_containers()`, which had no prior coverage: empty, all unknown, all complete, complete with unknown, failed and running precedence, created with unknown.
* `make test-python`: 401 passed.
* `make verify`: all checks passed.

Fixes #561
