### PR TITLE
fix(trainer): validate LoraConfig params and correctly pass falsy-but…

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -497,11 +497,11 @@ def get_args_using_torchtune_config(
         args.append(f"dtype={fine_tuning_config.dtype.value}")
 
     # Override the batch size if it is provided.
-    if fine_tuning_config.batch_size:
+    if fine_tuning_config.batch_size is not None:
         args.append(f"batch_size={fine_tuning_config.batch_size}")
 
     # Override the epochs if it is provided.
-    if fine_tuning_config.epochs:
+    if fine_tuning_config.epochs is not None:
         args.append(f"epochs={fine_tuning_config.epochs}")
 
     # Override the loss if it is provided.
@@ -563,8 +563,7 @@ def get_args_from_peft_config(peft_config: types.LoraConfig) -> list[str]:
             args.append(f"{arg_name}={value}")
 
     # Override the LoRA attention modules if they are provided.
-    if peft_config.lora_attn_modules:
-        args.append(f"model.lora_attn_modules=[{','.join(peft_config.lora_attn_modules)}]")
+    args.append(f"model.lora_attn_modules=[{','.join(peft_config.lora_attn_modules)}]")
 
     return args
 

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -794,6 +794,16 @@ def test_get_model_initializer(test_case):
             ],
         ),
         TestCase(
+            name="lora_attn_modules empty list is not silently dropped",
+            expected_status=SUCCESS,
+            config={
+                "peft_config": types.LoraConfig(lora_attn_modules=[]),
+            },
+            expected_output=[
+                "model.lora_attn_modules=[]",
+            ],
+        ),
+        TestCase(
             name="invalid peft config type raises ValueError",
             expected_status=FAILED,
             config={
@@ -913,6 +923,30 @@ def _build_builtin_runtime() -> types.Runtime:
                 "batch_size=8",
                 "epochs=3",
                 "loss=torchtune.modules.loss.CEWithChunkedOutputLoss",
+            ],
+        ),
+        TestCase(
+            name="batch_size=0 is not silently dropped",
+            expected_status=SUCCESS,
+            config={
+                "fine_tuning_config": types.TorchTuneConfig(
+                    batch_size=0,
+                ),
+            },
+            expected_output=[
+                "batch_size=0",
+            ],
+        ),
+        TestCase(
+            name="epochs=0 is not silently dropped",
+            expected_status=SUCCESS,
+            config={
+                "fine_tuning_config": types.TorchTuneConfig(
+                    epochs=0,
+                ),
+            },
+            expected_output=[
+                "epochs=0",
             ],
         ),
         TestCase(

--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -186,6 +186,17 @@ class LoraConfig:
     quantize_base: bool | None = None
     use_dora: bool | None = None
 
+    def __post_init__(self):
+        """Validate LoraConfig parameters."""
+        if self.lora_rank is not None and self.lora_rank <= 0:
+            raise ValueError(f"lora_rank must be greater than 0, got {self.lora_rank}")
+        if self.lora_alpha is not None and self.lora_alpha <= 0:
+            raise ValueError(f"lora_alpha must be greater than 0, got {self.lora_alpha}")
+        if self.lora_dropout is not None and not (0.0 <= self.lora_dropout <= 1.0):
+            raise ValueError(
+                f"lora_dropout must be between 0.0 and 1.0, got {self.lora_dropout}"
+            )
+
 
 # Configuration for the TorchTune LLM Trainer.
 @dataclass

--- a/kubeflow/trainer/types/types_test.py
+++ b/kubeflow/trainer/types/types_test.py
@@ -217,3 +217,96 @@ def test_hugging_face_dataset_initializer(test_case: TestCase):
         assert test_case.expected_status == FAILED
         assert type(e) is test_case.expected_error
     print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid lora config with positive values",
+            expected_status=SUCCESS,
+            config={
+                "lora_rank": 8,
+                "lora_alpha": 16,
+                "lora_dropout": 0.5,
+            },
+        ),
+        TestCase(
+            name="valid lora config with boundary dropout=0.0",
+            expected_status=SUCCESS,
+            config={
+                "lora_dropout": 0.0,
+            },
+        ),
+        TestCase(
+            name="valid lora config with boundary dropout=1.0",
+            expected_status=SUCCESS,
+            config={
+                "lora_dropout": 1.0,
+            },
+        ),
+        TestCase(
+            name="invalid lora_rank negative raises ValueError",
+            expected_status=FAILED,
+            config={
+                "lora_rank": -8,
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid lora_rank zero raises ValueError",
+            expected_status=FAILED,
+            config={
+                "lora_rank": 0,
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid lora_alpha negative raises ValueError",
+            expected_status=FAILED,
+            config={
+                "lora_alpha": -1,
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid lora_alpha zero raises ValueError",
+            expected_status=FAILED,
+            config={
+                "lora_alpha": 0,
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid lora_dropout above 1.0 raises ValueError",
+            expected_status=FAILED,
+            config={
+                "lora_dropout": 1.5,
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid lora_dropout negative raises ValueError",
+            expected_status=FAILED,
+            config={
+                "lora_dropout": -0.1,
+            },
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_lora_config_validation(test_case: TestCase):
+    """Test LoraConfig creation and validation."""
+    print("Executing test:", test_case.name)
+
+    try:
+        config = types.LoraConfig(**test_case.config)
+
+        assert test_case.expected_status == SUCCESS
+        for key in test_case.config:
+            assert getattr(config, key) == test_case.config[key]
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert type(e) is test_case.expected_error
+    print("test execution complete")


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes two related bugs in the TorchTune LoRA/PEFT configuration:

1. `LoraConfig` now validates hyperparameters at construction time, raising clear `ValueError` for `lora_rank <= 0`, `lora_alpha <= 0`, and `lora_dropout` outside `[0.0, 1.0]`. Previously these were accepted silently and surfaced later as opaque TorchTune runtime failures.

2. Argument-building utilities now use `is not None` instead of truthiness checks for `batch_size` and `epochs`, and always emit `lora_attn_modules`. Previously, explicitly-set falsy values (`batch_size=0`, `epochs=0`, `lora_attn_modules=[]`) were silently dropped with no error or indication.

**Which issue(s) this PR fixes**:

Fixes #579