### PR TITLE
fix(trainer): strictly type steps in LocalProcess backend to prevent NoneType iteration

### DIFF
--- a/kubeflow/trainer/backends/localprocess/job.py
+++ b/kubeflow/trainer/backends/localprocess/job.py
@@ -27,9 +27,9 @@ class LocalJob(threading.Thread):
         self,
         name,
         command: list | tuple[str] | str,
-        execution_dir: str = None,
-        env: dict[str, str] = None,
-        dependencies: list = None,
+        execution_dir: str | None = None,
+        env: dict[str, str] | None = None,
+        dependencies: list | None = None,
     ):
         """Creates a LocalJob.
 

--- a/kubeflow/trainer/backends/localprocess/job.py
+++ b/kubeflow/trainer/backends/localprocess/job.py
@@ -26,10 +26,10 @@ class LocalJob(threading.Thread):
     def __init__(
         self,
         name,
-        command: list | tuple[str] | str,
+        command: list[str] | tuple[str, ...],
         execution_dir: str | None = None,
         env: dict[str, str] | None = None,
-        dependencies: list | None = None,
+        dependencies: list["LocalJob"] | None = None,
     ):
         """Creates a LocalJob.
 

--- a/kubeflow/trainer/backends/localprocess/types.py
+++ b/kubeflow/trainer/backends/localprocess/types.py
@@ -16,7 +16,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from kubeflow.trainer.backends.localprocess.job import LocalJob
 from kubeflow.trainer.types import types
@@ -40,7 +40,7 @@ class LocalBackendStep(BaseModel):
 
 
 class LocalBackendJobs(BaseModel):
-    steps: list[LocalBackendStep] | None = []
+    steps: list[LocalBackendStep] = Field(default_factory=list)
     runtime: types.Runtime | None = None
     name: str
     created: datetime | None = None


### PR DESCRIPTION


**What this PR does / why we need it**:
Fixes a critical runtime bug in the `LocalProcess` backend where iterating over `_job[0].steps` could result in a `TypeError: 'NoneType' object is not iterable` if `steps` was passed as `None`. 

This PR modifies the `LocalBackendJobs` Pydantic model to properly enforce `steps` as an iterable list using `Field(default_factory=list)`, completely removing the `| None` ambiguity. Additionally, it cleans up a few related `invalid-parameter-default` type hinting errors in `job.py` flagged by the `ty check` analyzer.

**Which issue(s) this PR fixes**:
Fixes #569

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
- [x] Tested locally (Ran `make verify`, `uv run ty check`, and `make test-python`)


