### PR TITLE
fix(trainer): assert behavior in Kubernetes get_runtime_packages test

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -1041,10 +1041,13 @@ def test_get_runtime_packages(kubernetes_backend, test_case):
     """Test KubernetesBackend.get_runtime_packages with basic success path."""
     print("Executing test:", test_case.name)
 
-    try:
-        kubernetes_backend.get_runtime_packages(**test_case.config)
-    except Exception as e:
-        assert type(e) is test_case.expected_error
+    if test_case.expected_status == SUCCESS:
+        # get_runtime_packages runs a TrainJob and streams its logs; it does not
+        # return a value, so a successful call completes without raising.
+        assert kubernetes_backend.get_runtime_packages(**test_case.config) is None
+    else:
+        with pytest.raises(test_case.expected_error):
+            kubernetes_backend.get_runtime_packages(**test_case.config)
 
     print("test execution complete")
 


### PR DESCRIPTION

**What this PR does / why we need it**:

The Kubernetes backend's `test_get_runtime_packages` did not actually verify the
behavior it names. It wrapped the call in a bare `try/except` and only asserted the
exception type *inside* the `except` block:

```python
try:
    kubernetes_backend.get_runtime_packages(**test_case.config)
except Exception as e:
    assert type(e) is test_case.expected_error
```

Both parametrized cases passed without checking the contract:

- The FAILED case (`BuiltinTrainer`, `expected_error=ValueError`) relied entirely on
  the code raising. If the `raise ValueError("Cannot get Runtime packages for
  BuiltinTrainer")` guard in `backend.py` were ever removed or loosened, the call
  returns normally, the `except` never runs, and the test still passes green, silently
  losing the regression guard the case name promises.
- The SUCCESS case discarded the return value and asserted nothing at all.

This change rewrites the test to branch on `expected_status`, matching the same
file's `test_list_runtimes` idiom: `pytest.raises` for the failure case, and an
explicit assertion for success. `get_runtime_packages` on the Kubernetes backend runs
a TrainJob and streams its logs without returning a value, so the success path is
asserted as returning `None` (a comment notes this so the `is None` is not mistaken
for an oversight).

Test-only change; the backend source and all public signatures are untouched.

Verified red/green: with the `ValueError` guard temporarily removed so the function
returns normally for a `BuiltinTrainer`, the old test still passed (proving it was
vacuous) while the rewritten test fails on the failure case. Restored, both cases pass.
`ruff check` / `ruff format --check` are clean and the full kubernetes + localprocess
backend test suites pass (77 tests).

**Which issue(s) this PR fixes**:

Fixes #

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
  (n/a - test-only change, no user-facing behavior)

---

## Diff (test file only, +7/-4)

```diff
diff --git a/kubeflow/trainer/backends/kubernetes/backend_test.py b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -1040,10 +1040,13 @@ def test_get_runtime_packages(kubernetes_backend, test_case):
     """Test KubernetesBackend.get_runtime_packages with basic success path."""
     print("Executing test:", test_case.name)
 
-    try:
-        kubernetes_backend.get_runtime_packages(**test_case.config)
-    except Exception as e:
-        assert type(e) is test_case.expected_error
+    if test_case.expected_status == SUCCESS:
+        # get_runtime_packages runs a TrainJob and streams its logs; it does not
+        # return a value, so a successful call completes without raising.
+        assert kubernetes_backend.get_runtime_packages(**test_case.config) is None
+    else:
+        with pytest.raises(test_case.expected_error):
+            kubernetes_backend.get_runtime_packages(**test_case.config)
 
     print("test execution complete")
```
