### PR TITLE
fix(trainer): validate HuggingFaceModelInitializer storage_uri has a repo path

### DIFF
--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -443,6 +443,12 @@ class HuggingFaceModelInitializer(BaseInitializer):
         if not self.storage_uri.startswith("hf://"):
             raise ValueError(f"storage_uri must start with 'hf://', got {self.storage_uri}")
 
+        if urlparse(self.storage_uri).path == "":
+            raise ValueError(
+                "storage_uri: must have absolute path with 'hf://<user_name>/<model_name>', got "
+                f"{self.storage_uri}"
+            )
+
 
 @dataclass
 class S3ModelInitializer(BaseInitializer):

--- a/kubeflow/trainer/types/types_test.py
+++ b/kubeflow/trainer/types/types_test.py
@@ -113,3 +113,43 @@ def test_data_cache_initializer(test_case: TestCase):
         assert test_case.expected_status == FAILED
         assert type(e) is test_case.expected_error
     print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid storage_uri with user and model",
+            expected_status=SUCCESS,
+            config={"storage_uri": "hf://user/model"},
+        ),
+        TestCase(
+            name="invalid storage_uri without hf prefix raises ValueError",
+            expected_status=FAILED,
+            config={"storage_uri": "user/model"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid storage_uri without repo path raises ValueError",
+            expected_status=FAILED,
+            config={"storage_uri": "hf://model"},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_hugging_face_model_initializer(test_case: TestCase):
+    """Test HuggingFaceModelInitializer creation and validation."""
+    print("Executing test:", test_case.name)
+
+    try:
+        initializer = types.HuggingFaceModelInitializer(
+            storage_uri=test_case.config["storage_uri"],
+        )
+
+        assert test_case.expected_status == SUCCESS
+        assert initializer.storage_uri == test_case.config["storage_uri"]
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert type(e) is test_case.expected_error
+    print("test execution complete")


### PR DESCRIPTION
## What this does

`HuggingFaceModelInitializer.__post_init__` only validated the `hf://` prefix on `storage_uri`. Its sibling `HuggingFaceDatasetInitializer` also rejects a URI whose `urlparse(storage_uri).path` is empty, so the two initializers were inconsistent.

As a result a model `storage_uri` with no repo path, such as `hf://model`, was silently accepted and only failed later at download time.

## The fix

Add the same repo path guard to `HuggingFaceModelInitializer`, mirroring `HuggingFaceDatasetInitializer`. An invalid `storage_uri` now raises `ValueError` at construction with a clear message. A valid `hf://user/model` is unchanged.

## Testing

* Added parametrized unit tests for `HuggingFaceModelInitializer`, which had no prior coverage: valid `hf://user/model`, missing `hf://` prefix, and missing repo path.
* `make test-python`: 397 passed.
* `make verify`: all checks passed.

Fixes #563
