### PR TITLE
fix(docs): fix malformed RST hyperlink in Spark installation guide

### DIFF
--- a/docs/source/spark/index.rst
+++ b/docs/source/spark/index.rst
@@ -31,7 +31,7 @@ To use Spark with the Kubeflow SDK, install the Spark dependencies:
 
    pip install "kubeflow[spark]"
 
-For full setup instructions, see `the Spark installation guide. <https://www.kubeflow.org/docs/components/spark-operator/getting-started/>` _
+For full setup instructions, see `the Spark installation guide <https://www.kubeflow.org/docs/components/spark-operator/getting-started/>`_.
 
 Quick Example
 -------------


### PR DESCRIPTION
Fixes #565

## What this PR does
Fixes a malformed reStructuredText hyperlink in `docs/source/spark/index.rst` that was rendering as raw markup instead of a clickable link on the live docs page.

## Root cause
There was a stray space between the closing backtick and the trailing underscore (`` ` _ `` instead of `` `_ ``), which caused Docutils/Sphinx to fall back to parsing the text as a `title_reference` (plain text) instead of an external hyperlink reference. The trailing period was also inside the link text, which would've made it part of the clickable link.

## Fix
- Removed the stray space so the reference follows valid RST syntax: `` `link text <url>`_ ``
- Moved the trailing period outside the link text

## Verification
- Grepped `docs/source/` for the same `` `_ `` pattern to check for other occurrences — this was the only one in the repo.
- Verified with `docutils` directly that the fixed markup now parses into a proper `<reference>` node pointing at the correct URL, whereas the original markup parsed as a `<title_reference>` (matching the reported bug).

/cc @tariq-hasan @andreyvelich @kramaranya 
