### PR TITLE
fix: create a new status set for each function call

### DIFF
--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -234,7 +234,7 @@ class TrainerClient:
     def wait_for_job_status(
         self,
         name: str,
-        status: set[str] = {constants.TRAINJOB_COMPLETE},
+        status: set[str] | None = None,
         timeout: int = 600,
         polling_interval: int = 2,
         callbacks: list[Callable[[types.TrainJob], None]] | None = None,
@@ -244,7 +244,7 @@ class TrainerClient:
         Args:
             name: Name of the TrainJob.
             status: Expected statuses. Must be a subset of Created, Running, Complete, and
-                Failed statuses.
+                Failed statuses. 
             timeout: Maximum number of seconds to wait for the TrainJob to reach one of the
                 expected statuses.
             polling_interval: The polling interval in seconds to check TrainJob status.

--- a/kubeflow/trainer/backends/base.py
+++ b/kubeflow/trainer/backends/base.py
@@ -75,7 +75,7 @@ class RuntimeBackend(abc.ABC):
     def wait_for_job_status(
         self,
         name: str,
-        status: set[str] = {constants.TRAINJOB_COMPLETE},
+        status: set[str] | None = None,
         timeout: int = 600,
         polling_interval: int = 2,
         callbacks: list[Callable[[types.TrainJob], None]] | None = None,

--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -842,12 +842,15 @@ class ContainerBackend(RuntimeBackend):
     def wait_for_job_status(
         self,
         name: str,
-        status: set[str] = {constants.TRAINJOB_COMPLETE},
+        status: set[str] | None = None,
         timeout: int = 600,
         polling_interval: int = 2,
         callbacks: list[Callable[[types.TrainJob], None]] | None = None,
     ) -> types.TrainJob:
         import time
+
+        if status is None:
+            status = {constants.TRAINJOB_COMPLETE}
 
         end = time.time() + timeout
         while time.time() < end:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR replaces the mutable default `status` set with `None` and initializes a new status set inside the implementation when no value is provided.

This ensures that each function invocation receives a fresh set instance, following Python best practices for mutable default arguments while preserving the existing behavior.

**Which issue(s) this PR fixes**:

Fixes #605

**Checklist**

- [ ] Docs included if any changes are user facing
