### PR TITLE
chore: add boilerplate enforcement

### DIFF
--- a/.github/scripts/compare_versions.py
+++ b/.github/scripts/compare_versions.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Compare PEP 440 versions.
 

--- a/.github/scripts/extract_version.py
+++ b/.github/scripts/extract_version.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Extract package version from uv tree output.
 

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Unit tests for GitHub Actions scripts.
 
@@ -97,6 +110,7 @@ class TestExtractVersion:
             input=tree_output,
             capture_output=True,
             text=True,
+            encoding="utf-8",
         )
         return result.returncode, result.stdout.strip(), result.stderr.strip()
 

--- a/.github/scripts/update_overrides.py
+++ b/.github/scripts/update_overrides.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Update override-dependencies in pyproject.toml.
 

--- a/.github/workflows/test-python.yaml
+++ b/.github/workflows/test-python.yaml
@@ -21,6 +21,19 @@ jobs:
         with:
           extra_args: --all-files
 
+  boilerplate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Verify boilerplate headers
+        run: python hack/boilerplate/boilerplate.py --base-ref "${TARGET_BRANCH:-main}"
+
   test:
     runs-on: ubuntu-latest
     needs: pre-commit

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ verify: install-dev  ## install all required tools
 	@uv lock --check
 	@uv run ruff check --show-fixes --output-format=github .
 	@uv run ruff format --check kubeflow
+	@python3 hack/boilerplate/boilerplate.py --base-ref "$${TARGET_BRANCH:-main}"
 	@uv run ty check kubeflow/hub
 
 .PHONY: uv-venv
@@ -151,6 +152,10 @@ test-e2e-setup-cluster:  ## Setup Kind cluster for Spark E2E tests
 test-scripts: uv-venv  ## Run GitHub Actions script tests
 	@uv sync
 	@uv run pytest .github/scripts/test_scripts.py -v
+
+.PHONY: verify-boilerplate
+verify-boilerplate:  ## Verify copyright boilerplate headers in source files.
+	@python3 hack/boilerplate/boilerplate.py --base-ref "$${TARGET_BRANCH:-main}"
 
 
 .PHONY: install-dev

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:

--- a/examples/spark/spark_advanced_options.py
+++ b/examples/spark/spark_advanced_options.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Advanced SparkClient Options Examples (KEP-107 Options Pattern)
 

--- a/examples/spark/spark_connect_simple.py
+++ b/examples/spark/spark_connect_simple.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 SparkClient Examples - KEP-107 Three-Level API Pattern
 

--- a/hack/boilerplate/boilerplate.go.txt
+++ b/hack/boilerplate/boilerplate.go.txt
@@ -1,0 +1,15 @@
+/*
+Copyright The Kubeflow Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Verify repository boilerplate headers."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+YEAR_RE = re.compile(r"Copyright \d{4}(?:-\d{4})? ")
+ANY_YEAR_RE = re.compile(r"Copyright \d{4}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Verify boilerplate headers")
+    parser.add_argument(
+        "--base-ref",
+        default="main",
+        help="Base branch used to detect new files (default: main).",
+    )
+    return parser.parse_args()
+
+
+def load_template(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def template_for(relpath: str) -> str | None:
+    if relpath == "Makefile":
+        return "sh"
+    if relpath == "docs/source/conf.py":
+        return "sh"
+    if relpath.startswith("kubeflow/") and relpath.endswith(".py"):
+        return "sh"
+    if relpath.startswith("examples/spark/") and relpath.endswith(".py"):
+        return "sh"
+    if relpath.startswith("test/e2e/spark/") and relpath.endswith(".py"):
+        return "sh"
+    if relpath.startswith("docs/_ext/") and relpath.endswith(".py"):
+        return "sh"
+    if relpath.startswith(".github/scripts/") and relpath.endswith(".py"):
+        return "sh"
+    if relpath.startswith("hack/") and relpath.endswith(".sh"):
+        return "sh"
+    if relpath.startswith("hack/") and relpath.endswith(".go"):
+        return "go"
+    return None
+
+
+def collect_files() -> list[str]:
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(ROOT_DIR),
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in result.stdout.splitlines() if template_for(line)]
+
+
+def base_tree_files(base_ref: str) -> set[str] | None:
+    for ref in (f"origin/{base_ref}", base_ref):
+        try:
+            merge_base = subprocess.run(
+                ["git", "-C", str(ROOT_DIR), "merge-base", ref, "HEAD"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+            tree = subprocess.run(
+                ["git", "-C", str(ROOT_DIR), "ls-tree", "-r", "--name-only", merge_base],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            continue
+        return {line for line in tree.stdout.splitlines() if line}
+    return None
+
+
+def strip_shebang(lines: list[str]) -> list[str]:
+    if lines and lines[0].startswith("#!"):
+        return lines[1:]
+    return lines
+
+
+def file_passes(path: Path, template: list[str], new_file: bool) -> tuple[bool, str | None]:
+    try:
+        data = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return False, f"error reading file: {exc}"
+
+    lines = strip_shebang(data.splitlines())
+    if len(lines) < len(template):
+        return False, "file is shorter than the expected boilerplate header"
+
+    header = lines[: len(template)]
+    normalized = [YEAR_RE.sub("Copyright ", line) for line in header]
+    if normalized != template:
+        return False, "header does not match the boilerplate template"
+
+    if new_file and any(ANY_YEAR_RE.search(line) for line in header):
+        return False, "new files must use the year-less boilerplate header"
+
+    return True, None
+
+
+def main() -> int:
+    args = parse_args()
+
+    templates = {
+        "sh": load_template(ROOT_DIR / "hack" / "boilerplate" / "boilerplate.sh.txt"),
+        "go": load_template(ROOT_DIR / "hack" / "boilerplate" / "boilerplate.go.txt"),
+    }
+
+    files = collect_files()
+    base_files = base_tree_files(args.base_ref)
+    if base_files is None:
+        print(
+            f"ERROR: could not resolve base ref {args.base_ref!r}; fetch the base branch first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    failed: list[tuple[str, str]] = []
+    for relpath in files:
+        stem = template_for(relpath)
+        if stem is None:
+            continue
+
+        path = ROOT_DIR / relpath
+        passes, reason = file_passes(path, templates[stem], relpath not in base_files)
+        if not passes:
+            failed.append((relpath, reason or "unknown error"))
+
+    if failed:
+        print("Boilerplate verification failed:", file=sys.stderr)
+        for relpath, reason in failed:
+            print(f"  {relpath}: {reason}", file=sys.stderr)
+        print(
+            "Use the year-less copyright boilerplate from hack/boilerplate/ and rerun make verify-boilerplate.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Boilerplate header verification passed.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hack/boilerplate/boilerplate.sh.txt
+++ b/hack/boilerplate/boilerplate.sh.txt
@@ -1,4 +1,4 @@
-# Copyright 2025 The Kubeflow Authors.
+# Copyright The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubeflow/hub/types/__init__.py
+++ b/kubeflow/hub/types/__init__.py
@@ -1,3 +1,16 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from kubeflow.hub.types.types import OCIUploadParams, S3UploadParams, StorageConfig
 
 __all__ = ["StorageConfig", "S3UploadParams", "OCIUploadParams"]

--- a/kubeflow/optimizer/api/__init__.py
+++ b/kubeflow/optimizer/api/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/kubeflow/spark/tests/__init__.py
+++ b/kubeflow/spark/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/kubeflow/trainer/__init__.py
+++ b/kubeflow/trainer/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Kubeflow Authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubeflow/trainer/api/__init__.py
+++ b/kubeflow/trainer/api/__init__.py
@@ -1,3 +1,16 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # ruff: noqa
 
 # import apis into api package

--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Kubeflow Authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubeflow/trainer/backends/__init__.py
+++ b/kubeflow/trainer/backends/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/kubeflow/trainer/backends/kubernetes/__init__.py
+++ b/kubeflow/trainer/backends/kubernetes/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Kubeflow Authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubeflow/trainer/backends/localprocess/__init__.py
+++ b/kubeflow/trainer/backends/localprocess/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/kubeflow/trainer/backends/localprocess/utils.py
+++ b/kubeflow/trainer/backends/localprocess/utils.py
@@ -1,3 +1,19 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for the localprocess backend."""
+
 from collections.abc import Callable
 import inspect
 import os

--- a/kubeflow/trainer/constants/__init__.py
+++ b/kubeflow/trainer/constants/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/kubeflow/trainer/constants/constants.py
+++ b/kubeflow/trainer/constants/constants.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Kubeflow Authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubeflow/trainer/test/common.py
+++ b/kubeflow/trainer/test/common.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Shared test utilities and types for Kubeflow Trainer tests.
 
 from dataclasses import dataclass, field

--- a/kubeflow/trainer/types/__init__.py
+++ b/kubeflow/trainer/types/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Kubeflow Authors.
+# Copyright 2025 The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/e2e/spark/__init__.py
+++ b/test/e2e/spark/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
## Summary

This PR standardizes the repository's Apache 2.0 copyright boilerplate and adds automated boilerplate verification to ensure consistent copyright headers across the codebase.

**Related Issue:** [Issue #566](https://github.com/kubeflow/sdk/issues/566)

Fixes #566

## What changed

- Added a local boilerplate verification script under `hack/boilerplate/`.
- Added canonical Apache 2.0 boilerplate templates for Python, Shell, and Go source files.
- Integrated boilerplate verification into the CI workflow using GitHub Actions.
- Standardized existing copyright headers across the repository to follow the project's current Apache 2.0 convention.

## Validation

- `python hack/boilerplate/boilerplate.py --base-ref main`
- `python -m pytest .github/scripts/test_scripts.py -v`
- `python -m py_compile` on the modified Python files
- `git diff --check`