### PR TITLE
fix(trainer): validate HuggingFace storage_uri has both user and repo

### DIFF
--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -322,6 +322,19 @@ class BaseInitializer(abc.ABC):
     storage_uri: str
 
 
+def _validate_hf_storage_uri(storage_uri: str, entity: str) -> None:
+    """Validate an 'hf://<user_name>/<repo_name>' storage URI."""
+    if not storage_uri.startswith("hf://"):
+        raise ValueError(f"storage_uri must start with 'hf://', got {storage_uri}")
+
+    parsed = urlparse(storage_uri)
+    if not parsed.netloc or not parsed.path.strip("/"):
+        raise ValueError(
+            f"storage_uri: must have absolute path with 'hf://<user_name>/<{entity}>', got "
+            f"{storage_uri}"
+        )
+
+
 @dataclass
 class HuggingFaceDatasetInitializer(BaseInitializer):
     """Configuration for downloading datasets from HuggingFace Hub.
@@ -338,14 +351,7 @@ class HuggingFaceDatasetInitializer(BaseInitializer):
     def __post_init__(self):
         """Validate HuggingFaceDatasetInitializer parameters."""
 
-        if not self.storage_uri.startswith("hf://"):
-            raise ValueError(f"storage_uri must start with 'hf://', got {self.storage_uri}")
-
-        if urlparse(self.storage_uri).path == "":
-            raise ValueError(
-                "storage_uri: must have absolute path with 'hf://<user_name>/<dataset_name>', got "
-                f"{self.storage_uri}"
-            )
+        _validate_hf_storage_uri(self.storage_uri, "dataset_name")
 
 
 @dataclass
@@ -440,14 +446,7 @@ class HuggingFaceModelInitializer(BaseInitializer):
     def __post_init__(self):
         """Validate HuggingFaceModelInitializer parameters."""
 
-        if not self.storage_uri.startswith("hf://"):
-            raise ValueError(f"storage_uri must start with 'hf://', got {self.storage_uri}")
-
-        if urlparse(self.storage_uri).path == "":
-            raise ValueError(
-                "storage_uri: must have absolute path with 'hf://<user_name>/<model_name>', got "
-                f"{self.storage_uri}"
-            )
+        _validate_hf_storage_uri(self.storage_uri, "model_name")
 
 
 @dataclass

--- a/kubeflow/trainer/types/types_test.py
+++ b/kubeflow/trainer/types/types_test.py
@@ -135,6 +135,18 @@ def test_data_cache_initializer(test_case: TestCase):
             config={"storage_uri": "hf://model"},
             expected_error=ValueError,
         ),
+        TestCase(
+            name="invalid storage_uri with user but no repo raises ValueError",
+            expected_status=FAILED,
+            config={"storage_uri": "hf://user/"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid storage_uri with empty user raises ValueError",
+            expected_status=FAILED,
+            config={"storage_uri": "hf:///model"},
+            expected_error=ValueError,
+        ),
     ],
 )
 def test_hugging_face_model_initializer(test_case: TestCase):
@@ -143,6 +155,58 @@ def test_hugging_face_model_initializer(test_case: TestCase):
 
     try:
         initializer = types.HuggingFaceModelInitializer(
+            storage_uri=test_case.config["storage_uri"],
+        )
+
+        assert test_case.expected_status == SUCCESS
+        assert initializer.storage_uri == test_case.config["storage_uri"]
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert type(e) is test_case.expected_error
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid storage_uri with user and dataset",
+            expected_status=SUCCESS,
+            config={"storage_uri": "hf://user/dataset"},
+        ),
+        TestCase(
+            name="invalid storage_uri without hf prefix raises ValueError",
+            expected_status=FAILED,
+            config={"storage_uri": "user/dataset"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid storage_uri without repo path raises ValueError",
+            expected_status=FAILED,
+            config={"storage_uri": "hf://dataset"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid storage_uri with user but no repo raises ValueError",
+            expected_status=FAILED,
+            config={"storage_uri": "hf://user/"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid storage_uri with empty user raises ValueError",
+            expected_status=FAILED,
+            config={"storage_uri": "hf:///dataset"},
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_hugging_face_dataset_initializer(test_case: TestCase):
+    """Test HuggingFaceDatasetInitializer creation and validation."""
+    print("Executing test:", test_case.name)
+
+    try:
+        initializer = types.HuggingFaceDatasetInitializer(
             storage_uri=test_case.config["storage_uri"],
         )
 


### PR DESCRIPTION
## What this does

Follow-up to #564. The HuggingFace initializers only rejected a `storage_uri` with an empty path, so URIs missing either component were still accepted and only failed later at download time:

* `hf://user/` (no repo name)
* `hf:///model` (no user name)

`HuggingFaceDatasetInitializer` also had no test coverage for its validation.

## The fix

Consolidate the validation into a shared `_validate_hf_storage_uri` helper used by both `HuggingFaceModelInitializer` and `HuggingFaceDatasetInitializer`, requiring a non-empty user and repo. Valid URIs such as `hf://user/model` are unchanged.

## Testing

* Added a parametrized test for `HuggingFaceDatasetInitializer` (previously uncovered) and new rejected-form cases for both initializers.
* `make test-python`: 404 passed.
* `make verify`: all checks passed.
