### PR TITLE
fix(spark): validate hostname is present in Spark Connect URL

### DIFF
--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -320,6 +320,8 @@ def validate_spark_connect_url(url: str) -> bool:
     parsed = urlparse(url)
     if parsed.scheme != "sc":
         raise ValueError(f"Invalid scheme '{parsed.scheme}'. Expected 'sc://'")
+    if not parsed.hostname:
+        raise ValueError("Host is required in Spark Connect URL")
     if not parsed.port:
         raise ValueError("Port is required in Spark Connect URL")
     return True

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -100,6 +100,11 @@ class TestValidateSparkConnectUrl:
         """U14: Missing port raises ValueError."""
         with pytest.raises(ValueError, match="Port is required"):
             validate_spark_connect_url("sc://localhost")
+    
+    def test_missing_hostname(self):
+        """U16: Missing hostname raises ValueError."""
+        with pytest.raises(ValueError, match="Host is required"):
+            validate_spark_connect_url("sc://:15002")
 
 
 class TestBuildServiceUrl:

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -100,7 +100,7 @@ class TestValidateSparkConnectUrl:
         """U14: Missing port raises ValueError."""
         with pytest.raises(ValueError, match="Port is required"):
             validate_spark_connect_url("sc://localhost")
-    
+
     def test_missing_hostname(self):
         """U16: Missing hostname raises ValueError."""
         with pytest.raises(ValueError, match="Host is required"):


### PR DESCRIPTION
Fixes #598 

## What this PR does

`validate_spark_connect_url()` in `kubeflow/spark/backends/kubernetes/utils.py`
checked the URL scheme and port, but never checked that a hostname was
present. This meant a malformed URL like `sc://:15002` passed validation
and only failed later, further down the connection path, with a much
less clear error.

This PR adds a `parsed.hostname` check alongside the existing port check.



## Change

```python
parsed = urlparse(url)
if parsed.scheme != "sc":
    raise ValueError(f"Invalid scheme '{parsed.scheme}'. Expected 'sc://'")
if not parsed.hostname:
    raise ValueError("Host is required in Spark Connect URL")
if not parsed.port:
    raise ValueError("Port is required in Spark Connect URL")
return True
```

## Testing

- Added `test_missing_hostname` to `TestValidateSparkConnectUrl` in
  `utils_test.py`, following the existing `test_missing_port` pattern.
- Verified `parsed.hostname` correctly distinguishes the empty-host case
  from all legitimate hostname shapes (plain hosts, FQDNs, IPv6 literals
  like `sc://[::1]:15002`) — none of these are affected by this change.
- Ran the full local test suite:
  - `utils_test.py`: 35 passed
  - `backend_test.py`: 33 passed (no regressions)


## Checklist

- [x] Tests added/updated
- [x] DCO sign-off on commit
- [x] Followed existing code style in the file