### PR TITLE
fix(trainer): Move TrainJob cleanup to finally block in get_runtime_packages

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -267,7 +267,9 @@ class KubernetesBackend(RuntimeBackend):
                 trainer=types.CustomTrainer(
                     func=print_packages,
                     num_nodes=1,
-                    resources_per_node=({"cpu": 1} if runtime_copy.trainer.device != "gpu" else None),
+                    resources_per_node=(
+                        {"cpu": 1} if runtime_copy.trainer.device != "gpu" else None
+                    ),
                 ),
             )
             self.wait_for_job_status(job_name)

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -276,7 +276,14 @@ class KubernetesBackend(RuntimeBackend):
             print("\n".join(self.get_job_logs(name=job_name)))
         finally:
             if job_name is not None:
-                self.delete_job(job_name)
+                try:
+                    self.delete_job(job_name)
+                except Exception:
+                    logger.exception(
+                        "Failed to delete temporary TrainJob %s/%s created by get_runtime_packages",
+                        self.namespace,
+                        job_name,
+                    )
 
     def train(
         self,

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -260,18 +260,21 @@ class KubernetesBackend(RuntimeBackend):
 
         # Create the TrainJob and wait until it completes.
         # If Runtime trainer has GPU resources use them, otherwise run TrainJob with 1 CPU.
-        job_name = self.train(
-            runtime=runtime_copy,
-            trainer=types.CustomTrainer(
-                func=print_packages,
-                num_nodes=1,
-                resources_per_node=({"cpu": 1} if runtime_copy.trainer.device != "gpu" else None),
-            ),
-        )
-
-        self.wait_for_job_status(job_name)
-        print("\n".join(self.get_job_logs(name=job_name)))
-        self.delete_job(job_name)
+        job_name = None
+        try:
+            job_name = self.train(
+                runtime=runtime_copy,
+                trainer=types.CustomTrainer(
+                    func=print_packages,
+                    num_nodes=1,
+                    resources_per_node=({"cpu": 1} if runtime_copy.trainer.device != "gpu" else None),
+                ),
+            )
+            self.wait_for_job_status(job_name)
+            print("\n".join(self.get_job_logs(name=job_name)))
+        finally:
+            if job_name is not None:
+                self.delete_job(job_name)
 
     def train(
         self,

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -1037,11 +1037,9 @@ def test_list_runtimes(kubernetes_backend, test_case):
         ),
     ],
 )
-def test_get_runtime_packages(kubernetes_backend, mocker, test_case):
+def test_get_runtime_packages(kubernetes_backend, test_case):
     """Test KubernetesBackend.get_runtime_packages with basic success path."""
     print("Executing test:", test_case.name)
-    spy_train = mocker.spy(kubernetes_backend, "train")
-    spy_delete_job = mocker.spy(kubernetes_backend, "delete_job")
 
     try:
         kubernetes_backend.get_runtime_packages(**test_case.config)
@@ -1049,10 +1047,9 @@ def test_get_runtime_packages(kubernetes_backend, mocker, test_case):
         assert type(e) is test_case.expected_error
 
     if test_case.expected_status == SUCCESS:
-        job_name = spy_train.spy_return
-        spy_delete_job.assert_called_with(job_name)
+        kubernetes_backend.custom_api.delete_namespaced_custom_object.assert_called_once()
     else:
-        spy_delete_job.assert_not_called()
+        kubernetes_backend.custom_api.delete_namespaced_custom_object.assert_not_called()
 
     print("test execution complete")
 

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -1037,14 +1037,22 @@ def test_list_runtimes(kubernetes_backend, test_case):
         ),
     ],
 )
-def test_get_runtime_packages(kubernetes_backend, test_case):
+def test_get_runtime_packages(kubernetes_backend, mocker, test_case):
     """Test KubernetesBackend.get_runtime_packages with basic success path."""
     print("Executing test:", test_case.name)
+    spy_train = mocker.spy(kubernetes_backend, "train")
+    spy_delete_job = mocker.spy(kubernetes_backend, "delete_job")
 
     try:
         kubernetes_backend.get_runtime_packages(**test_case.config)
     except Exception as e:
         assert type(e) is test_case.expected_error
+
+    if test_case.expected_status == SUCCESS:
+        job_name = spy_train.spy_return
+        spy_delete_job.assert_called_with(job_name)
+    else:
+        spy_delete_job.assert_not_called()
 
     print("test execution complete")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This PR moves temporary TrainJob cleanup into a finally block in get_runtime_packages()`.

Previously, if  wait_for_job_status()  or  get_job_logs()  raised an exception, the temporary TrainJob would not be deleted. This change ensures that  delete_job()  is always called after a TrainJob has been created, preventing temporary TrainJobs from being left behind when an error occurs.

**Which issue(s) this PR fixes**:

Fixes #580


**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
