### PR TITLE
fix(trainer): avoid scanning runtime sources twice on missing runtime

### DIFF
--- a/kubeflow/trainer/backends/container/runtime_loader.py
+++ b/kubeflow/trainer/backends/container/runtime_loader.py
@@ -624,10 +624,10 @@ def get_training_runtime_from_sources(name: str, sources: list[str]) -> base_typ
     Raises:
         ValueError: If the runtime is not found
     """
-    for rt in list_training_runtimes_from_sources(sources):
+    runtimes = list_training_runtimes_from_sources(sources)
+    for rt in runtimes:
         if rt.name == name:
             return rt
     raise ValueError(
-        f"Runtime '{name}' not found. Available runtimes: "
-        f"{[rt.name for rt in list_training_runtimes_from_sources(sources)]}"
+        f"Runtime '{name}' not found. Available runtimes: {[rt.name for rt in runtimes]}"
     )

--- a/kubeflow/trainer/backends/container/runtime_loader_test.py
+++ b/kubeflow/trainer/backends/container/runtime_loader_test.py
@@ -640,3 +640,65 @@ def test_parse_runtime_yaml_extracts_image(test_case):
     except Exception as e:
         assert type(e) is test_case.expected_error
     print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="get existing runtime",
+            expected_status=SUCCESS,
+            config={
+                "requested_name": constants.DEFAULT_TRAINING_RUNTIME,
+            },
+        ),
+        TestCase(
+            name="get missing runtime raises value error",
+            expected_status=FAILED,
+            config={
+                "requested_name": "nonexistent-runtime",
+            },
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_get_training_runtime_from_sources(test_case):
+    """
+    Test getting a single runtime by name.
+
+    The sources are only scanned once, even when the runtime is not found, to
+    avoid duplicating the (potentially network-bound) source lookup for the
+    error message.
+    """
+    print("Executing test:", test_case.name)
+    available_runtime = base_types.Runtime(
+        name=constants.DEFAULT_TRAINING_RUNTIME,
+        kind=base_types.RuntimeKind.TRAINING_RUNTIME,
+        trainer=base_types.RuntimeTrainer(
+            trainer_type=base_types.TrainerType.CUSTOM_TRAINER,
+            framework="torch",
+            num_nodes=1,
+            image="example.com/container",
+        ),
+    )
+    try:
+        with patch(
+            "kubeflow.trainer.backends.container.runtime_loader.list_training_runtimes_from_sources"
+        ) as mock_list:
+            mock_list.return_value = [available_runtime]
+
+            runtime = runtime_loader.get_training_runtime_from_sources(
+                test_case.config["requested_name"], ["github://kubeflow/trainer"]
+            )
+
+            assert test_case.expected_status == SUCCESS
+            assert runtime.name == test_case.config["requested_name"]
+            # Sources are scanned exactly once on the found path.
+            assert mock_list.call_count == 1
+
+    except Exception as e:
+        assert type(e) is test_case.expected_error
+        assert available_runtime.name in str(e)
+        # Sources must be scanned exactly once even on the not-found path.
+        assert mock_list.call_count == 1
+    print("test execution complete")


### PR DESCRIPTION

**What this PR does / why we need it**:

`get_training_runtime_from_sources()` in the container backend
(`kubeflow/trainer/backends/container/runtime_loader.py`) scanned the configured
runtime sources twice whenever a runtime name was not found: once to look the runtime
up, and then a second time inside the `ValueError` message just to build the "Available
runtimes" list.

That lookup is not cached in-process, and each source can do real work per call:

- `github://` sources fetch the GitHub tree and then one raw file per discovered
  runtime YAML,
- `http(s)://` sources fetch the URL,
- filesystem sources glob and parse every YAML on disk.

So a single request for an unknown or mistyped runtime name (for example
`train(runtime="torch-distributd")`) triggered the full source scan twice, doubling the
network fetches and YAML parsing before the error surfaced. With a cold or expired
on-disk cache, or a slow/unreachable source, that also doubles the latency and load.

The fix materializes the runtime list once and reuses it for both the name lookup and
the error message. The public signature, return value, and the exact error text are
unchanged. A regression test asserts the sources are scanned exactly once on both the
found and not-found paths.

**Which issue(s) this PR fixes**:

Fixes #

(No existing issue; self-identified fix. Behavior and the public API are unchanged.)

**Checklist:**

- [ ] Docs included if any changes are user facing

(No docs change: the public API, return value, and error message are all unchanged, so
nothing user-facing changed.)

---

## The change (for reviewer convenience)

`kubeflow/trainer/backends/container/runtime_loader.py` (`get_training_runtime_from_sources`):

```diff
-    for rt in list_training_runtimes_from_sources(sources):
+    runtimes = list_training_runtimes_from_sources(sources)
+    for rt in runtimes:
         if rt.name == name:
             return rt
     raise ValueError(
-        f"Runtime '{name}' not found. Available runtimes: "
-        f"{[rt.name for rt in list_training_runtimes_from_sources(sources)]}"
+        f"Runtime '{name}' not found. Available runtimes: {[rt.name for rt in runtimes]}"
     )
```

Plus a new parametrized regression test `test_get_training_runtime_from_sources` in
`kubeflow/trainer/backends/container/runtime_loader_test.py` (found + not-found cases)
that patches `list_training_runtimes_from_sources` and asserts `call_count == 1` on both
paths, and that the not-found path raises `ValueError` containing the available name.

Net: 6-line source change, +61 test lines.
