### PR TITLE
fix: create a new status set for each function call

### DIFF
--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -239,6 +239,11 @@ class TrainerClient:
         polling_interval: int = 2,
         callbacks: list[Callable[[types.TrainJob], None]] | None = None,
     ) -> types.TrainJob:
+        
+         if status is None:
+            status={constants.TRAINJOB_COMPLETE}
+        
+         ## in every call creat a new set 
         """Wait for a TrainJob to reach a desired status.
 
         Args:


### PR DESCRIPTION
This PR fixes the handling of the default status value by ensuring that a new set is created whenever status is not provided.
Previously, when status was None, the function did not explicitly create a fresh set for each invocation. This change initializes status as:
if status is None:
    status = {constants.TRAINJOB_COMPLETE}
By creating a new set on every function call, each invocation receives its own independent status object. This follows Python best practices for handling mutable objects, avoids unintended sharing of state between calls, and improves the reliability and maintainability of the code without changing the existing behavior.
Ensures each function call receives an independent status object.
Prevents potential issues related to mutable state being shared across invocations.
Preserves the existing functionality while improving code robustness.
Which issue(s) this PR fixes

Fixes #<issue-#605>.
