### PR TITLE
fix(trainer): log LocalJob completed output correctly

### DIFF
--- a/kubeflow/trainer/backends/localprocess/job.py
+++ b/kubeflow/trainer/backends/localprocess/job.py
@@ -119,7 +119,7 @@ class LocalJob(threading.Thread):
                 constants.TRAINJOB_COMPLETE if self._success else (constants.TRAINJOB_FAILED)
             )
             self._stdout += msg
-            logger.debug("Job output: ", self._stdout)
+            logger.debug(f"Job output: {self._stdout}")
 
         except Exception as e:
             with self._lock:

--- a/kubeflow/trainer/backends/localprocess/job.py
+++ b/kubeflow/trainer/backends/localprocess/job.py
@@ -119,7 +119,7 @@ class LocalJob(threading.Thread):
                 constants.TRAINJOB_COMPLETE if self._success else (constants.TRAINJOB_FAILED)
             )
             self._stdout += msg
-            logger.debug(f"Job output: {self._stdout}")
+            logger.debug("Job output: %s", self._stdout)
 
         except Exception as e:
             with self._lock:

--- a/kubeflow/trainer/backends/localprocess/job_test.py
+++ b/kubeflow/trainer/backends/localprocess/job_test.py
@@ -1,0 +1,83 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the LocalJob class in the Kubeflow Trainer SDK.
+"""
+
+import logging
+import sys
+
+import pytest
+
+from kubeflow.trainer.backends.localprocess import job as job_module
+from kubeflow.trainer.backends.localprocess.job import LocalJob
+from kubeflow.trainer.constants import constants
+
+
+def test_run_logs_job_output_at_debug(caplog, monkeypatch):
+    """LocalJob.run() must log the completed job output without a logging error.
+
+    Regression test for the debug log using printf-style arguments without a
+    format placeholder, which raised TypeError at record-format time (swallowed
+    by logging.Handler.handleError) instead of logging the job output.
+    """
+    marker = "kubeflow-local-job-output-marker"
+
+    # Any logging-format failure is normally swallowed by Handler.handleError; make
+    # it fail the test loudly so a broken log call cannot pass silently.
+    def fail_on_handle_error(self, record):
+        raise AssertionError("logging raised while formatting the job output record")
+
+    monkeypatch.setattr(logging.Handler, "handleError", fail_on_handle_error)
+
+    job = LocalJob(name="test-job", command=[sys.executable, "-c", f"print('{marker}')"])
+
+    with caplog.at_level(logging.DEBUG, logger=job_module.logger.name):
+        job.run()
+
+    assert job.status == constants.TRAINJOB_COMPLETE
+    assert any(
+        record.getMessage() == f"Job output: {job.stdout}"
+        for record in caplog.records
+        if record.levelno == logging.DEBUG
+    )
+
+
+@pytest.mark.parametrize(
+    "stdout_fragment",
+    [
+        "plain output",
+        "100% done",
+        "value {with braces}",
+    ],
+)
+def test_run_debug_log_formats_with_percent_in_output(caplog, monkeypatch, stdout_fragment):
+    """The debug log must format even when the job output contains a percent sign."""
+
+    def fail_on_handle_error(self, record):
+        raise AssertionError("logging raised while formatting the job output record")
+
+    monkeypatch.setattr(logging.Handler, "handleError", fail_on_handle_error)
+
+    job = LocalJob(
+        name="test-job",
+        command=[sys.executable, "-c", f"print({stdout_fragment!r})"],
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=job_module.logger.name):
+        job.run()
+
+    assert job.status == constants.TRAINJOB_COMPLETE
+    assert stdout_fragment in job.stdout


### PR DESCRIPTION

**What this PR does / why we need it**:

`LocalJob.run()` logs the completed job's output with a `logger.debug` call that
passes the output as a printf-style positional argument, but the message
template has no `%` placeholder:

```python
logger.debug("Job output: ", self._stdout)
```

Python's `logging` treats the second positional argument as a `%`-format
argument for the message. Because `"Job output: "` contains no format specifier,
formatting the record runs `"Job output: " % (self._stdout,)`, which raises
`TypeError: not all arguments converted during string formatting` when the
record is formatted. The standard library catches this in
`logging.Handler.handleError` and writes the traceback to `stderr` instead of
emitting the record. The result is that the job's stdout is silently dropped
from the debug log, and with `DEBUG` logging enabled a logging-error traceback
is printed for every completed local job.

This changes the call to an f-string so the output is logged correctly:

```python
logger.debug(f"Job output: {self._stdout}")
```

This matches the f-string debug logging already used in the same method (for
example the "Started at ..." log a few lines above) and formats correctly even
when the captured output contains `%`, `{`, or `}` characters.

Scope: one line in the LocalProcess backend's success path. No change to job
execution behavior, only to what the debug log emits.

A colocated regression test (`job_test.py`) runs a trivial real subprocess and
patches `logging.Handler.handleError` to raise, so any logging-format failure
fails the test loudly instead of being swallowed. It asserts the job completes
and the `Job output: ...` record is emitted, and parametrizes output containing
a percent sign and braces.

**Which issue(s) this PR fixes**:

Fixes #

(No existing issue; self-identified bug.)

**Checklist:**

- [ ] Docs included if any changes are user facing  *(n/a - internal debug log
  only, no user-facing change)*
