### PR TITLE
fix: align SparkConnectState with operator states

### DIFF
--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -258,7 +258,7 @@ class KubernetesBackend(RuntimeBackend):
         while True:
             info = self.get_session(name)
 
-            if info.state in (SparkConnectState.READY, SparkConnectState.RUNNING):
+            if info.state == SparkConnectState.READY:
                 logger.info(
                     "Session ready: %s/%s state=%s serviceName=%s (%.0fs)",
                     self.namespace,

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -282,12 +282,12 @@ def get_spark_connect_info_from_cr(
         raise ValueError(f"SparkConnect CR is invalid: {spark_connect_cr}")
 
     # Parse state
-    state = SparkConnectState.PROVISIONING
-    if spark_connect_cr.status and spark_connect_cr.status.state:
+    state = SparkConnectState.NEW
+    if spark_connect_cr.status and spark_connect_cr.status.state is not None:
         try:
             state = SparkConnectState(spark_connect_cr.status.state)
         except ValueError:
-            state = SparkConnectState.PROVISIONING
+            state = SparkConnectState.NEW
 
     # Extract server status
     server_status = None

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -361,25 +361,25 @@ class TestGetSparkConnectInfoFromCr:
 
         assert info.state == SparkConnectState.FAILED
 
-    def test_parse_running_status(self, minimal_spec):
-        """Parse CR with Running state (operator may set this when server is up)."""
+    def test_parse_new_status(self, minimal_spec):
+        """Parse CR with operator New state."""
         spark_connect_cr = models.SparkV1alpha1SparkConnect(
             metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
-                name="run-session",
+                name="new-session",
                 namespace="default",
             ),
             spec=minimal_spec,
             status=models.SparkV1alpha1SparkConnectStatus(
-                state="Running",
+                state="",
                 server=models.SparkV1alpha1SparkConnectServerStatus(
-                    podName="run-session-server",
-                    serviceName="run-session-svc",
+                    podName="new-session-server",
+                    serviceName="new-session-svc",
                 ),
             ),
         )
         info = get_spark_connect_info_from_cr(spark_connect_cr)
-        assert info.state == SparkConnectState.RUNNING
-        assert info.service_name == "run-session-svc"
+        assert info.state == SparkConnectState.NEW
+        assert info.service_name == "new-session-svc"
 
     def test_parse_empty_status(self, minimal_spec):
         """Parse CR with empty status."""
@@ -392,7 +392,7 @@ class TestGetSparkConnectInfoFromCr:
         )
         info = get_spark_connect_info_from_cr(spark_connect_cr)
 
-        assert info.state == SparkConnectState.PROVISIONING
+        assert info.state == SparkConnectState.NEW
         assert info.driver_pod_name is None
 
     def test_invalid_cr_missing_name_raises_error(self, minimal_spec):

--- a/kubeflow/spark/types/types.py
+++ b/kubeflow/spark/types/types.py
@@ -22,9 +22,9 @@ from enum import Enum
 class SparkConnectState(str, Enum):
     """State of a SparkConnect session."""
 
+    NEW = ""  # Operator "New" state is the empty string; avoid truthiness checks.
     PROVISIONING = "Provisioning"
     READY = "Ready"
-    RUNNING = "Running"  # Operator may set this when server is up; treated as ready
     NOT_READY = "NotReady"
     FAILED = "Failed"
 

--- a/kubeflow/spark/types/types_test.py
+++ b/kubeflow/spark/types/types_test.py
@@ -29,9 +29,9 @@ class TestSparkConnectState:
 
     def test_enum_values(self):
         """T01: Verify SparkConnectState enum has expected values."""
+        assert SparkConnectState.NEW == ""
         assert SparkConnectState.PROVISIONING == "Provisioning"
         assert SparkConnectState.READY == "Ready"
-        assert SparkConnectState.RUNNING == "Running"
         assert SparkConnectState.NOT_READY == "NotReady"
         assert SparkConnectState.FAILED == "Failed"
 

--- a/test/e2e/spark/test_spark_examples.py
+++ b/test/e2e/spark/test_spark_examples.py
@@ -111,7 +111,11 @@ def test_spark_connect_crd_smoke():
     info = backend._create_session(options=[Name(name)])
     assert info.name == name
     assert info.namespace == namespace
-    assert info.state in (SparkConnectState.PROVISIONING, SparkConnectState.READY)
+    assert info.state in (
+        SparkConnectState.NEW,
+        SparkConnectState.PROVISIONING,
+        SparkConnectState.READY,
+    )
     assert backend.get_session(name).name == name
     backend.delete_session(name)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Aligns the SDK `SparkConnectState` enum with the Spark Operator state model by adding the missing `NEW` state (`""`) and removing the SDK-only `RUNNING` state. Empty, missing, or unknown SparkConnect status values now map to `NEW`, and readiness checks only treat `READY` as ready.

**Which issue(s) this PR fixes** *(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)*:

Fixes #572

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing