### PR TITLE
feat(spark): consolidate connect API with typed session modes

### DIFF
--- a/examples/spark/connect_existing_session.py
+++ b/examples/spark/connect_existing_session.py
@@ -32,7 +32,7 @@ import sys
 import uuid
 
 from kubeflow.common.types import KubernetesBackendConfig
-from kubeflow.spark import Name, SparkClient
+from kubeflow.spark import ExistingSession, Name, NewSession, SparkClient
 from kubeflow.spark.backends.kubernetes.utils import build_service_url
 
 
@@ -65,7 +65,11 @@ def test_connect_to_existing_session():
         # Phase 1: Setup client creates SparkConnect server
         print("\n[Phase 1] Creating SparkConnect server...")
         setup_client = SparkClient(backend_config=_backend_config())
-        setup_spark = setup_client.connect(options=[Name(session_name)], timeout=180)
+        setup_spark = setup_client.connect(
+            session=NewSession(),
+            options=[Name(session_name)],
+            timeout=180,
+        )
 
         info = setup_client.get_session(session_name)
         service_url = build_service_url(info)
@@ -75,10 +79,10 @@ def test_connect_to_existing_session():
         setup_spark.stop()
         print("   Setup SparkSession stopped (server still running)")
 
-        # Phase 2: Test client connects via base_url
-        print("\n[Phase 2] Connecting via base_url...")
+        # Phase 2: Test client connects via ExistingSession
+        print("\n[Phase 2] Connecting via ExistingSession...")
         test_client = SparkClient(backend_config=_backend_config())
-        test_spark = test_client.connect(base_url=service_url)
+        test_spark = test_client.connect(session=ExistingSession(base_url=service_url))
         print("   Connected successfully!")
 
         # Phase 3: Validate with Spark operations
@@ -87,7 +91,7 @@ def test_connect_to_existing_session():
         print(f"   spark.range(100).count() = {count}")
         assert count == 100, f"Expected 100, got {count}"
 
-        print("\n[SUCCESS] connect(base_url=...) works correctly!")
+        print("\n[SUCCESS] ExistingSession connect works correctly!")
 
     finally:
         # Phase 4: Cleanup

--- a/examples/spark/spark_advanced_options.py
+++ b/examples/spark/spark_advanced_options.py
@@ -23,6 +23,7 @@ from kubeflow.spark import (
     # Options for advanced Kubernetes configuration
     Labels,
     Name,
+    NewSession,
     NodeSelector,
     PodTemplateOverride,
     SparkClient,
@@ -55,9 +56,11 @@ def example_labels_and_annotations():
     client = SparkClient(backend_config=_backend_config())
 
     spark = client.connect(
-        num_executors=3,
-        resources_per_executor={"cpu": "2", "memory": "4Gi"},
-        spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
+        session=NewSession(
+            num_executors=3,
+            resources_per_executor={"cpu": "2", "memory": "4Gi"},
+            spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
+        ),
         options=[
             Labels(
                 {
@@ -102,13 +105,15 @@ def example_node_selection():
     client = SparkClient(backend_config=_backend_config())
 
     spark = client.connect(
-        num_executors=5,
-        resources_per_executor={
-            "cpu": "4",
-            "memory": "16Gi",
-            "nvidia.com/gpu": "1",  # Request GPU
-        },
-        spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
+        session=NewSession(
+            num_executors=5,
+            resources_per_executor={
+                "cpu": "4",
+                "memory": "16Gi",
+                "nvidia.com/gpu": "1",  # Request GPU
+            },
+            spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
+        ),
         options=[
             NodeSelector(
                 {
@@ -142,9 +147,11 @@ def example_tolerations():
     client = SparkClient(backend_config=_backend_config())
 
     spark = client.connect(
-        num_executors=10,
-        resources_per_executor={"cpu": "8", "memory": "32Gi"},
-        spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
+        session=NewSession(
+            num_executors=10,
+            resources_per_executor={"cpu": "8", "memory": "32Gi"},
+            spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
+        ),
         options=[
             # Tolerate nodes tainted for Spark workloads
             Toleration(
@@ -187,13 +194,15 @@ def example_pod_template_override():
     client = SparkClient(backend_config=_backend_config())
 
     spark = client.connect(
-        driver=Driver(resources={"cpu": "2", "memory": "4Gi"}),
-        executor=Executor(
-            num_instances=5,
-            resources_per_executor={"cpu": "4", "memory": "8Gi"},
+        session=NewSession(
+            spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
         ),
-        spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
         options=[
+            Driver(resources={"cpu": "2", "memory": "4Gi"}),
+            Executor(
+                num_instances=5,
+                resources_per_executor={"cpu": "4", "memory": "8Gi"},
+            ),
             # Add security context to executors
             PodTemplateOverride(
                 role="executor",
@@ -244,9 +253,11 @@ def example_name_option():
     client = SparkClient(backend_config=_backend_config())
 
     spark = client.connect(
-        num_executors=3,
-        resources_per_executor={"cpu": "2", "memory": "4Gi"},
-        spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
+        session=NewSession(
+            num_executors=3,
+            resources_per_executor={"cpu": "2", "memory": "4Gi"},
+            spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
+        ),
         options=[
             Name(_e2e_session_name("custom-session-name")),
             Labels({"app": "spark", "team": "data-eng"}),
@@ -276,22 +287,24 @@ def example_combined_options():
     client = SparkClient(backend_config=_backend_config("spark-production"))
 
     spark = client.connect(
-        driver=Driver(
-            resources={"cpu": "4", "memory": "8Gi"},
-            service_account="spark-driver-prod",
+        session=NewSession(
+            spark_conf={
+                "spark.app.name": "prod-etl-pipeline",
+                "spark.sql.adaptive.enabled": "true",
+                "spark.sql.adaptive.coalescePartitions.enabled": "true",
+                "spark.dynamicAllocation.enabled": "false",
+                "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
+            },
         ),
-        executor=Executor(
-            num_instances=20,
-            resources_per_executor={"cpu": "8", "memory": "32Gi"},
-        ),
-        spark_conf={
-            "spark.app.name": "prod-etl-pipeline",
-            "spark.sql.adaptive.enabled": "true",
-            "spark.sql.adaptive.coalescePartitions.enabled": "true",
-            "spark.dynamicAllocation.enabled": "false",
-            "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
-        },
         options=[
+            Driver(
+                resources={"cpu": "4", "memory": "8Gi"},
+                service_account="spark-driver-prod",
+            ),
+            Executor(
+                num_instances=20,
+                resources_per_executor={"cpu": "8", "memory": "32Gi"},
+            ),
             # Custom session name
             Name(_e2e_session_name("prod-etl-session")),
             # Organization and cost tracking

--- a/examples/spark/spark_connect_simple.py
+++ b/examples/spark/spark_connect_simple.py
@@ -24,7 +24,7 @@ import os
 import uuid
 
 from kubeflow.common.types import KubernetesBackendConfig
-from kubeflow.spark import Driver, Executor, Name, SparkClient
+from kubeflow.spark import Driver, Executor, Name, NewSession, SparkClient
 
 
 def _e2e_session_name(base: str) -> str:
@@ -59,7 +59,9 @@ def example_level1_minimal():
     # Use Name option to track session for cleanup
     session_name = _e2e_session_name("spark-connect-minimal")
     spark = client.connect(
-        spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
+        session=NewSession(
+            spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
+        ),
         options=[Name(session_name)],
     )
 
@@ -92,12 +94,14 @@ def example_level2_simple():
     client = SparkClient(backend_config=_backend_config())
     session_name = _e2e_session_name("my-simple-session")
     spark = client.connect(
-        num_executors=5,
-        resources_per_executor={"cpu": "2", "memory": "4Gi"},
-        spark_conf={
-            "spark.sql.adaptive.enabled": "true",
-            "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
-        },
+        session=NewSession(
+            num_executors=5,
+            resources_per_executor={"cpu": "2", "memory": "4Gi"},
+            spark_conf={
+                "spark.sql.adaptive.enabled": "true",
+                "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
+            },
+        ),
         options=[Name(session_name)],
     )
 
@@ -131,25 +135,29 @@ def example_level3_advanced():
     session_name = _e2e_session_name("advanced-session-name")
 
     spark = client.connect(
-        driver=Driver(
-            resources={"cpu": "1", "memory": "2Gi"},
-            # service_account="spark-driver",  # Optional: custom service account
-        ),
-        executor=Executor(
-            num_instances=2,  # Reduced for Kind cluster compatibility
-            resources_per_executor={
-                "cpu": "1",
-                "memory": "2Gi",
-                # Add GPU if needed: "nvidia.com/gpu": "1"
+        session=NewSession(
+            spark_conf={
+                "spark.app.name": "advanced-spark-app",
+                "spark.sql.adaptive.enabled": "true",
+                "spark.sql.adaptive.coalescePartitions.enabled": "true",
+                "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
             },
         ),
-        spark_conf={
-            "spark.app.name": "advanced-spark-app",
-            "spark.sql.adaptive.enabled": "true",
-            "spark.sql.adaptive.coalescePartitions.enabled": "true",
-            "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
-        },
-        options=[Name(session_name)],
+        options=[
+            Name(session_name),
+            Driver(
+                resources={"cpu": "1", "memory": "2Gi"},
+                # service_account="spark-driver",  # Optional: custom service account
+            ),
+            Executor(
+                num_instances=2,  # Reduced for Kind cluster compatibility
+                resources_per_executor={
+                    "cpu": "1",
+                    "memory": "2Gi",
+                    # Add GPU if needed: "nvidia.com/gpu": "1"
+                },
+            ),
+        ],
     )
 
     # Use Spark - complex data operations
@@ -177,10 +185,10 @@ def example_connect_existing():
     SparkClient(backend_config=_backend_config())
 
     # Example URL - replace with your actual server URL
-    # spark = client.connect(base_url="sc://spark-server:15002")
+    # spark = client.connect(session=ExistingSession(base_url="sc://spark-server:15002"))
 
     print("\nTo connect to existing server, use:")
-    print('spark = client.connect(base_url="sc://spark-server:15002")')
+    print('spark = client.connect(session=ExistingSession(base_url="sc://spark-server:15002"))')
     print("\nExample shown.\n")
 
 
@@ -197,9 +205,11 @@ def example_with_namespace():
     client = SparkClient(backend_config=_backend_config("spark-jobs"))
 
     spark = client.connect(
-        num_executors=5,
-        resources_per_executor={"cpu": "4", "memory": "8Gi"},
-        spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
+        session=NewSession(
+            num_executors=5,
+            resources_per_executor={"cpu": "4", "memory": "8Gi"},
+            spark_conf={"spark.serializer": "org.apache.spark.serializer.KryoSerializer"},
+        ),
     )
 
     df = spark.range(50)

--- a/kubeflow/spark/__init__.py
+++ b/kubeflow/spark/__init__.py
@@ -27,8 +27,10 @@ from kubeflow.spark.types.options import (
 from kubeflow.spark.types.types import (
     Driver,
     Executor,
+    ExistingSession,
     FileJob,
     FuncJob,
+    NewSession,
     SparkConnectInfo,
     SparkConnectState,
     SparkJob,
@@ -40,9 +42,11 @@ __all__ = [
     "SparkClient",
     # Types
     "Driver",
+    "ExistingSession",
     "Executor",
     "FileJob",
     "FuncJob",
+    "NewSession",
     "SparkConnectInfo",
     "SparkConnectState",
     "SparkJob",

--- a/kubeflow/spark/api/spark_client.py
+++ b/kubeflow/spark/api/spark_client.py
@@ -15,6 +15,7 @@
 """SparkClient for Kubeflow SDK."""
 
 from collections.abc import Iterator
+import warnings
 
 from pyspark.sql import SparkSession
 
@@ -25,8 +26,10 @@ from kubeflow.spark.backends.kubernetes.utils import validate_spark_connect_url
 from kubeflow.spark.types.types import (
     Driver,
     Executor,
+    ExistingSession,
     FileJob,
     FuncJob,
+    NewSession,
     SparkConnectInfo,
     SparkJob,
     SparkJobStatus,
@@ -71,27 +74,44 @@ class SparkClient:
         options: list | None = None,
         timeout: int = 300,
         connect_timeout: int = 120,
+        *,
+        session: ExistingSession | NewSession | None = None,
     ) -> SparkSession:
         """Connect to or create a SparkConnect session.
 
-        This method supports two modes based on parameters:
-        - **Connect mode**: When `base_url` is provided, connects to an existing Spark Connect server
-        - **Create mode**: When `base_url` is not provided, creates a new Spark Connect session
+        Preferred usage uses typed session modes, symmetric with batch job modes:
+
+        - ``session=ExistingSession(...)``: connect to an existing Spark Connect server
+        - ``session=NewSession(...)``: create a new Spark Connect session
+
+        ``Driver`` and ``Executor`` should be passed through ``options``.
+
+        Legacy keyword arguments remain supported for compatibility and emit
+        deprecation warnings when used without ``session=``.
 
         Args:
-            base_url: Optional URL to existing Spark Connect server (e.g., "sc://server:15002").
-                 If provided, connects to existing server. If None, creates new session.
-            token: Optional authentication token for existing server.
+            base_url: Optional URL to existing Spark Connect server
+                (e.g., "sc://server:15002"). Deprecated in favor of
+                ``session=ExistingSession(base_url=...)``.
+            token: Optional authentication token for existing server. Deprecated in
+                favor of ``session=ExistingSession(..., token=...)``.
             num_executors: Number of executor instances (create mode only).
+                Deprecated in favor of ``session=NewSession(num_executors=...)``.
             resources_per_executor: Resource requirements per executor as dict.
                 Format: `{"cpu": "5", "memory": "10Gi"}` (create mode only).
+                Deprecated in favor of ``session=NewSession(...)``.
             spark_conf: Spark configuration dictionary (create mode only).
-            driver: Driver configuration object (create mode only).
-            executor: Executor configuration object (create mode only).
+                Deprecated in favor of ``session=NewSession(spark_conf=...)``.
+            driver: Driver configuration object (create mode only). Deprecated in
+                favor of ``options=[Driver(...)]``.
+            executor: Executor configuration object (create mode only). Deprecated in
+                favor of ``options=[Executor(...)]``.
             options: List of configuration options (create mode only).
-                Use Name option for custom session name.
+                Use Name, Driver, Executor, and other options here.
             timeout: Timeout in seconds to wait for session ready.
-            connect_timeout: Timeout in seconds for SparkSession.getOrCreate() (create mode only).
+            connect_timeout: Timeout in seconds for SparkSession.getOrCreate()
+                (create mode only).
+            session: Typed connection mode. Use ``ExistingSession`` or ``NewSession``.
 
         Returns:
             SparkSession connected to Spark (self-managing).
@@ -104,23 +124,160 @@ class SparkClient:
         Note:
             Server port defaults to 15002 (Spark Connect gRPC). PySpark and server Spark
             major.minor should match; see constants and pyproject.toml [spark].
-        """
-        if base_url:
-            validate_spark_connect_url(base_url)
-            builder = SparkSession.builder.remote(base_url)
-            if token:
-                builder = builder.config("spark.connect.authenticate.token", token)
-            return builder.getOrCreate()
 
-        return self.backend.create_and_connect(
+        Examples:
+            # Connect to existing server
+            spark = client.connect(session=ExistingSession(base_url="sc://server:15002"))
+
+            # Create with simple parameters
+            spark = client.connect(
+                session=NewSession(
+                    num_executors=5,
+                    resources_per_executor={"cpu": "5", "memory": "10Gi"},
+                    spark_conf={"spark.sql.adaptive.enabled": "true"},
+                )
+            )
+
+            # Create with Driver/Executor options
+            spark = client.connect(
+                session=NewSession(),
+                options=[
+                    Driver(resources={"cpu": "2", "memory": "4Gi"}),
+                    Executor(
+                        num_instances=5,
+                        resources_per_executor={"cpu": "4", "memory": "8Gi"},
+                    ),
+                ],
+            )
+
+            # Minimal - use all defaults (auto-generated name)
+            spark = client.connect()
+        """
+        (
+            resolved_base_url,
+            resolved_token,
+            resolved_num_executors,
+            resolved_resources_per_executor,
+            resolved_spark_conf,
+            resolved_options,
+        ) = self._resolve_connect_args(
+            session=session,
+            options=options,
+            base_url=base_url,
+            token=token,
             num_executors=num_executors,
             resources_per_executor=resources_per_executor,
             spark_conf=spark_conf,
             driver=driver,
             executor=executor,
-            options=options,
+        )
+
+        if resolved_base_url:
+            validate_spark_connect_url(resolved_base_url)
+            builder = SparkSession.builder.remote(resolved_base_url)
+            if resolved_token:
+                builder = builder.config("spark.connect.authenticate.token", resolved_token)
+            return builder.getOrCreate()
+
+        return self.backend.create_and_connect(
+            num_executors=resolved_num_executors,
+            resources_per_executor=resolved_resources_per_executor,
+            spark_conf=resolved_spark_conf,
+            driver=None,
+            executor=None,
+            options=resolved_options,
             timeout=timeout,
             connect_timeout=connect_timeout,
+        )
+
+    def _resolve_connect_args(
+        self,
+        *,
+        session: ExistingSession | NewSession | None,
+        options: list | None,
+        base_url: str | None,
+        token: str | None,
+        num_executors: int | None,
+        resources_per_executor: dict[str, str] | None,
+        spark_conf: dict[str, str] | None,
+        driver: Driver | None,
+        executor: Executor | None,
+    ) -> tuple[
+        str | None,
+        str | None,
+        int | None,
+        dict[str, str] | None,
+        dict[str, str] | None,
+        list | None,
+    ]:
+        """Normalize typed session modes and legacy connect kwargs."""
+        legacy_connect = base_url is not None or token is not None
+        legacy_create = any(
+            value is not None
+            for value in (
+                num_executors,
+                resources_per_executor,
+                spark_conf,
+                driver,
+                executor,
+            )
+        )
+
+        if session is not None and (legacy_connect or legacy_create):
+            raise ValueError(
+                "Pass either `session=` or legacy connect keyword arguments, not both."
+            )
+
+        if legacy_connect and not base_url:
+            raise ValueError(
+                "`base_url` must be a non-empty string to connect to an existing Spark "
+                "Connect server. `token` alone is not sufficient."
+            )
+
+        resolved_options: list = list(options) if options is not None else []
+
+        if isinstance(session, ExistingSession):
+            if not session.base_url:
+                raise ValueError("`ExistingSession.base_url` must be a non-empty string.")
+            return session.base_url, session.token, None, None, None, None
+
+        if isinstance(session, NewSession):
+            return (
+                None,
+                None,
+                session.num_executors,
+                session.resources_per_executor,
+                session.spark_conf,
+                resolved_options or None,
+            )
+
+        if session is not None:
+            raise TypeError(
+                "`session` must be an instance of ExistingSession or NewSession, "
+                f"got {type(session).__name__}."
+            )
+
+        if legacy_connect or legacy_create:
+            warnings.warn(
+                "Passing connect configuration as keyword arguments is deprecated. "
+                "Use session=ExistingSession(...) or session=NewSession(...), and pass "
+                "Driver/Executor through options.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+
+        if driver is not None:
+            resolved_options.insert(0, driver)
+        if executor is not None:
+            resolved_options.insert(0, executor)
+
+        return (
+            base_url,
+            token,
+            num_executors,
+            resources_per_executor,
+            spark_conf,
+            resolved_options or None,
         )
 
     def list_sessions(self) -> list[SparkConnectInfo]:

--- a/kubeflow/spark/api/spark_client_test.py
+++ b/kubeflow/spark/api/spark_client_test.py
@@ -14,7 +14,7 @@
 
 """Unit tests for SparkClient API."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -22,8 +22,12 @@ from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.api.spark_client import SparkClient
 from kubeflow.spark.test.common import FAILED, SUCCESS, TestCase
 from kubeflow.spark.types.types import (
+    Driver,
+    Executor,
+    ExistingSession,
     FileJob,
     FuncJob,
+    NewSession,
     SparkJob,
 )
 
@@ -76,7 +80,8 @@ def test_create_and_connect(test_case: TestCase):
         # Validate the exception type if specified
         if test_case.expected_error:
             assert isinstance(e, test_case.expected_error), (
-                f"Expected exception type '{test_case.expected_error.__name__}' but got '{type(e).__name__}: {str(e)}'"
+                f"Expected exception type '{test_case.expected_error.__name__}' but got "
+                f"'{type(e).__name__}: {str(e)}'"
             )
 
 
@@ -171,3 +176,120 @@ def test_submit_job_success(job):
             num_executors=None,
             resources_per_executor=None,
         )
+
+
+def test_connect_existing_session_mode():
+    """ExistingSession connects via remote SparkSession builder."""
+    with (
+        patch("kubeflow.spark.api.spark_client.KubernetesBackend"),
+        patch("kubeflow.spark.api.spark_client.validate_spark_connect_url") as validate,
+        patch("kubeflow.spark.api.spark_client.SparkSession") as spark_session,
+    ):
+        remote_builder = MagicMock()
+        configured_builder = MagicMock()
+        spark_session.builder.remote.return_value = remote_builder
+        remote_builder.config.return_value = configured_builder
+        configured_builder.getOrCreate.return_value = "spark"
+
+        client = SparkClient()
+        result = client.connect(session=ExistingSession(base_url="sc://server:15002", token="t"))
+
+        validate.assert_called_once_with("sc://server:15002")
+        spark_session.builder.remote.assert_called_once_with("sc://server:15002")
+        remote_builder.config.assert_called_once_with("spark.connect.authenticate.token", "t")
+        assert result == "spark"
+
+
+def test_connect_new_session_mode():
+    """NewSession delegates create-mode to the backend."""
+    with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as backend_cls:
+        backend = backend_cls.return_value
+        backend.create_and_connect.return_value = "spark"
+        client = SparkClient()
+
+        result = client.connect(
+            session=NewSession(
+                num_executors=2,
+                resources_per_executor={"cpu": "1", "memory": "1Gi"},
+                spark_conf={"spark.app.name": "demo"},
+            ),
+            options=[Driver(resources={"cpu": "1", "memory": "1Gi"})],
+        )
+
+        backend.create_and_connect.assert_called_once_with(
+            num_executors=2,
+            resources_per_executor={"cpu": "1", "memory": "1Gi"},
+            spark_conf={"spark.app.name": "demo"},
+            driver=None,
+            executor=None,
+            options=[Driver(resources={"cpu": "1", "memory": "1Gi"})],
+            timeout=300,
+            connect_timeout=120,
+        )
+        assert result == "spark"
+
+
+def test_connect_rejects_empty_existing_session_base_url():
+    """ExistingSession with an empty base_url must be rejected, not silently create a session."""
+    with (
+        patch("kubeflow.spark.api.spark_client.KubernetesBackend") as backend_cls,
+    ):
+        backend = backend_cls.return_value
+        client = SparkClient()
+
+        with pytest.raises(ValueError, match="ExistingSession.base_url"):
+            client.connect(session=ExistingSession(base_url=""))
+
+        backend.create_and_connect.assert_not_called()
+
+
+def test_connect_rejects_legacy_token_without_base_url():
+    """Legacy token-only calls (no base_url) must be rejected, not silently create a session."""
+    with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as backend_cls:
+        backend = backend_cls.return_value
+        client = SparkClient()
+
+        with pytest.raises(ValueError, match="base_url"):
+            client.connect(token="secret")
+
+        backend.create_and_connect.assert_not_called()
+
+
+def test_connect_rejects_legacy_empty_base_url():
+    """Legacy base_url="" must be rejected, not silently create a session."""
+    with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as backend_cls:
+        backend = backend_cls.return_value
+        client = SparkClient()
+
+        with pytest.raises(ValueError, match="base_url"):
+            client.connect(base_url="", token="secret")
+
+        backend.create_and_connect.assert_not_called()
+
+
+def test_connect_rejects_mixed_session_and_legacy_kwargs():
+    """Typed session mode cannot be mixed with legacy kwargs."""
+    with patch("kubeflow.spark.api.spark_client.KubernetesBackend"):
+        client = SparkClient()
+        with pytest.raises(ValueError, match="legacy connect keyword arguments"):
+            client.connect(session=NewSession(), num_executors=2)
+
+
+def test_connect_legacy_kwargs_move_driver_executor_into_options():
+    """Legacy driver/executor kwargs are moved into options with a warning."""
+    with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as backend_cls:
+        backend = backend_cls.return_value
+        backend.create_and_connect.return_value = "spark"
+        client = SparkClient()
+
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            client.connect(
+                driver=Driver(resources={"cpu": "2", "memory": "4Gi"}),
+                executor=Executor(num_instances=3),
+            )
+
+        kwargs = backend.create_and_connect.call_args.kwargs
+        assert kwargs["driver"] is None
+        assert kwargs["executor"] is None
+        assert kwargs["options"][0] == Executor(num_instances=3)
+        assert kwargs["options"][1] == Driver(resources={"cpu": "2", "memory": "4Gi"})

--- a/kubeflow/spark/types/options_test.py
+++ b/kubeflow/spark/types/options_test.py
@@ -29,6 +29,7 @@ from kubeflow.spark.types.options import (
     PodTemplateOverride,
     Toleration,
 )
+from kubeflow.spark.types.types import Driver, Executor
 
 
 @pytest.fixture
@@ -122,6 +123,84 @@ class TestAnnotations:
 
         with pytest.raises(ValueError, match="not compatible"):
             option(spark_connect_model, mock_non_k8s_backend)
+
+
+class TestDriverCallableComposability:
+    """Tests for Driver applied as an option, composed with other options."""
+
+    def test_driver_preserves_earlier_node_selector(self, mock_k8s_backend, spark_connect_model):
+        """Driver must not wipe out template changes made by earlier options."""
+        NodeSelector({"node-type": "spark"})(spark_connect_model, mock_k8s_backend)
+
+        Driver(resources={"cpu": "4", "memory": "8Gi"})(spark_connect_model, mock_k8s_backend)
+
+        assert spark_connect_model.spec.server.cores == 4
+        assert spark_connect_model.spec.server.template.spec.node_selector == {"node-type": "spark"}
+
+    def test_driver_merges_service_account_into_existing_template(
+        self, mock_k8s_backend, spark_connect_model
+    ):
+        """Driver's service_account must merge into an existing template, not replace it."""
+        Toleration(key="spark-workload")(spark_connect_model, mock_k8s_backend)
+
+        Driver(service_account="spark-driver-sa")(spark_connect_model, mock_k8s_backend)
+
+        server_template = spark_connect_model.spec.server.template
+        assert server_template.spec.service_account_name == "spark-driver-sa"
+        assert len(server_template.spec.tolerations) == 1
+
+    def test_driver_without_resources_keeps_existing_cores_memory(
+        self, mock_k8s_backend, spark_connect_model
+    ):
+        """Driver with no resources set must not reset previously configured cores/memory."""
+        spark_connect_model.spec.server.cores = 4
+        spark_connect_model.spec.server.memory = "8g"
+
+        Driver(service_account="spark-driver-sa")(spark_connect_model, mock_k8s_backend)
+
+        assert spark_connect_model.spec.server.cores == 4
+        assert spark_connect_model.spec.server.memory == "8g"
+
+
+class TestExecutorCallableComposability:
+    """Tests for Executor applied as an option, composed with other options."""
+
+    def test_executor_preserves_earlier_node_selector(self, mock_k8s_backend, spark_connect_model):
+        """Executor must not wipe out template changes made by earlier options."""
+        NodeSelector({"node-type": "spark"})(spark_connect_model, mock_k8s_backend)
+
+        Executor(resources_per_executor={"cpu": "4", "memory": "8Gi"})(
+            spark_connect_model, mock_k8s_backend
+        )
+
+        assert spark_connect_model.spec.executor.cores == 4
+        assert spark_connect_model.spec.executor.template.spec.node_selector == {
+            "node-type": "spark"
+        }
+
+    def test_executor_without_num_instances_keeps_existing_instance_count(
+        self, mock_k8s_backend, spark_connect_model
+    ):
+        """Executor(resources_per_executor=...) alone must not reset the instance count."""
+        # Simulate NewSession(num_executors=5) having already set the instance count.
+        spark_connect_model.spec.executor.instances = 5
+
+        Executor(resources_per_executor={"cpu": "4", "memory": "8Gi"})(
+            spark_connect_model, mock_k8s_backend
+        )
+
+        assert spark_connect_model.spec.executor.instances == 5
+        assert spark_connect_model.spec.executor.cores == 4
+
+    def test_executor_with_num_instances_overrides_existing_count(
+        self, mock_k8s_backend, spark_connect_model
+    ):
+        """Executor(num_instances=...) explicitly overrides a previously set instance count."""
+        spark_connect_model.spec.executor.instances = 5
+
+        Executor(num_instances=10)(spark_connect_model, mock_k8s_backend)
+
+        assert spark_connect_model.spec.executor.instances == 10
 
 
 class TestNodeSelector:
@@ -276,3 +355,30 @@ class TestNameOption:
 
         with pytest.raises(ValueError, match="not compatible"):
             option(spark_connect_model, mock_non_k8s_backend)
+
+
+class TestDriverExecutorOptions:
+    """Tests for Driver and Executor as connect options."""
+
+    def test_driver_option_applies_server_spec(self, mock_k8s_backend, spark_connect_model):
+        option = Driver(resources={"cpu": "2", "memory": "2Gi"}, image="custom-spark:v1")
+        option(spark_connect_model, mock_k8s_backend)
+
+        assert spark_connect_model.spec.server.cores == 2
+        assert spark_connect_model.spec.server.memory == "2g"
+        assert spark_connect_model.spec.image == "custom-spark:v1"
+
+    def test_executor_option_applies_executor_spec(self, mock_k8s_backend, spark_connect_model):
+        option = Executor(
+            num_instances=5,
+            resources_per_executor={"cpu": "4", "memory": "8Gi"},
+        )
+        option(spark_connect_model, mock_k8s_backend)
+
+        assert spark_connect_model.spec.executor.instances == 5
+        assert spark_connect_model.spec.executor.cores == 4
+        assert spark_connect_model.spec.executor.memory == "8g"
+
+    def test_driver_option_incompatible_backend(self, mock_non_k8s_backend, spark_connect_model):
+        with pytest.raises(ValueError, match="not compatible"):
+            Driver()(spark_connect_model, mock_non_k8s_backend)

--- a/kubeflow/spark/types/types.py
+++ b/kubeflow/spark/types/types.py
@@ -59,11 +59,43 @@ class SparkConnectInfo:
 
 
 @dataclass
+class ExistingSession:
+    """Connect to an existing Spark Connect server.
+
+    Args:
+        base_url: Spark Connect URL (for example ``sc://server:15002``).
+        token: Optional authentication token for the existing server.
+    """
+
+    base_url: str
+    token: str | None = None
+
+
+@dataclass
+class NewSession:
+    """Create a new Spark Connect session.
+
+    Args:
+        num_executors: Number of executor instances.
+        resources_per_executor: Resource requirements per executor as a dict.
+            Format: ``{"cpu": "5", "memory": "10Gi"}``.
+        spark_conf: Spark configuration dictionary.
+    """
+
+    num_executors: int | None = None
+    resources_per_executor: dict[str, str] | None = None
+    spark_conf: dict[str, str] | None = None
+
+
+@dataclass
 class Driver:
     """Driver configuration for Spark Connect session.
 
     The Driver configuration allows fine-grained control over the Spark driver pod.
     All fields are optional, with sensible defaults applied by the backend.
+
+    Prefer passing ``Driver(...)`` through ``connect(..., options=[...])`` so the
+    create-mode API stays aligned with other Spark options.
 
     Args:
         image: Custom container image for the driver.
@@ -72,9 +104,14 @@ class Driver:
         service_account: Kubernetes service account name for RBAC.
 
     Example:
-        driver = Driver(
-            resources={"cpu": "4", "memory": "8Gi"},
-            service_account="spark-driver-prod"
+        spark = client.connect(
+            session=NewSession(),
+            options=[
+                Driver(
+                    resources={"cpu": "4", "memory": "8Gi"},
+                    service_account="spark-driver-prod",
+                )
+            ],
         )
 
     Note:
@@ -87,6 +124,45 @@ class Driver:
     java_options: str | None = None
     service_account: str | None = None
 
+    def __call__(self, spark_connect: Any, backend: Any) -> None:
+        """Apply driver configuration to a SparkConnect model.
+
+        Only Driver-owned fields are updated in place so options applied earlier
+        (e.g. NodeSelector, Toleration, PodTemplateOverride) are preserved rather
+        than discarded by rebuilding the server spec from scratch.
+        """
+        from kubeflow_spark_api import models
+
+        from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
+        from kubeflow.spark.backends.kubernetes.utils import _memory_kubernetes_to_spark
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"Driver option is not compatible with {type(backend).__name__}. "
+                f"Supported backends: KubernetesBackend"
+            )
+
+        if spark_connect.spec is None:
+            raise ValueError("SparkConnect spec must be set before applying Driver")
+
+        server_spec = spark_connect.spec.server
+        if self.resources:
+            if "cpu" in self.resources:
+                server_spec.cores = int(self.resources["cpu"])
+            if "memory" in self.resources:
+                server_spec.memory = _memory_kubernetes_to_spark(self.resources["memory"])
+
+        if self.service_account:
+            if server_spec.template is None:
+                server_spec.template = models.IoK8sApiCoreV1PodTemplateSpec()
+            if server_spec.template.spec is None:
+                # PodSpec requires containers field (can be empty list)
+                server_spec.template.spec = models.IoK8sApiCoreV1PodSpec(containers=[])
+            server_spec.template.spec.service_account_name = self.service_account
+
+        if self.image:
+            spark_connect.spec.image = self.image
+
 
 @dataclass
 class Executor:
@@ -95,6 +171,9 @@ class Executor:
     The Executor configuration controls the worker pods that execute Spark tasks.
     All fields are optional, with sensible defaults applied by the backend.
 
+    Prefer passing ``Executor(...)`` through ``connect(..., options=[...])`` so the
+    create-mode API stays aligned with other Spark options.
+
     Args:
         num_instances: Number of executor instances (pods).
         resources_per_executor: Resource requirements per executor as dict
@@ -102,9 +181,18 @@ class Executor:
         java_options: JVM options for executors (e.g., "-Xmx28g -XX:+UseG1GC").
 
     Example:
-        executor = Executor(
-            num_instances=20,
-            resources_per_executor={"cpu": "8", "memory": "32Gi"}
+        spark = client.connect(
+            session=NewSession(),
+            options=[
+                Executor(
+                    num_instances=20,
+                    resources_per_executor={
+                        "cpu": "8",
+                        "memory": "32Gi",
+                        "nvidia.com/gpu": "2",
+                    },
+                )
+            ],
         )
 
     Note:
@@ -115,6 +203,37 @@ class Executor:
     num_instances: int | None = None
     resources_per_executor: dict[str, str] | None = None
     java_options: str | None = None
+
+    def __call__(self, spark_connect: Any, backend: Any) -> None:
+        """Apply executor configuration to a SparkConnect model.
+
+        Only explicitly set Executor fields are merged into the existing executor
+        spec so values already applied by ``NewSession``/legacy simple arguments or
+        earlier template options (e.g. NodeSelector, Toleration) are preserved.
+        """
+        from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
+        from kubeflow.spark.backends.kubernetes.utils import _memory_kubernetes_to_spark
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"Executor option is not compatible with {type(backend).__name__}. "
+                f"Supported backends: KubernetesBackend"
+            )
+
+        if spark_connect.spec is None:
+            raise ValueError("SparkConnect spec must be set before applying Executor")
+
+        executor_spec = spark_connect.spec.executor
+        if self.num_instances:
+            executor_spec.instances = self.num_instances
+
+        if self.resources_per_executor:
+            if "cpu" in self.resources_per_executor:
+                executor_spec.cores = int(self.resources_per_executor["cpu"])
+            if "memory" in self.resources_per_executor:
+                executor_spec.memory = _memory_kubernetes_to_spark(
+                    self.resources_per_executor["memory"]
+                )
 
 
 class SparkJobStatus(str, Enum):

--- a/kubeflow/spark/types/types_test.py
+++ b/kubeflow/spark/types/types_test.py
@@ -22,8 +22,10 @@ import pytest
 from kubeflow.spark.types.types import (
     Driver,
     Executor,
+    ExistingSession,
     FileJob,
     FuncJob,
+    NewSession,
     SparkConnectInfo,
     SparkConnectState,
     SparkJob,
@@ -45,6 +47,21 @@ from kubeflow.trainer.test.common import SUCCESS, TestCase
 def test_spark_connect_state_values(state, expected):
     """Test SparkConnectState enum values."""
     assert state == expected
+
+
+def test_existing_session():
+    """Test ExistingSession dataclass."""
+    session = ExistingSession(base_url="sc://server:15002", token="secret")
+    assert session.base_url == "sc://server:15002"
+    assert session.token == "secret"
+
+
+def test_new_session_defaults():
+    """Test NewSession defaults."""
+    session = NewSession()
+    assert session.num_executors is None
+    assert session.resources_per_executor is None
+    assert session.spark_conf is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Add typed `ExistingSession` and `NewSession` modes for `SparkClient.connect`, aligned with typed batch job modes
- Make `Driver` and `Executor` callable options so advanced config goes through `options=[...]`
- Keep legacy connect kwargs working with deprecation warnings
- Update Spark examples and unit tests for the consolidated API

Fixes #596

## Test plan
- [x] `uv run pytest -q kubeflow/spark/api/spark_client_test.py`
- [x] `uv run pytest -q kubeflow/spark/types/types_test.py`
- [x] `uv run pytest -q kubeflow/spark/types/options_test.py`
- [x] `uv run pytest -q kubeflow/spark/backends/kubernetes/utils_test.py`