### PR TITLE
Feat/spark job driver resources options

### DIFF
--- a/.github/workflows/test-spark-examples.yaml
+++ b/.github/workflows/test-spark-examples.yaml
@@ -83,7 +83,7 @@ jobs:
           SPARK_E2E_DEBUG: "1"
           SPARK_E2E_RUN_IN_CLUSTER: "1"
           SPARK_E2E_RUNNER_IMAGE: spark-e2e-runner:local
-        timeout-minutes: 10
+        timeout-minutes: 15
 
       - name: Collect logs on failure
         if: failure()

--- a/examples/spark/Spark_job.py
+++ b/examples/spark/Spark_job.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Simple Spark application for SDK batch job examples."""
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col
+
+spark = SparkSession.builder.appName("KubeflowSparkExample").getOrCreate()
+
+# Create a small DataFrame
+df = spark.range(10).withColumn("square", col("id") * col("id"))
+
+print("Input DataFrame:")
+df.show()
+
+count = df.count()
+total = df.agg({"square": "sum"}).collect()[0][0]
+
+print(f"Row count: {count}")
+print(f"Sum of squares: {total}")
+
+spark.stop()

--- a/examples/spark/batch_failed_job.py
+++ b/examples/spark/batch_failed_job.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+
+from kubeflow.common.types import KubernetesBackendConfig
+from kubeflow.spark import FileJob, SparkClient, SparkJobStatus
+
+REMOTE_PI = "https://raw.githubusercontent.com/apache/spark/master/examples/src/main/python/pi.py"
+
+JOB_NAME: str | None = None
+
+
+def _backend_config(namespace_default: str = "default"):
+    """Backend config; uses SPARK_TEST_NAMESPACE in CI."""
+    return KubernetesBackendConfig(
+        namespace=os.environ.get("SPARK_TEST_NAMESPACE", namespace_default)
+    )
+
+
+def _client() -> SparkClient:
+    """Create SparkClient."""
+    return SparkClient(backend_config=_backend_config())
+
+
+def example_submit_and_wait():
+    """Submit a Spark batch job expected to fail."""
+    global JOB_NAME
+
+    print("=" * 70)
+    print("SUBMIT FAILED SPARK BATCH JOB")
+    print("=" * 70)
+
+    client = _client()
+
+    print("\nSubmitting Spark job expected to fail...")
+
+    JOB_NAME = client.submit_job(
+        job=FileJob(
+            file_source=REMOTE_PI,
+            args=["hello"],
+        ),
+        num_executors=1,
+        resources_per_executor={
+            "cpu": "1",
+            "memory": "512Mi",
+        },
+    )
+
+    print(f"Job submitted successfully: {JOB_NAME}")
+
+    print("\nWaiting for job to fail...")
+
+    job = client.wait_for_job_status(
+        JOB_NAME,
+        status={SparkJobStatus.FAILED},
+        timeout=300,
+    )
+
+    print("Job failed as expected.")
+    print(f"Status: {job.status}")
+    print(f"Driver Pod: {job.driver_pod_name}")
+    print(f"Namespace: {job.namespace}")
+
+    print("\nSubmit and wait example complete.\n")
+
+
+def example_get_job():
+    """Get information about the failed Spark batch job."""
+    print("=" * 70)
+    print("GET FAILED SPARK BATCH JOB")
+    print("=" * 70)
+
+    if JOB_NAME is None:
+        raise RuntimeError("No job has been submitted.")
+
+    client = _client()
+
+    print(f"\nRetrieving job: {JOB_NAME}")
+
+    job = client.get_job(JOB_NAME)
+
+    print("Job retrieved successfully.")
+    print(f"Name: {job.name}")
+    print(f"Namespace: {job.namespace}")
+    print(f"Status: {job.status}")
+    print(f"Driver Pod: {job.driver_pod_name}")
+    print(f"Executors: {job.num_executors}")
+
+    if job.status != SparkJobStatus.FAILED:
+        raise RuntimeError("Expected job to be in FAILED state.")
+
+    print("\nGet job example complete.\n")
+
+
+def example_get_job_logs():
+    """Get logs from the failed Spark batch job."""
+    print("=" * 70)
+    print("GET FAILED SPARK BATCH JOB LOGS")
+    print("=" * 70)
+
+    if JOB_NAME is None:
+        raise RuntimeError("No job has been submitted.")
+
+    client = _client()
+
+    print(f"\nRetrieving logs for: {JOB_NAME}")
+
+    print("\nDriver logs (first 20 lines):")
+    print("-" * 70)
+
+    line_count = 0
+    for line in client.get_job_logs(JOB_NAME):
+        print(line.rstrip())
+        line_count += 1
+
+        if line_count >= 20:
+            print("...")
+            break
+
+    print("-" * 70)
+    print(f"Displayed {line_count} log lines.")
+
+    print("\nGet job logs example complete.\n")
+
+
+def example_delete_job():
+    """Delete the failed Spark batch job."""
+    print("=" * 70)
+    print("DELETE FAILED SPARK BATCH JOB")
+    print("=" * 70)
+
+    global JOB_NAME
+
+    if JOB_NAME is None:
+        raise RuntimeError("No job has been submitted.")
+
+    client = _client()
+
+    print(f"\nDeleting job: {JOB_NAME}")
+
+    client.delete_job(JOB_NAME)
+
+    print("Job deleted.")
+
+    try:
+        client.get_job(JOB_NAME)
+    except RuntimeError as e:
+        if "Spark job not found" not in str(e):
+            raise
+    else:
+        raise RuntimeError("Job still exists after deletion.")
+
+    print("Verified job has been deleted.")
+
+    JOB_NAME = None
+
+    print("\nDelete job example complete.\n")
+
+
+def main():
+    """Run failed batch job examples."""
+    print("E2E: Starting batch_failed_job.py", flush=True)
+    print()
+    print("=" * 70)
+    print("KUBEFLOW SPARKCLIENT - FAILED BATCH JOB")
+    print("=" * 70)
+
+    try:
+        example_submit_and_wait()
+        example_get_job()
+        example_get_job_logs()
+        example_delete_job()
+
+        print("=" * 70)
+        print("FAILED BATCH JOB EXAMPLE COMPLETE!")
+        print("=" * 70)
+
+    except Exception as e:
+        print(f"\nError: {e}")
+        raise SystemExit(1) from e
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/spark/batch_job_lifecycle.py
+++ b/examples/spark/batch_job_lifecycle.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+
+from kubeflow.common.types import KubernetesBackendConfig
+from kubeflow.spark import FileJob, SparkClient, SparkJobStatus
+
+REMOTE_PI = "https://raw.githubusercontent.com/apache/spark/master/examples/src/main/python/pi.py"
+
+JOB_NAME: str | None = None
+
+
+def _backend_config(namespace_default: str = "default"):
+    """Backend config; uses SPARK_TEST_NAMESPACE in CI."""
+    return KubernetesBackendConfig(
+        namespace=os.environ.get("SPARK_TEST_NAMESPACE", namespace_default)
+    )
+
+
+def _client() -> SparkClient:
+    """Create SparkClient."""
+    return SparkClient(backend_config=_backend_config())
+
+
+def example_submit_and_wait():
+    """Submit a Spark batch job and wait for completion."""
+    global JOB_NAME
+
+    print("=" * 70)
+    print("SUBMIT SPARK BATCH JOB")
+    print("=" * 70)
+
+    client = _client()
+
+    print("\nSubmitting Spark job...")
+
+    JOB_NAME = client.submit_job(
+        job=FileJob(
+            file_source=REMOTE_PI,
+            args=["10"],
+        ),
+        num_executors=1,
+        resources_per_executor={
+            "cpu": "1",
+            "memory": "512Mi",
+        },
+    )
+
+    print(f"Job submitted successfully: {JOB_NAME}")
+
+    print("\nWaiting for job to complete...")
+
+    job = client.wait_for_job_status(
+        JOB_NAME,
+        status={SparkJobStatus.COMPLETED},
+        timeout=300,
+    )
+
+    print("Job completed successfully.")
+    print(f"Status: {job.status}")
+    print(f"Driver Pod: {job.driver_pod_name}")
+    print(f"Namespace: {job.namespace}")
+    print("\nSubmit and wait example complete.\n")
+
+
+def example_get_job():
+    """Get information about a Spark batch job."""
+    print("=" * 70)
+    print("GET SPARK BATCH JOB")
+    print("=" * 70)
+
+    if JOB_NAME is None:
+        raise RuntimeError("No job has been submitted.")
+
+    client = _client()
+
+    print(f"\nRetrieving job: {JOB_NAME}")
+
+    job = client.get_job(JOB_NAME)
+
+    if job.status != SparkJobStatus.COMPLETED:
+        raise RuntimeError(f"Expected COMPLETED status, got {job.status}.")
+
+    if not job.driver_pod_name:
+        raise RuntimeError("Expected driver pod name to be populated.")
+
+    print("Job retrieved successfully.")
+    print(f"Name: {job.name}")
+    print(f"Namespace: {job.namespace}")
+    print(f"Status: {job.status}")
+    print(f"Driver Pod: {job.driver_pod_name}")
+    print(f"Executors: {job.num_executors}")
+
+    print("\nGet job example complete.\n")
+
+
+def example_list_jobs():
+    """List Spark batch jobs."""
+    print("=" * 70)
+    print("LIST SPARK BATCH JOBS")
+    print("=" * 70)
+
+    if JOB_NAME is None:
+        raise RuntimeError("No job has been submitted.")
+
+    client = _client()
+
+    print("\nListing Spark jobs...")
+
+    jobs = client.list_jobs()
+
+    print(f"Found {len(jobs)} Spark job(s).\n")
+
+    job_found = False
+
+    for job in jobs:
+        print(f"- {job.name} | Status: {job.status} | Namespace: {job.namespace}")
+
+        if job.name == JOB_NAME:
+            job_found = True
+
+    if not job_found:
+        raise RuntimeError(f"Submitted job '{JOB_NAME}' not found in job list.")
+
+    print("\nSubmitted job found in job list.")
+
+    print("\nListing completed Spark jobs...")
+
+    completed_jobs = client.list_jobs(
+        status={SparkJobStatus.COMPLETED},
+    )
+
+    print(f"Found {len(completed_jobs)} completed Spark job(s).\n")
+
+    completed_job_found = False
+
+    for job in completed_jobs:
+        if job.status != SparkJobStatus.COMPLETED:
+            raise RuntimeError(f"Expected COMPLETED status, got {job.status}.")
+
+        print(f"- {job.name} | Status: {job.status} | Namespace: {job.namespace}")
+
+        if job.name == JOB_NAME:
+            completed_job_found = True
+
+    if not completed_job_found:
+        raise RuntimeError(f"Submitted completed job '{JOB_NAME}' not found in filtered job list.")
+
+    print("\nCompleted job filter verified.")
+    print("\nList jobs example complete.\n")
+
+
+def example_get_job_logs():
+    """Get logs from a Spark batch job."""
+    print("=" * 70)
+    print("GET SPARK BATCH JOB LOGS")
+    print("=" * 70)
+
+    if JOB_NAME is None:
+        raise RuntimeError("No job has been submitted.")
+
+    client = _client()
+
+    print(f"\nRetrieving logs for: {JOB_NAME}")
+
+    print("\nDriver logs (first 20 lines):")
+    print("-" * 70)
+
+    line_count = 0
+    for line in client.get_job_logs(JOB_NAME):
+        print(line.rstrip())
+        line_count += 1
+
+        if line_count >= 20:
+            print("...")
+            break
+
+    print("-" * 70)
+    print(f"Displayed {line_count} log lines.")
+
+    print("\nGet job logs example complete.\n")
+
+
+def example_delete_job():
+    """Delete a Spark batch job."""
+    print("=" * 70)
+    print("DELETE SPARK BATCH JOB")
+    print("=" * 70)
+
+    global JOB_NAME
+
+    if JOB_NAME is None:
+        raise RuntimeError("No job has been submitted.")
+
+    client = _client()
+
+    print(f"\nDeleting job: {JOB_NAME}")
+
+    client.delete_job(JOB_NAME)
+
+    print("Job deleted.")
+
+    try:
+        client.get_job(JOB_NAME)
+    except RuntimeError as e:
+        if "Spark job not found" not in str(e):
+            raise
+    else:
+        raise RuntimeError("Job still exists after deletion.")
+
+    print("Verified job has been deleted.")
+
+    JOB_NAME = None
+
+    print("\nDelete job example complete.\n")
+
+
+def main():
+    """Run all batch job lifecycle examples."""
+    print("E2E: Starting batch_job_lifecycle.py", flush=True)
+    print()
+    print("=" * 70)
+    print("KUBEFLOW SPARKCLIENT - BATCH JOB LIFECYCLE")
+    print("=" * 70)
+
+    try:
+        example_submit_and_wait()
+        example_get_job()
+        example_list_jobs()
+        example_get_job_logs()
+        example_delete_job()
+
+        print("=" * 70)
+        print("BATCH JOB LIFECYCLE COMPLETE!")
+        print("=" * 70)
+
+    except Exception as e:
+        print(f"\nError: {e}")
+        raise SystemExit(1) from e
+
+
+if __name__ == "__main__":
+    main()

--- a/hack/e2e-setup-cluster.sh
+++ b/hack/e2e-setup-cluster.sh
@@ -277,6 +277,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "services", "configmaps"]
     verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -301,6 +304,9 @@ metadata:
 rules:
   - apiGroups: ["sparkoperator.k8s.io"]
     resources: ["sparkconnects", "sparkconnects/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["sparkoperator.k8s.io"]
+    resources: ["sparkapplications", "sparkapplications/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/kubeflow/spark/__init__.py
+++ b/kubeflow/spark/__init__.py
@@ -27,8 +27,12 @@ from kubeflow.spark.types.options import (
 from kubeflow.spark.types.types import (
     Driver,
     Executor,
+    FileJob,
+    FuncJob,
     SparkConnectInfo,
     SparkConnectState,
+    SparkJob,
+    SparkJobStatus,
 )
 
 __all__ = [
@@ -37,8 +41,12 @@ __all__ = [
     # Types
     "Driver",
     "Executor",
+    "FileJob",
+    "FuncJob",
     "SparkConnectInfo",
     "SparkConnectState",
+    "SparkJob",
+    "SparkJobStatus",
     # Options (KEP-107 extensibility pattern - callable pattern like trainer SDK)
     "Annotations",
     "Labels",

--- a/kubeflow/spark/__init__.py
+++ b/kubeflow/spark/__init__.py
@@ -18,6 +18,7 @@ from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.api.spark_client import SparkClient
 from kubeflow.spark.types.options import (
     Annotations,
+    DriverResources,
     Labels,
     Name,
     NodeSelector,
@@ -49,6 +50,7 @@ __all__ = [
     "SparkJobStatus",
     # Options (KEP-107 extensibility pattern - callable pattern like trainer SDK)
     "Annotations",
+    "DriverResources",
     "Labels",
     "Name",
     "NodeSelector",

--- a/kubeflow/spark/api/spark_client.py
+++ b/kubeflow/spark/api/spark_client.py
@@ -15,23 +15,38 @@
 """SparkClient for Kubeflow SDK."""
 
 from collections.abc import Iterator
-import logging
 
 from pyspark.sql import SparkSession
 
 from kubeflow.common.types import KubernetesBackendConfig
+import kubeflow.common.utils as common_utils
 from kubeflow.spark.backends.kubernetes import KubernetesBackend
 from kubeflow.spark.backends.kubernetes.utils import validate_spark_connect_url
-from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo
-
-logger = logging.getLogger(__name__)
+from kubeflow.spark.types.types import (
+    Driver,
+    Executor,
+    FileJob,
+    FuncJob,
+    SparkConnectInfo,
+    SparkJob,
+    SparkJobStatus,
+)
 
 
 class SparkClient:
     """Stateless Spark client for Kubeflow."""
 
     def __init__(self, backend_config: KubernetesBackendConfig | None = None):
-        """Initialize SparkClient."""
+        """Initialize the Spark client.
+
+        Args:
+            backend_config: Kubernetes backend configuration. If not provided, the default
+                configuration is used.
+
+        Raises:
+            ValueError:
+                If backend_config is not a KubernetesBackendConfig instance.
+        """
         if backend_config is None:
             backend_config = KubernetesBackendConfig()
 
@@ -39,6 +54,10 @@ class SparkClient:
             self.backend = KubernetesBackend(backend_config)
         else:
             raise ValueError(f"Invalid backend config: {type(backend_config)}")
+
+    # ------------------------------------------------------------------
+    # Spark Connect sessions
+    # ------------------------------------------------------------------
 
     def connect(
         self,
@@ -53,7 +72,7 @@ class SparkClient:
         timeout: int = 300,
         connect_timeout: int = 120,
     ) -> SparkSession:
-        """Connect to or create a SparkConnect session (KEP-107 lines 298-347).
+        """Connect to or create a SparkConnect session.
 
         This method supports two modes based on parameters:
         - **Connect mode**: When `base_url` is provided, connects to an existing Spark Connect server
@@ -77,32 +96,10 @@ class SparkClient:
         Returns:
             SparkSession connected to Spark (self-managing).
 
-        Examples:
-            # Connect to existing server
-            spark = client.connect(base_url="sc://server:15002")
-
-            # Create with simple parameters
-            spark = client.connect(
-                num_executors=5,
-                resources_per_executor={"cpu": "5", "memory": "10Gi"},
-                spark_conf={"spark.sql.adaptive.enabled": "true"}
-            )
-
-            # Create with custom name
-            from kubeflow.spark.types.options import Name
-            spark = client.connect(options=[Name("my-session")])
-
-            # Create with advanced configuration
-            spark = client.connect(
-                driver=Driver(resources={"cpu": "2", "memory": "4Gi"}),
-                executor=Executor(
-                    num_instances=5,
-                    resources_per_executor={"cpu": "4", "memory": "8Gi"}
-                )
-            )
-
-            # Minimal - use all defaults (auto-generated name)
-            spark = client.connect()
+        Raises:
+            ValueError: If base_url is invalid or the provided resource configuration is invalid.
+            TimeoutError: If creating a Spark Connect session or connecting to it times out.
+            RuntimeError: If the Spark Connect session cannot be created or connected to.
 
         Note:
             Server port defaults to 15002 (Spark Connect gRPC). PySpark and server Spark
@@ -127,17 +124,196 @@ class SparkClient:
         )
 
     def list_sessions(self) -> list[SparkConnectInfo]:
-        """List all SparkConnect sessions."""
+        """List SparkConnect sessions.
+
+        Returns:
+            List of SparkConnectInfo objects.
+        """
         return self.backend.list_sessions()
 
     def get_session(self, name: str) -> SparkConnectInfo:
-        """Get session info by name."""
+        """Get information about a SparkConnect session.
+
+        Args:
+            name:
+                Name of the SparkConnect session.
+
+        Returns:
+            SparkConnectInfo containing information about the SparkConnect session.
+        """
         return self.backend.get_session(name)
 
     def delete_session(self, name: str) -> None:
-        """Delete a SparkConnect session."""
+        """Delete a SparkConnect session.
+
+        Args:
+            name:
+                Name of the SparkConnect session to delete.
+        """
         self.backend.delete_session(name)
 
     def get_session_logs(self, name: str, follow: bool = False) -> Iterator[str]:
-        """Get logs from a session."""
+        """Get logs from a SparkConnect session.
+
+        Args:
+            name:
+                Name of the SparkConnect session.
+
+            follow:
+                Whether to stream logs continuously.
+
+        Returns:
+            Iterator of log lines from the SparkConnect driver pod.
+        """
         return self.backend.get_session_logs(name, follow=follow)
+
+    # ------------------------------------------------------------------
+    # Spark batch jobs
+    # ------------------------------------------------------------------
+
+    def submit_job(
+        self,
+        job: FileJob | FuncJob,
+        num_executors: int | None = None,
+        resources_per_executor: dict[str, str] | None = None,
+        spark_conf: dict[str, str] | None = None,
+        options: list | None = None,
+    ) -> str:
+        """Submit a batch Spark job.
+
+        This method supports two job types:
+
+        - **FileJob**: Submit a Spark application referenced by a local
+        or remote file source.
+        - **FuncJob**: Submit a Python function as a Spark batch job.
+
+        Function-based jobs will be supported in Phase 2.
+
+        Args:
+            job:
+                Job definition describing the workload to execute.
+                Supports either ``FileJob`` or ``FuncJob``.
+
+            num_executors:
+                Number of executor instances.
+
+            resources_per_executor:
+                Resource requirements per executor.
+                Format: ``{"cpu": "5", "memory": "10Gi"}``.
+
+            spark_conf:
+                Spark configuration dictionary.
+
+            options:
+                List of additional Spark configuration options.
+
+        Raises:
+            ValueError:
+                If unsupported Phase 1 features are requested or the job definition is invalid.
+
+            TypeError:
+                If the job type is invalid.
+
+            NotImplementedError:
+                If unsupported features are requested.
+        """
+        if spark_conf is not None:
+            raise NotImplementedError("spark_conf support is not yet implemented.")
+
+        if options is not None:
+            raise NotImplementedError("options are not supported in Phase 1.")
+
+        return self.backend.submit_job(
+            job=job,
+            num_executors=num_executors,
+            resources_per_executor=resources_per_executor,
+        ).name
+
+    def get_job(self, name: str) -> SparkJob:
+        """Get information about a Spark job.
+
+        Args:
+            name:
+                Name of the Spark job.
+
+        Returns:
+            SparkJob containing information about the Spark job.
+        """
+
+        return self.backend.get_job(name)
+
+    def list_jobs(
+        self,
+        status: set[SparkJobStatus] | None = None,
+    ) -> list[SparkJob]:
+        """List Spark jobs.
+
+        Args:
+            status:
+                Optional set of job statuses to filter the returned jobs.
+
+        Returns:
+            List of SparkJob objects.
+        """
+        return self.backend.list_jobs(status=status)
+
+    def delete_job(self, name: str) -> None:
+        """Delete a Spark job.
+
+        Args:
+            name:
+                Name of the Spark job to delete.
+        """
+        self.backend.delete_job(name)
+
+    def wait_for_job_status(
+        self,
+        name: str,
+        status: set[SparkJobStatus] | None = None,
+        timeout: int = 600,
+        polling_interval: int = 2,
+    ) -> SparkJob:
+        """Wait for a Spark job to reach one of the target states.
+        Args:
+            name: Job name.
+            status: Target job state(s).
+            timeout: Maximum wait time in seconds. Default 600.
+            polling_interval: Time in seconds between status checks.
+
+        Returns:
+            Spark job information after reaching one of the target statuses.
+
+        Raises:
+            ValueError:
+                If the polling interval or timeout values are invalid.
+        """
+        common_utils.validate_wait_for_job_status(
+            polling_interval,
+            timeout,
+        )
+
+        return self.backend.wait_for_job_status(
+            name=name,
+            status=status,
+            timeout=timeout,
+            polling_interval=polling_interval,
+        )
+
+    def get_job_logs(
+        self,
+        name: str,
+        follow: bool = False,
+    ) -> Iterator[str]:
+        """Get logs from a Spark job.
+
+        Args:
+            name: Spark job name.
+            follow: Whether to stream logs in realtime.
+
+        Returns:
+            Iterator of log lines.
+        """
+        return self.backend.get_job_logs(
+            name=name,
+            follow=follow,
+        )

--- a/kubeflow/spark/api/spark_client.py
+++ b/kubeflow/spark/api/spark_client.py
@@ -220,13 +220,11 @@ class SparkClient:
         if spark_conf is not None:
             raise NotImplementedError("spark_conf support is not yet implemented.")
 
-        if options is not None:
-            raise NotImplementedError("options are not supported in Phase 1.")
-
         return self.backend.submit_job(
             job=job,
             num_executors=num_executors,
             resources_per_executor=resources_per_executor,
+            options=options,
         ).name
 
     def get_job(self, name: str) -> SparkJob:

--- a/kubeflow/spark/api/spark_client_test.py
+++ b/kubeflow/spark/api/spark_client_test.py
@@ -21,6 +21,11 @@ import pytest
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.api.spark_client import SparkClient
 from kubeflow.spark.test.common import FAILED, SUCCESS, TestCase
+from kubeflow.spark.types.types import (
+    FileJob,
+    FuncJob,
+    SparkJob,
+)
 
 
 @pytest.mark.parametrize(
@@ -73,3 +78,98 @@ def test_create_and_connect(test_case: TestCase):
             assert isinstance(e, test_case.expected_error), (
                 f"Expected exception type '{test_case.expected_error.__name__}' but got '{type(e).__name__}: {str(e)}'"
             )
+
+
+@pytest.mark.parametrize(
+    "job,spark_conf,options,backend_error,expected_error",
+    [
+        (
+            FuncJob(func=lambda: None),
+            None,
+            None,
+            NotImplementedError("Function-based jobs are not supported in Phase 1."),
+            NotImplementedError,
+        ),
+        (
+            "not-a-job",
+            None,
+            None,
+            TypeError("job must be an instance of FileJob or FuncJob."),
+            TypeError,
+        ),
+        (
+            FileJob(file_source=""),
+            None,
+            None,
+            ValueError("`job.file_source` must be a non-empty string."),
+            ValueError,
+        ),
+        (
+            FileJob(file_source="s3://bucket/job.py"),
+            {"spark.executor.memory": "4g"},
+            None,
+            None,
+            NotImplementedError,
+        ),
+        (
+            FileJob(file_source="s3://bucket/job.py"),
+            None,
+            [object()],
+            None,
+            NotImplementedError,
+        ),
+    ],
+)
+def test_submit_job_validation(
+    job,
+    spark_conf,
+    options,
+    backend_error,
+    expected_error,
+):
+    """Test SparkClient submit_job validation."""
+
+    with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as mock_backend:
+        backend = mock_backend.return_value
+
+        if backend_error is not None:
+            backend.submit_job.side_effect = backend_error
+
+        client = SparkClient()
+
+        with pytest.raises(expected_error):
+            client.submit_job(
+                job=job,
+                spark_conf=spark_conf,
+                options=options,
+            )
+
+
+def test_submit_job_success():
+    """Test successful submit_job."""
+
+    with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as mock_backend:
+        backend = mock_backend.return_value
+
+        backend.submit_job.return_value = SparkJob(
+            name="spark-job-123",
+            namespace="default",
+        )
+
+        client = SparkClient()
+
+        name = client.submit_job(
+            job=FileJob(
+                file_source="s3://bucket/job.py",
+            ),
+        )
+
+        assert name == "spark-job-123"
+
+        backend.submit_job.assert_called_once_with(
+            job=FileJob(
+                file_source="s3://bucket/job.py",
+            ),
+            num_executors=None,
+            resources_per_executor=None,
+        )

--- a/kubeflow/spark/api/spark_client_test.py
+++ b/kubeflow/spark/api/spark_client_test.py
@@ -111,13 +111,6 @@ def test_create_and_connect(test_case: TestCase):
             None,
             NotImplementedError,
         ),
-        (
-            FileJob(file_source="s3://bucket/job.py"),
-            None,
-            [object()],
-            None,
-            NotImplementedError,
-        ),
     ],
 )
 def test_submit_job_validation(
@@ -172,4 +165,39 @@ def test_submit_job_success():
             ),
             num_executors=None,
             resources_per_executor=None,
+            options=None,
+        )
+
+
+def test_submit_job_with_driver_resources_option():
+    """Test submit_job forwards DriverResources options to the backend."""
+    from kubeflow.spark.types.options import DriverResources
+
+    with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as mock_backend:
+        backend = mock_backend.return_value
+
+        backend.submit_job.return_value = SparkJob(
+            name="spark-job-456",
+            namespace="default",
+        )
+
+        client = SparkClient()
+        options = [DriverResources({"cpu": "2", "memory": "4Gi"})]
+
+        name = client.submit_job(
+            job=FileJob(
+                file_source="s3://bucket/job.py",
+            ),
+            options=options,
+        )
+
+        assert name == "spark-job-456"
+
+        backend.submit_job.assert_called_once_with(
+            job=FileJob(
+                file_source="s3://bucket/job.py",
+            ),
+            num_executors=None,
+            resources_per_executor=None,
+            options=options,
         )

--- a/kubeflow/spark/backends/base.py
+++ b/kubeflow/spark/backends/base.py
@@ -17,17 +17,31 @@
 import abc
 from collections.abc import Iterator
 
-from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo
+from pyspark.sql import SparkSession
+
+from kubeflow.spark.types.types import (
+    Driver,
+    Executor,
+    FileJob,
+    FuncJob,
+    SparkConnectInfo,
+    SparkJob,
+    SparkJobStatus,
+)
 
 
 class RuntimeBackend(abc.ABC):
     """Abstract base class for Spark backends.
 
-    All Spark backends must implement these methods to manage SparkConnect sessions.
+    All Spark backends must implement these methods to manage SparkConnect sessions and Spark batch jobs.
     """
 
+    # ------------------------------------------------------------------
+    # Spark Connect sessions
+    # ------------------------------------------------------------------
+
     @abc.abstractmethod
-    def connect(
+    def create_and_connect(
         self,
         num_executors: int | None = None,
         resources_per_executor: dict[str, str] | None = None,
@@ -35,7 +49,9 @@ class RuntimeBackend(abc.ABC):
         driver: Driver | None = None,
         executor: Executor | None = None,
         options: list | None = None,
-    ) -> SparkConnectInfo:
+        timeout: int = 300,
+        connect_timeout: int = 120,
+    ) -> SparkSession:
         """Create a new SparkConnect session (INTERNAL USE ONLY).
 
         This is an internal method used by SparkClient.connect().
@@ -48,9 +64,11 @@ class RuntimeBackend(abc.ABC):
             driver: Driver configuration.
             executor: Executor configuration.
             options: List of configuration options (use Name option for custom name).
+            timeout: Maximum time in seconds to wait for the session to become ready.
+            connect_timeout: Maximum time in seconds to establish the Spark Connect session.
 
         Returns:
-            SparkConnectInfo with session details (may be in PROVISIONING state).
+            Connected SparkSession.
 
         Raises:
             TimeoutError: If the creation request times out.
@@ -101,34 +119,6 @@ class RuntimeBackend(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def _wait_for_session_ready(
-        self,
-        name: str,
-        timeout: int = 300,
-        polling_interval: int = 2,
-    ) -> SparkConnectInfo:
-        """Wait for a SparkConnect session to become ready (INTERNAL USE ONLY).
-
-        This is an internal method used by SparkClient.connect().
-        Use SparkClient.connect() instead of calling this directly.
-
-        Polls the session status until it reaches READY state or times out.
-
-        Args:
-            name: Session name.
-            timeout: Maximum wait time in seconds. Default 300 (5 minutes).
-            polling_interval: Seconds between status checks. Default 2.
-
-        Returns:
-            SparkConnectInfo when session is ready.
-
-        Raises:
-            TimeoutError: If session does not become ready within timeout.
-            RuntimeError: If session fails.
-        """
-        raise NotImplementedError()
-
-    @abc.abstractmethod
     def get_session_logs(
         self,
         name: str,
@@ -146,5 +136,112 @@ class RuntimeBackend(abc.ABC):
         Raises:
             TimeoutError: If reading logs times out.
             RuntimeError: If the session/pod is not found or reading fails.
+        """
+        raise NotImplementedError()
+
+    # ------------------------------------------------------------------
+    # Spark batch jobs
+    # ------------------------------------------------------------------
+
+    @abc.abstractmethod
+    def submit_job(
+        self,
+        job: FileJob | FuncJob,
+        num_executors: int | None = None,
+        resources_per_executor: dict[str, str] | None = None,
+    ) -> SparkJob:
+        """Submit a Spark batch job.
+
+        Args:
+            job: Spark application to execute.
+            num_executors: Number of executor instances.
+            resources_per_executor: Resource requirements for each executor.
+
+        Returns:
+            Submitted Spark job information.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_job(
+        self,
+        name: str,
+    ) -> SparkJob:
+        """Get a Spark job.
+
+        Args:
+            name: Name of the Spark job.
+
+        Returns:
+            Spark job information.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def list_jobs(
+        self,
+        status: set[SparkJobStatus] | None = None,
+    ) -> list[SparkJob]:
+        """List Spark jobs.
+
+        Args:
+            status: Optional set of Spark job statuses used to filter results.
+
+        Returns:
+            List of Spark jobs.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def delete_job(
+        self,
+        name: str,
+    ) -> None:
+        """Delete a Spark job.
+
+        Args:
+            name: Name of the Spark job to delete.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def wait_for_job_status(
+        self,
+        name: str,
+        status: set[SparkJobStatus] | None = None,
+        timeout: int = 600,
+        polling_interval: int = 2,
+    ) -> SparkJob:
+        """Wait for a Spark job to reach one of the desired statuses.
+
+        Args:
+            name: Name of the Spark job.
+            status: Optional set of target Spark job statuses.
+                Defaults to ``{SparkJobStatus.COMPLETED}``.
+            timeout: Maximum time in seconds to wait.
+            polling_interval: Time in seconds between status checks.
+
+        Returns:
+            Spark job information after reaching one of the desired statuses.
+
+        Raises:
+            TimeoutError: If the timeout is exceeded before reaching the target status.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def get_job_logs(
+        self,
+        name: str,
+        follow: bool = False,
+    ) -> Iterator[str]:
+        """Get logs from a Spark job.
+
+        Args:
+            name: Name of the Spark job.
+            follow: Whether to stream logs in real time.
+
+        Returns:
+            Iterator over log lines.
         """
         raise NotImplementedError()

--- a/kubeflow/spark/backends/base.py
+++ b/kubeflow/spark/backends/base.py
@@ -149,6 +149,7 @@ class RuntimeBackend(abc.ABC):
         job: FileJob | FuncJob,
         num_executors: int | None = None,
         resources_per_executor: dict[str, str] | None = None,
+        options: list | None = None,
     ) -> SparkJob:
         """Submit a Spark batch job.
 
@@ -156,6 +157,7 @@ class RuntimeBackend(abc.ABC):
             job: Spark application to execute.
             num_executors: Number of executor instances.
             resources_per_executor: Resource requirements for each executor.
+            options: List of configuration options (e.g. DriverResources).
 
         Returns:
             Submitted Spark job information.

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -36,12 +36,25 @@ from kubeflow.spark.backends.base import RuntimeBackend
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.utils import (
     build_service_url,
+    build_spark_application_cr,
     build_spark_connect_cr,
+    generate_job_name,
     generate_session_name,
+    get_spark_application_info_from_cr,
     get_spark_connect_info_from_cr,
+    read_pod_logs,
 )
 from kubeflow.spark.types.options import Name
-from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo, SparkConnectState
+from kubeflow.spark.types.types import (
+    Driver,
+    Executor,
+    FileJob,
+    FuncJob,
+    SparkConnectInfo,
+    SparkConnectState,
+    SparkJob,
+    SparkJobStatus,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +62,13 @@ _spark_debug_logging_enabled = False
 
 
 def _enable_spark_debug_logging() -> None:
-    """Turn on INFO logging for kubeflow.spark to stderr (for E2E debug)."""
+    """Enable INFO-level logging for the ``kubeflow.spark`` logger.
+
+    This helper is intended for E2E debugging and configures logging only once.
+
+    Returns:
+        None.
+    """
     global _spark_debug_logging_enabled
     if _spark_debug_logging_enabled:
         return
@@ -63,10 +82,18 @@ def _enable_spark_debug_logging() -> None:
 
 
 class KubernetesBackend(RuntimeBackend):
-    """Kubernetes backend for managing SparkConnect sessions."""
+    """Kubernetes backend for managing SparkConnect sessions and Spark batch jobs."""
 
     def __init__(self, backend_config: KubernetesBackendConfig):
-        """Initialize Kubernetes Spark backend."""
+        """Initialize the Kubernetes Spark backend.
+
+        Args:
+            backend_config: Kubernetes backend configuration.
+
+        Raises:
+            ConfigException:
+                If the Kubernetes configuration cannot be loaded.
+        """
         self.namespace = backend_config.namespace or "default"
 
         if backend_config.config_file:
@@ -81,6 +108,10 @@ class KubernetesBackend(RuntimeBackend):
 
         self.custom_api = client.CustomObjectsApi()
         self.core_api = client.CoreV1Api()
+
+    # ------------------------------------------------------------------
+    # Spark Connect sessions
+    # ------------------------------------------------------------------
 
     def _extract_name_option(self, options: list | None) -> tuple[str, list]:
         """Extract Name option from options list, or generate name if absent.
@@ -120,7 +151,25 @@ class KubernetesBackend(RuntimeBackend):
         executor: Executor | None = None,
         options: list | None = None,
     ) -> SparkConnectInfo:
-        """Create a new SparkConnect session (INTERNAL USE ONLY)."""
+        """Create a SparkConnect session.
+
+        Args:
+            num_executors: Number of executor instances.
+            resources_per_executor: Resource requirements per executor.
+            spark_conf: Spark configuration properties.
+            driver: Driver configuration.
+            executor: Executor configuration.
+            options: List of configuration options.
+
+        Returns:
+            Information about the created SparkConnect session.
+
+        Raises:
+            TimeoutError:
+                If creating the SparkConnect resource times out.
+            RuntimeError:
+                If the SparkConnect resource cannot be created.
+        """
         # Extract Name option if present, or auto-generate
         name, filtered_options = self._extract_name_option(options)
 
@@ -161,7 +210,20 @@ class KubernetesBackend(RuntimeBackend):
         return get_spark_connect_info_from_cr(spark_connect_cr)
 
     def get_session(self, name: str) -> SparkConnectInfo:
-        """Get information about a SparkConnect session."""
+        """Get information about a SparkConnect session.
+
+        Args:
+            name: Name of the SparkConnect session.
+
+        Returns:
+            Information about the SparkConnect session.
+
+        Raises:
+            TimeoutError:
+                If getting the SparkConnect resource times out.
+            RuntimeError:
+                If the SparkConnect resource cannot be retrieved.
+        """
         try:
             thread = self.custom_api.get_namespaced_custom_object(
                 group=constants.SPARK_CONNECT_GROUP,
@@ -193,7 +255,17 @@ class KubernetesBackend(RuntimeBackend):
             ) from e
 
     def list_sessions(self) -> list[SparkConnectInfo]:
-        """List all SparkConnect sessions."""
+        """List SparkConnect sessions.
+
+        Returns:
+            List of SparkConnect session information objects.
+
+        Raises:
+            TimeoutError:
+                If listing SparkConnect resources times out.
+            RuntimeError:
+                If the SparkConnect resources cannot be listed.
+        """
         try:
             thread = self.custom_api.list_namespaced_custom_object(
                 group=constants.SPARK_CONNECT_GROUP,
@@ -216,7 +288,17 @@ class KubernetesBackend(RuntimeBackend):
         return [get_spark_connect_info_from_cr(sc) for sc in spark_connect_list.items]
 
     def delete_session(self, name: str) -> None:
-        """Delete a SparkConnect session."""
+        """Delete a SparkConnect session.
+
+        Args:
+            name: Name of the SparkConnect session to delete.
+
+        Raises:
+            TimeoutError:
+                If deleting the SparkConnect resource times out.
+            RuntimeError:
+                If the SparkConnect resource cannot be deleted.
+        """
         try:
             thread = self.custom_api.delete_namespaced_custom_object(
                 group=constants.SPARK_CONNECT_GROUP,
@@ -251,9 +333,30 @@ class KubernetesBackend(RuntimeBackend):
         timeout: int = 300,
         polling_interval: int = 2,
     ) -> SparkConnectInfo:
-        """Wait for a SparkConnect session to become ready (INTERNAL USE ONLY)."""
-        start_time = time.time()
-        last_log_time = 0.0
+        """Wait for a SparkConnect session to become ready.
+
+        Args:
+            name:
+                Name of the SparkConnect session.
+
+            timeout:
+                Maximum time in seconds to wait.
+
+            polling_interval:
+                Time in seconds between status checks.
+
+        Returns:
+            SparkConnectInfo containing information about the ready session.
+
+        Raises:
+            RuntimeError:
+                If the SparkConnect session reaches the failed state.
+
+            TimeoutError:
+                If the session does not become ready within the timeout.
+        """
+        start_time = time.monotonic()
+        last_log_time = start_time
 
         while True:
             info = self.get_session(name)
@@ -265,7 +368,7 @@ class KubernetesBackend(RuntimeBackend):
                     name,
                     info.state,
                     info.service_name,
-                    time.time() - start_time,
+                    time.monotonic() - start_time,
                 )
                 return info
 
@@ -274,7 +377,7 @@ class KubernetesBackend(RuntimeBackend):
                     f"{constants.SPARK_CONNECT_KIND} failed: {self.namespace}/{name}"
                 )
 
-            now = time.time()
+            now = time.monotonic()
             if now - last_log_time >= 10.0:
                 logger.info(
                     "Waiting for session: %s/%s state=%s serviceName=%s elapsed=%.0fs",
@@ -297,7 +400,24 @@ class KubernetesBackend(RuntimeBackend):
     def _wait_for_connect_port(
         self, host: str, port: int, timeout_sec: int = 60, interval_sec: float = 2.0
     ) -> bool:
-        """Wait until a TCP connection to host:port succeeds (Spark Connect server reachable)."""
+        """Wait until a Spark Connect server becomes reachable.
+
+        Args:
+            host:
+                Hostname or IP address of the Spark Connect server.
+
+            port:
+                TCP port of the Spark Connect server.
+
+            timeout_sec:
+                Maximum time in seconds to wait.
+
+            interval_sec:
+                Time in seconds between connection attempts.
+
+        Returns:
+            True if the server becomes reachable before the timeout, otherwise False.
+        """
         deadline = time.monotonic() + timeout_sec
         while time.monotonic() < deadline:
             try:
@@ -587,7 +707,29 @@ class KubernetesBackend(RuntimeBackend):
         name: str,
         follow: bool = False,
     ) -> Iterator[str]:
-        """Get logs from a SparkConnect session."""
+        """Get logs from a SparkConnect session.
+
+        Logs are retrieved from the Kubernetes driver pod associated with the
+        SparkConnect session. Log retrieval is only available while the driver
+        pod exists.
+
+        Args:
+            name:
+                Name of the SparkConnect session.
+
+            follow:
+                Whether to stream logs continuously.
+
+        Yields:
+            Log lines from the SparkConnect driver pod.
+
+        Raises:
+            RuntimeError:
+                If the driver pod does not exist or logs cannot be retrieved.
+
+            TimeoutError:
+                If retrieving the driver pod logs times out.
+        """
         info = self.get_session(name)
 
         if not info.driver_pod_name:
@@ -595,32 +737,417 @@ class KubernetesBackend(RuntimeBackend):
                 f"No driver pod for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
             )
 
+        def _stream() -> Iterator[str]:
+            try:
+                yield from read_pod_logs(
+                    core_api=self.core_api,
+                    namespace=self.namespace,
+                    pod_name=info.driver_pod_name,
+                    follow=follow,
+                )
+
+            except TimeoutError as e:
+                raise TimeoutError(
+                    f"Timeout to get logs for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
+                ) from e
+
+            except RuntimeError as e:
+                raise RuntimeError(
+                    f"Failed to get logs for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
+                ) from e
+
+        return _stream()
+
+    # ------------------------------------------------------------------
+    # Spark batch jobs
+    # ------------------------------------------------------------------
+
+    def _validate_job(
+        self,
+        job: FileJob | FuncJob,
+    ) -> None:
+        """Validate a Spark job.
+
+        Args:
+            job: Spark job definition to validate.
+
+        Raises:
+            NotImplementedError: If a function-based job is provided, as function-based jobs are
+                not supported in Phase 1.
+            TypeError: If job is not an instance of FileJob or FuncJob.
+        """
+
+        if isinstance(job, FileJob):
+            self._validate_file_job(job)
+            return
+
+        if isinstance(job, FuncJob):
+            raise NotImplementedError("Function-based jobs are not supported in Phase 1.")
+
+        raise TypeError("job must be an instance of FileJob or FuncJob.")
+
+    def _validate_file_job(
+        self,
+        job: FileJob,
+    ) -> None:
+        """Validate a file-based Spark job.
+
+        Args:
+            job: File-based Spark job definition to validate.
+
+        Raises:
+            ValueError: If file_source is empty, args is not a list of strings.
+        """
+
+        if not isinstance(job.file_source, str) or not job.file_source.strip():
+            raise ValueError("`job.file_source` must be a non-empty string.")
+
+        if job.args is not None:
+            if not isinstance(job.args, list):
+                raise ValueError("`job.args` must be a list of strings.")
+
+            if not all(isinstance(arg, str) for arg in job.args):
+                raise ValueError("All `job.args` must be strings.")
+
+    def submit_job(
+        self,
+        job: FileJob | FuncJob,
+        num_executors: int | None = None,
+        resources_per_executor: dict[str, str] | None = None,
+    ) -> SparkJob:
+        """Submit a SparkApplication for batch execution.
+
+        Args:
+            job:
+                File-based Spark workload definition.
+
+            num_executors:
+                Number of executor instances.
+
+            resources_per_executor:
+                Resource requirements per executor.
+
+        Returns:
+            SparkJob information object.
+
+        Raises:
+            ValueError:
+                If job validation fails.
+
+            TimeoutError:
+                If SparkApplication creation times out.
+
+            RuntimeError:
+                If SparkApplication creation fails.
+        """
+        self._validate_job(job)
+
+        job_name = generate_job_name()
+
+        logger.info(
+            "Submitting SparkApplication '%s'",
+            job_name,
+        )
+
+        spark_application = build_spark_application_cr(
+            name=job_name,
+            namespace=self.namespace,
+            main_file=job.file_source,
+            arguments=job.args,
+            num_executors=num_executors,
+            resources_per_executor=resources_per_executor,
+        )
+
         try:
-            if follow:
-                thread = self.core_api.read_namespaced_pod_log(
-                    name=info.driver_pod_name,
-                    namespace=self.namespace,
-                    follow=True,
-                    _preload_content=False,
-                    async_req=True,
-                )
-                resp = thread.get(common_constants.DEFAULT_TIMEOUT)
-                for line in resp.stream():
-                    yield line.decode("utf-8").rstrip("\n")
-            else:
-                thread = self.core_api.read_namespaced_pod_log(
-                    name=info.driver_pod_name,
-                    namespace=self.namespace,
-                    async_req=True,
-                )
-                logs = thread.get(common_constants.DEFAULT_TIMEOUT)
-                for line in logs.split("\n"):
-                    yield line
+            thread = self.custom_api.create_namespaced_custom_object(
+                group=constants.SPARK_APPLICATION_GROUP,
+                version=constants.SPARK_APPLICATION_VERSION,
+                namespace=self.namespace,
+                plural=constants.SPARK_APPLICATION_PLURAL,
+                body=spark_application.to_dict(),
+                async_req=True,
+            )
+            response = thread.get(common_constants.DEFAULT_TIMEOUT)
+
         except multiprocessing.TimeoutError as e:
-            raise TimeoutError(
-                f"Timeout to get logs for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
-            ) from e
+            raise TimeoutError(f"Timeout creating Spark job: {self.namespace}/{job_name}") from e
+
         except Exception as e:
             raise RuntimeError(
-                f"Failed to get logs for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
+                f"Failed to create Spark job: {self.namespace}/{job_name}: {e}"
             ) from e
+
+        cr = models.SparkV1beta2SparkApplication.from_dict(response)
+
+        return get_spark_application_info_from_cr(cr)
+
+    def get_job(self, name: str) -> SparkJob:
+        """Get information about a Spark job.
+
+        Args:
+            name:
+                Name of the SparkApplication.
+
+        Returns:
+            SparkJob information object.
+
+        Raises:
+            TimeoutError: If retrieving the SparkApplication times out.
+            RuntimeError: If the SparkApplication is not found or cannot be retrieved.
+        """
+
+        try:
+            thread = self.custom_api.get_namespaced_custom_object(
+                group=constants.SPARK_APPLICATION_GROUP,
+                version=constants.SPARK_APPLICATION_VERSION,
+                namespace=self.namespace,
+                plural=constants.SPARK_APPLICATION_PLURAL,
+                name=name,
+                async_req=True,
+            )
+
+            response = thread.get(common_constants.DEFAULT_TIMEOUT)
+
+            spark_application = models.SparkV1beta2SparkApplication.from_dict(response)
+
+        except multiprocessing.TimeoutError as e:
+            raise TimeoutError(f"Timeout to get Spark job: {self.namespace}/{name}") from e
+
+        except client.ApiException as e:
+            if e.status == 404:
+                raise RuntimeError(f"Spark job not found: {self.namespace}/{name}") from e
+
+            raise RuntimeError(f"Failed to get Spark job: {self.namespace}/{name}: {e}") from e
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to get Spark job: {self.namespace}/{name}") from e
+        return get_spark_application_info_from_cr(spark_application)
+
+    def list_jobs(
+        self,
+        status: set[SparkJobStatus] | None = None,
+    ) -> list[SparkJob]:
+        """List Spark jobs.
+
+        Args:
+            status:
+                Optional set of job statuses to filter the returned jobs.
+
+        Returns:
+            List of SparkJob information objects.
+
+        Raises:
+            TimeoutError: If listing SparkApplications times out.
+            RuntimeError: If the SparkApplications cannot be listed.
+        """
+
+        try:
+            thread = self.custom_api.list_namespaced_custom_object(
+                group=constants.SPARK_APPLICATION_GROUP,
+                version=constants.SPARK_APPLICATION_VERSION,
+                namespace=self.namespace,
+                plural=constants.SPARK_APPLICATION_PLURAL,
+                async_req=True,
+            )
+
+            response = thread.get(
+                common_constants.DEFAULT_TIMEOUT,
+            )
+
+        except multiprocessing.TimeoutError as e:
+            raise TimeoutError(
+                f"Timeout to list {constants.SPARK_APPLICATION_KIND}s "
+                f"in namespace: {self.namespace}"
+            ) from e
+
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to list {constants.SPARK_APPLICATION_KIND}s in namespace: {self.namespace}"
+            ) from e
+
+        spark_application_list = models.SparkV1beta2SparkApplicationList.from_dict(
+            response,
+        )
+
+        jobs = [get_spark_application_info_from_cr(app) for app in spark_application_list.items]
+
+        if status:
+            jobs = [job for job in jobs if job.status in status]
+
+        return jobs
+
+    def delete_job(self, name: str) -> None:
+        """Delete a Spark job.
+
+        Args:
+            name:
+                Name of the SparkApplication to delete.
+
+        Raises:
+            TimeoutError: If deleting the SparkApplication times out.
+            RuntimeError: If the SparkApplication is not found or cannot be deleted.
+        """
+
+        try:
+            thread = self.custom_api.delete_namespaced_custom_object(
+                group=constants.SPARK_APPLICATION_GROUP,
+                version=constants.SPARK_APPLICATION_VERSION,
+                namespace=self.namespace,
+                plural=constants.SPARK_APPLICATION_PLURAL,
+                name=name,
+                async_req=True,
+            )
+
+            thread.get(common_constants.DEFAULT_TIMEOUT)
+
+            logger.info("Deleted Spark job '%s'", name)
+
+        except multiprocessing.TimeoutError as e:
+            raise TimeoutError(
+                f"Timeout to delete {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{name}"
+            ) from e
+
+        except client.ApiException as e:
+            if e.status == 404:
+                raise RuntimeError(
+                    f"{constants.SPARK_APPLICATION_KIND} not found: {self.namespace}/{name}"
+                ) from e
+
+            raise RuntimeError(
+                f"Failed to delete {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{name}"
+            ) from e
+
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to delete {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{name}"
+            ) from e
+
+    def wait_for_job_status(
+        self,
+        name: str,
+        status: set[SparkJobStatus] | None = None,
+        timeout: int = 600,
+        polling_interval: int = 2,
+    ) -> SparkJob:
+        """Wait for a Spark job to reach one of the target states.
+
+        Args:
+            name: Name of the SparkApplication.
+            status: Target job statuses to wait for. Defaults to COMPLETED.
+            timeout: Maximum time in seconds to wait.
+            polling_interval: Time in seconds between status checks.
+
+        Returns:
+            SparkJob information object after the target status is reached.
+
+        Raises:
+            ValueError: If polling_interval is negative.
+            RuntimeError: If the SparkApplication reaches the FAILED state before reaching
+                one of the target statuses.
+            TimeoutError: If the target status is not reached within the timeout.
+        """
+
+        if status is None:
+            status = {SparkJobStatus.COMPLETED}
+
+        if timeout <= 0:
+            raise ValueError("timeout must be positive.")
+
+        if polling_interval <= 0:
+            raise ValueError("polling_interval must be positive.")
+
+        start_time = time.monotonic()
+        last_log_time = start_time
+
+        while True:
+            job = self.get_job(name)
+
+            if job.status in status:
+                logger.info(
+                    "Job reached target state: %s/%s status=%s (%.0fs)",
+                    self.namespace,
+                    name,
+                    job.status,
+                    time.monotonic() - start_time,
+                )
+                return job
+            if job.status == SparkJobStatus.FAILED and SparkJobStatus.FAILED not in status:
+                raise RuntimeError(
+                    f"Spark job reached failed state: {self.namespace}/{name}(status={job.status})"
+                )
+
+            now = time.monotonic()
+
+            if now - last_log_time >= 10.0:
+                logger.info(
+                    "Waiting for job: %s/%s status=%s elapsed=%.0fs",
+                    self.namespace,
+                    name,
+                    job.status,
+                    now - start_time,
+                )
+                last_log_time = now
+
+            if now - start_time >= timeout:
+                raise TimeoutError(
+                    f"Timeout waiting for Spark job to reach "
+                    f"{status}: {self.namespace}/{name} "
+                    f"(timeout: {timeout}s)"
+                )
+
+            time.sleep(polling_interval)
+
+    def get_job_logs(
+        self,
+        name: str,
+        follow: bool = False,
+    ) -> Iterator[str]:
+        """Get logs from a Spark job.
+
+        Logs are retrieved from the Kubernetes driver pod associated with the
+        SparkApplication. Log retrieval is only available while the driver pod
+        exists.
+
+        Args:
+            name: Name of the SparkApplication.
+            follow: Whether to stream logs continuously.
+
+        Yields:
+            Log lines from the SparkApplication driver pod.
+
+        Raises:
+            RuntimeError: If the driver pod does not exist or logs cannot be retrieved.
+            TimeoutError: If retrieving the driver pod logs times out.
+        """
+
+        job = self.get_job(name)
+
+        if not job.driver_pod_name:
+            raise RuntimeError(
+                f"No driver pod for {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{name}"
+            )
+
+        def _stream() -> Iterator[str]:
+            try:
+                yield from read_pod_logs(
+                    core_api=self.core_api,
+                    namespace=self.namespace,
+                    pod_name=job.driver_pod_name,
+                    follow=follow,
+                )
+
+            except TimeoutError as e:
+                raise TimeoutError(
+                    f"Timeout to get logs for "
+                    f"{constants.SPARK_APPLICATION_KIND}: "
+                    f"{self.namespace}/{name}"
+                ) from e
+
+            except RuntimeError as e:
+                raise RuntimeError(
+                    f"Failed to get logs for "
+                    f"{constants.SPARK_APPLICATION_KIND}: "
+                    f"{self.namespace}/{name}"
+                ) from e
+
+        return _stream()

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -814,6 +814,7 @@ class KubernetesBackend(RuntimeBackend):
         job: FileJob | FuncJob,
         num_executors: int | None = None,
         resources_per_executor: dict[str, str] | None = None,
+        options: list | None = None,
     ) -> SparkJob:
         """Submit a SparkApplication for batch execution.
 
@@ -826,6 +827,9 @@ class KubernetesBackend(RuntimeBackend):
 
             resources_per_executor:
                 Resource requirements per executor.
+
+            options:
+                List of configuration options (e.g. DriverResources).
 
         Returns:
             SparkJob information object.
@@ -856,6 +860,8 @@ class KubernetesBackend(RuntimeBackend):
             arguments=job.args,
             num_executors=num_executors,
             resources_per_executor=resources_per_executor,
+            options=options,
+            backend=self,
         )
 
         try:

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -18,13 +18,16 @@ import multiprocessing
 from unittest.mock import Mock, patch
 
 from kubeflow_spark_api import models
+from kubernetes import client
 from kubernetes.client import ApiException
 import pytest
 
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
-from kubeflow.spark.backends.kubernetes.utils import validate_spark_connect_url
+from kubeflow.spark.backends.kubernetes.utils import (
+    validate_spark_connect_url,
+)
 from kubeflow.spark.test.common import (
     DEFAULT_NAMESPACE,
     FAILED,
@@ -37,7 +40,13 @@ from kubeflow.spark.test.common import (
     TestCase,
 )
 from kubeflow.spark.types.options import Labels, Name
-from kubeflow.spark.types.types import SparkConnectInfo, SparkConnectState
+from kubeflow.spark.types.types import (
+    FileJob,
+    FuncJob,
+    SparkConnectInfo,
+    SparkConnectState,
+    SparkJobStatus,
+)
 
 # --------------------------
 # Fixtures
@@ -69,22 +78,62 @@ def kubernetes_backend():
 
 
 # --------------------------
-# Mock Handlers
+# Mock Helpers
 # --------------------------
 
 
-def create_mock_thread(response=None):
-    """Create mock thread that returns response on .get()."""
-    mock_thread = Mock()
-    mock_thread.get.return_value = response
-    return mock_thread
+def get_spark_application(
+    name: str,
+    namespace: str = DEFAULT_NAMESPACE,
+    state: str | None = "SUBMITTED",
+) -> models.SparkV1beta2SparkApplication:
+    """Create a mock SparkApplication model for testing."""
+    return models.SparkV1beta2SparkApplication(
+        api_version=f"{constants.SPARK_APPLICATION_GROUP}/{constants.SPARK_APPLICATION_VERSION}",
+        kind=constants.SPARK_APPLICATION_KIND,
+        metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+            name=name,
+            namespace=namespace,
+        ),
+        spec=models.SparkV1beta2SparkApplicationSpec(
+            type="Python",
+            mode="cluster",
+            spark_version="4.0.1",
+            image="spark:latest",
+            main_application_file="s3://job.py",
+            driver=models.SparkV1beta2DriverSpec(
+                cores=1,
+                memory="1g",
+            ),
+            executor=models.SparkV1beta2ExecutorSpec(
+                cores=1,
+                memory="1g",
+                instances=1,
+            ),
+        ),
+        status=(
+            models.SparkV1beta2SparkApplicationStatus(
+                application_state=models.SparkV1beta2ApplicationState(
+                    state=state,
+                ),
+                driver_info=models.SparkV1beta2DriverInfo(
+                    pod_name=f"{name}-driver",
+                ),
+            )
+            if state is not None
+            else None
+        ),
+    )
 
 
-def create_error_thread(exc: Exception):
-    """Create mock thread whose .get() raises the given exception."""
-    mock_thread = Mock()
-    mock_thread.get.side_effect = exc
-    return mock_thread
+def get_spark_application_list(
+    items: list[models.SparkV1beta2SparkApplication],
+) -> models.SparkV1beta2SparkApplicationList:
+    """Create a SparkApplicationList for testing."""
+
+    return models.SparkV1beta2SparkApplicationList(
+        items=items,
+    )
 
 
 def get_spark_connect(
@@ -123,6 +172,25 @@ def get_spark_connect(
     )
 
 
+def create_mock_thread(response=None):
+    """Create mock thread that returns response on .get()."""
+    mock_thread = Mock()
+    mock_thread.get.return_value = response
+    return mock_thread
+
+
+def create_error_thread(exc: Exception):
+    """Create mock thread whose .get() raises the given exception."""
+    mock_thread = Mock()
+    mock_thread.get.side_effect = exc
+    return mock_thread
+
+
+# --------------------------
+# Mock Handlers
+# --------------------------
+
+
 def mock_get_response(name: str) -> dict:
     """Return mock CR response based on session name."""
     if name == SPARK_CONNECT_READY:
@@ -138,11 +206,25 @@ def mock_get_response(name: str) -> dict:
         return get_spark_connect(name=name, state="Provisioning").to_dict()
     elif name == SPARK_CONNECT_FAILED:
         return get_spark_connect(name=name, state="Failed").to_dict()
+    elif name.startswith("spark-job-"):
+        return get_spark_application(name=name).to_dict()
     raise ApiException(status=404, reason="Not Found")
 
 
 def mock_list_response(*args, **kwargs) -> dict:
     """Return mock list response."""
+    plural = kwargs.get("plural")
+
+    if plural == constants.SPARK_APPLICATION_PLURAL:
+        return get_spark_application_list(
+            [
+                get_spark_application("job-submitted", state="SUBMITTED"),
+                get_spark_application("job-running", state="RUNNING"),
+                get_spark_application("job-completed", state="COMPLETED"),
+                get_spark_application("job-failed", state="FAILED"),
+            ]
+        ).to_dict()
+
     spark_connect_list = models.SparkV1alpha1SparkConnectList(
         api_version=f"{constants.SPARK_CONNECT_GROUP}/{constants.SPARK_CONNECT_VERSION}",
         kind="SparkConnectList",
@@ -163,6 +245,24 @@ def mock_create_response(*args, **kwargs) -> dict:
     return spark_connect.to_dict()
 
 
+def mock_create_spark_application_response(*args, **kwargs) -> dict:
+    """Return mock SparkApplication create response."""
+    body = kwargs.get("body", {})
+
+    spark_application = models.SparkV1beta2SparkApplication.from_dict(body)
+
+    spark_application.status = models.SparkV1beta2SparkApplicationStatus(
+        application_state=models.SparkV1beta2ApplicationState(
+            state="SUBMITTED",
+        ),
+        driver_info=models.SparkV1beta2DriverInfo(
+            pod_name=f"{spark_application.metadata.name}-driver"
+        ),
+    )
+
+    return spark_application.to_dict()
+
+
 def mock_delete_response(name: str) -> None:
     """Mock delete - raise 404 for unknown sessions."""
     if name.startswith("unknown"):
@@ -177,7 +277,10 @@ def _mock_create(*args, **kw):
         return create_error_thread(multiprocessing.TimeoutError())
     elif namespace == RUNTIME:
         return create_error_thread(RuntimeError())
-    return create_mock_thread(response=mock_create_response(**kw))
+    body = kw.get("body", {})
+    if body.get("kind") == constants.SPARK_APPLICATION_KIND:
+        return create_mock_thread(response=mock_create_spark_application_response(*args, **kw))
+    return create_mock_thread(response=mock_create_response(*args, **kw))
 
 
 def _mock_get(*args, **kw):
@@ -222,7 +325,7 @@ def _mock_list(*args, **kw):
         return create_error_thread(multiprocessing.TimeoutError())
     elif namespace == RUNTIME:
         return create_error_thread(RuntimeError())
-    return create_mock_thread(response=mock_list_response())
+    return create_mock_thread(response=mock_list_response(*args, **kw))
 
 
 def _mock_read_logs(*args, **kw):
@@ -486,14 +589,44 @@ def test_get_session_logs(kubernetes_backend, test_case):
         pod_name = test_case.config.get("pod_name", f"{test_case.config['name']}-0")
         kubernetes_backend.get_session = Mock(return_value=Mock(driver_pod_name=pod_name))
 
-        logs = list(kubernetes_backend.get_session_logs(test_case.config["name"], follow=False))
+        with patch(
+            "kubeflow.spark.backends.kubernetes.backend.read_pod_logs",
+        ) as mock_read_pod_logs:
+            if test_case.expected_status == SUCCESS:
+                mock_read_pod_logs.return_value = iter(
+                    [
+                        "log line 1",
+                        "log line 2",
+                    ]
+                )
 
-        if test_case.expected_status == SUCCESS:
-            assert len(logs) == 2
-            assert logs[0] == "log line 1"
-        else:
-            # Should not reach here for failed test cases
-            raise AssertionError(f"Expected {test_case.expected_error.__name__} but test succeeded")
+                logs = list(
+                    kubernetes_backend.get_session_logs(
+                        test_case.config["name"],
+                        follow=False,
+                    )
+                )
+
+                assert len(logs) == 2
+                assert logs[0] == "log line 1"
+
+                mock_read_pod_logs.assert_called_once_with(
+                    core_api=kubernetes_backend.core_api,
+                    namespace=DEFAULT_NAMESPACE,
+                    pod_name=pod_name,
+                    follow=False,
+                )
+
+            else:
+                mock_read_pod_logs.side_effect = test_case.expected_error()
+
+                with pytest.raises(test_case.expected_error):
+                    list(
+                        kubernetes_backend.get_session_logs(
+                            test_case.config["name"],
+                            follow=False,
+                        )
+                    )
 
     except Exception as e:
         if test_case.expected_status == FAILED:
@@ -736,4 +869,805 @@ def test_extract_name_option(kubernetes_backend, test_case):
 
     except Exception as e:
         assert type(e) is test_case.expected_error
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid remote file job",
+            expected_status=SUCCESS,
+            config={
+                "job": FileJob(
+                    file_source="s3://bucket/job.py",
+                    args=["--date", "2026-06-30"],
+                ),
+            },
+        ),
+        TestCase(
+            name="valid local file job",
+            expected_status=SUCCESS,
+            config={
+                "job": FileJob(
+                    file_source="local:///opt/spark/job.py",
+                ),
+            },
+        ),
+        TestCase(
+            name="empty file source",
+            expected_status=FAILED,
+            config={
+                "job": FileJob(file_source=""),
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="arguments not list",
+            expected_status=FAILED,
+            config={
+                "job": FileJob(
+                    file_source="s3://bucket/job.py",
+                    args="invalid",
+                ),
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="arguments contain non string",
+            expected_status=FAILED,
+            config={
+                "job": FileJob(
+                    file_source="s3://bucket/job.py",
+                    args=["ok", 1],
+                ),
+            },
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_validate_file_job(kubernetes_backend, test_case):
+    """Test KubernetesBackend._validate_file_job()."""
+    print("Executing test:", test_case.name)
+
+    try:
+        kubernetes_backend._validate_file_job(
+            test_case.config["job"],
+        )
+
+        assert test_case.expected_status == SUCCESS
+
+    except Exception as e:
+        assert type(e) is test_case.expected_error
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid file job",
+            expected_status=SUCCESS,
+            config={
+                "job": FileJob(
+                    file_source="s3://bucket/job.py",
+                ),
+            },
+        ),
+        TestCase(
+            name="function job not implemented",
+            expected_status=FAILED,
+            config={
+                "job": FuncJob(
+                    func=lambda: None,
+                ),
+            },
+            expected_error=NotImplementedError,
+        ),
+        TestCase(
+            name="invalid job type",
+            expected_status=FAILED,
+            config={
+                "job": "invalid-job",
+            },
+            expected_error=TypeError,
+        ),
+    ],
+)
+def test_validate_job(kubernetes_backend, test_case):
+    """Test KubernetesBackend._validate_job()."""
+    print("Executing test:", test_case.name)
+
+    try:
+        kubernetes_backend._validate_job(
+            test_case.config["job"],
+        )
+
+        assert test_case.expected_status == SUCCESS
+
+    except Exception as e:
+        assert type(e) is test_case.expected_error
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid remote file submission",
+            expected_status=SUCCESS,
+            config={
+                "job": FileJob(
+                    file_source="s3://bucket/job.py",
+                    args=["--date", "2026-06-30"],
+                ),
+            },
+        ),
+        TestCase(
+            name="timeout creating SparkApplication",
+            expected_status=FAILED,
+            config={
+                "namespace": TIMEOUT,
+                "job": FileJob(
+                    file_source="s3://bucket/job.py",
+                ),
+            },
+            expected_error=TimeoutError,
+        ),
+        TestCase(
+            name="runtime error creating SparkApplication",
+            expected_status=FAILED,
+            config={
+                "namespace": RUNTIME,
+                "job": FileJob(
+                    file_source="s3://bucket/job.py",
+                ),
+            },
+            expected_error=RuntimeError,
+        ),
+        TestCase(
+            name="invalid file job submission",
+            expected_status=FAILED,
+            config={
+                "job": FileJob(file_source=""),
+            },
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_submit_job(kubernetes_backend, test_case):
+    """Test KubernetesBackend.submit_job()."""
+    print("Executing test:", test_case.name)
+
+    try:
+        kubernetes_backend.namespace = test_case.config.get(
+            "namespace",
+            DEFAULT_NAMESPACE,
+        )
+
+        job = kubernetes_backend.submit_job(
+            job=test_case.config["job"],
+        )
+
+        assert test_case.expected_status == SUCCESS
+        assert job.name.startswith("spark-job-")
+
+    except Exception as e:
+        assert type(e) is test_case.expected_error
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="submitted job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-submitted",
+                "state": "SUBMITTED",
+            },
+            expected_output=SparkJobStatus.CREATED,
+        ),
+        TestCase(
+            name="running job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-running",
+                "state": "RUNNING",
+            },
+            expected_output=SparkJobStatus.RUNNING,
+        ),
+        TestCase(
+            name="succeeding job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-succeeding",
+                "state": "SUCCEEDING",
+            },
+            expected_output=SparkJobStatus.RUNNING,
+        ),
+        TestCase(
+            name="suspending job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-suspending",
+                "state": "SUSPENDING",
+            },
+            expected_output=SparkJobStatus.RUNNING,
+        ),
+        TestCase(
+            name="suspended job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-suspended",
+                "state": "SUSPENDED",
+            },
+            expected_output=SparkJobStatus.RUNNING,
+        ),
+        TestCase(
+            name="resuming job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-resuming",
+                "state": "RESUMING",
+            },
+            expected_output=SparkJobStatus.RUNNING,
+        ),
+        TestCase(
+            name="completed job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-completed",
+                "state": "COMPLETED",
+            },
+            expected_output=SparkJobStatus.COMPLETED,
+        ),
+        TestCase(
+            name="failed job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-failed",
+                "state": "FAILED",
+            },
+            expected_output=SparkJobStatus.FAILED,
+        ),
+        TestCase(
+            name="submission failed job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-submission-failed",
+                "state": "SUBMISSION_FAILED",
+            },
+            expected_output=SparkJobStatus.FAILED,
+        ),
+        TestCase(
+            name="failing job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-failing",
+                "state": "FAILING",
+            },
+            expected_output=SparkJobStatus.FAILED,
+        ),
+        TestCase(
+            name="pending rerun job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-pending-rerun",
+                "state": "PENDING_RERUN",
+            },
+            expected_output=SparkJobStatus.FAILED,
+        ),
+        TestCase(
+            name="invalidating job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-invalidating",
+                "state": "INVALIDATING",
+            },
+            expected_output=SparkJobStatus.FAILED,
+        ),
+        TestCase(
+            name="unknown state job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-unknown",
+                "state": "UNKNOWN",
+            },
+            expected_output=SparkJobStatus.FAILED,
+        ),
+        TestCase(
+            name="job not found",
+            expected_status=FAILED,
+            config={
+                "job_name": "unknown-job",
+                "api_status": 404,
+            },
+            expected_error=RuntimeError,
+        ),
+        TestCase(
+            name="api error getting job",
+            expected_status=FAILED,
+            config={
+                "job_name": "spark-job-api-error",
+                "api_status": 500,
+            },
+            expected_error=RuntimeError,
+        ),
+        TestCase(
+            name="runtime error getting job",
+            expected_status=FAILED,
+            config={
+                "namespace": RUNTIME,
+                "job_name": "spark-job-runtime",
+            },
+            expected_error=RuntimeError,
+        ),
+        TestCase(
+            name="new job without status",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-new",
+                "no_status": True,
+            },
+            expected_output=SparkJobStatus.CREATED,
+        ),
+    ],
+)
+def test_get_job(kubernetes_backend, test_case):
+    """Test get_job."""
+    print("Executing test:", test_case.name)
+
+    try:
+        kubernetes_backend.namespace = test_case.config.get(
+            "namespace",
+            DEFAULT_NAMESPACE,
+        )
+
+        if test_case.expected_status == SUCCESS:
+            with patch(
+                "kubeflow.spark.backends.kubernetes.backend.models.SparkV1beta2SparkApplication.from_dict"
+            ) as mock_from_dict:
+                if test_case.config.get("no_status"):
+                    mock_from_dict.return_value = get_spark_application(
+                        name=test_case.config["job_name"],
+                        state=None,
+                    )
+                else:
+                    mock_from_dict.return_value = get_spark_application(
+                        name=test_case.config["job_name"],
+                        state=test_case.config["state"],
+                    )
+
+                job = kubernetes_backend.get_job(
+                    test_case.config["job_name"],
+                )
+
+                assert job.name == test_case.config["job_name"]
+                assert job.status == test_case.expected_output
+
+        else:
+            api_status = test_case.config.get("api_status")
+
+            if api_status is not None:
+                with patch.object(
+                    kubernetes_backend.custom_api,
+                    "get_namespaced_custom_object",
+                    side_effect=client.ApiException(status=api_status),
+                ):
+                    with pytest.raises(RuntimeError) as exc_info:
+                        kubernetes_backend.get_job(
+                            test_case.config["job_name"],
+                        )
+
+                    if api_status == 404:
+                        assert "Spark job not found" in str(exc_info.value)
+                    else:
+                        assert "Failed to get Spark job" in str(exc_info.value)
+
+            else:
+                kubernetes_backend.get_job(
+                    test_case.config["job_name"],
+                )
+
+    except Exception as e:
+        assert type(e) is test_case.expected_error
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="list all jobs",
+            expected_status=SUCCESS,
+            config={},
+            expected_output=4,
+        ),
+        TestCase(
+            name="filter created jobs",
+            expected_status=SUCCESS,
+            config={
+                "status": {SparkJobStatus.CREATED},
+            },
+            expected_output=1,
+        ),
+        TestCase(
+            name="filter running jobs",
+            expected_status=SUCCESS,
+            config={
+                "status": {SparkJobStatus.RUNNING},
+            },
+            expected_output=1,
+        ),
+        TestCase(
+            name="filter completed jobs",
+            expected_status=SUCCESS,
+            config={
+                "status": {SparkJobStatus.COMPLETED},
+            },
+            expected_output=1,
+        ),
+        TestCase(
+            name="filter failed jobs",
+            expected_status=SUCCESS,
+            config={
+                "status": {SparkJobStatus.FAILED},
+            },
+            expected_output=1,
+        ),
+        TestCase(
+            name="timeout listing jobs",
+            expected_status=FAILED,
+            config={
+                "namespace": TIMEOUT,
+            },
+            expected_error=TimeoutError,
+        ),
+        TestCase(
+            name="runtime error listing jobs",
+            expected_status=FAILED,
+            config={
+                "namespace": RUNTIME,
+            },
+            expected_error=RuntimeError,
+        ),
+    ],
+)
+def test_list_jobs(kubernetes_backend, test_case):
+    """Test list_jobs."""
+    print("Executing test:", test_case.name)
+
+    try:
+        kubernetes_backend.namespace = test_case.config.get(
+            "namespace",
+            DEFAULT_NAMESPACE,
+        )
+
+        jobs = kubernetes_backend.list_jobs(
+            status=test_case.config.get("status"),
+        )
+
+        if test_case.expected_status == SUCCESS:
+            assert len(jobs) == test_case.expected_output
+
+    except Exception as e:
+        assert type(e) is test_case.expected_error
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid delete job",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-delete",
+            },
+        ),
+        TestCase(
+            name="job not found",
+            expected_status=FAILED,
+            config={
+                "job_name": "unknown-job",
+            },
+            expected_error=RuntimeError,
+        ),
+        TestCase(
+            name="timeout deleting job",
+            expected_status=FAILED,
+            config={
+                "namespace": TIMEOUT,
+                "job_name": "spark-job-timeout",
+            },
+            expected_error=TimeoutError,
+        ),
+        TestCase(
+            name="runtime error deleting job",
+            expected_status=FAILED,
+            config={
+                "namespace": RUNTIME,
+                "job_name": "spark-job-runtime",
+            },
+            expected_error=RuntimeError,
+        ),
+    ],
+)
+def test_delete_job(kubernetes_backend, test_case):
+    """Test delete_job."""
+    print("Executing test:", test_case.name)
+
+    try:
+        kubernetes_backend.namespace = test_case.config.get(
+            "namespace",
+            DEFAULT_NAMESPACE,
+        )
+
+        kubernetes_backend.delete_job(
+            test_case.config["job_name"],
+        )
+
+        assert test_case.expected_status == SUCCESS
+
+    except Exception as e:
+        assert type(e) is test_case.expected_error
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="job reaches target state",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-completed",
+                "job_status": SparkJobStatus.COMPLETED,
+                "target_status": {SparkJobStatus.COMPLETED},
+            },
+        ),
+        TestCase(
+            name="job reaches default completed state",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-completed",
+                "job_status": SparkJobStatus.COMPLETED,
+                "target_status": None,
+            },
+        ),
+        TestCase(
+            name="job fails before reaching target state",
+            expected_status=FAILED,
+            config={
+                "job_name": "spark-job-failed",
+                "job_status": SparkJobStatus.FAILED,
+                "target_status": {SparkJobStatus.COMPLETED},
+            },
+            expected_error=RuntimeError,
+        ),
+        TestCase(
+            name="job wait timeout",
+            expected_status=FAILED,
+            config={
+                "job_name": "spark-job-running",
+                "job_status": SparkJobStatus.RUNNING,
+                "target_status": {SparkJobStatus.COMPLETED},
+            },
+            expected_error=TimeoutError,
+        ),
+        TestCase(
+            name="job reaches failed target state",
+            expected_status=SUCCESS,
+            config={
+                "job_name": "spark-job-failed",
+                "job_status": SparkJobStatus.FAILED,
+                "target_status": {SparkJobStatus.FAILED},
+            },
+        ),
+        TestCase(
+            name="runtime error while polling",
+            expected_status=FAILED,
+            config={
+                "raise_error": RuntimeError(),
+            },
+            expected_error=RuntimeError,
+        ),
+        TestCase(
+            name="timeout error while polling",
+            expected_status=FAILED,
+            config={
+                "raise_error": TimeoutError(),
+            },
+            expected_error=TimeoutError,
+        ),
+    ],
+)
+def test_wait_for_job_status(kubernetes_backend, test_case):
+    """Test wait_for_job_status."""
+    print("Executing test:", test_case.name)
+
+    if "raise_error" in test_case.config:
+        with patch.object(
+            kubernetes_backend,
+            "get_job",
+            side_effect=test_case.config["raise_error"],
+        ):
+            if test_case.expected_status == SUCCESS:
+                kubernetes_backend.wait_for_job_status(
+                    name="test-job",
+                    status={SparkJobStatus.COMPLETED},
+                    timeout=1,
+                )
+            else:
+                with pytest.raises(test_case.expected_error):
+                    kubernetes_backend.wait_for_job_status(
+                        name="test-job",
+                        status={SparkJobStatus.COMPLETED},
+                        timeout=1,
+                    )
+
+    else:
+        mock_job = Mock()
+        mock_job.name = test_case.config["job_name"]
+        mock_job.status = test_case.config["job_status"]
+
+        with patch.object(
+            kubernetes_backend,
+            "get_job",
+            return_value=mock_job,
+        ):
+            kwargs = {
+                "name": test_case.config["job_name"],
+                "timeout": 1,
+                "polling_interval": 1,
+            }
+
+            if test_case.config["target_status"] is not None:
+                kwargs["status"] = test_case.config["target_status"]
+
+            if test_case.expected_status == SUCCESS:
+                job = kubernetes_backend.wait_for_job_status(**kwargs)
+                assert job.status == test_case.config["job_status"]
+            else:
+                with pytest.raises(test_case.expected_error):
+                    kubernetes_backend.wait_for_job_status(**kwargs)
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="get logs",
+            expected_status=SUCCESS,
+            config={
+                "follow": False,
+            },
+            expected_output=[
+                "log line 1",
+                "log line 2",
+            ],
+        ),
+        TestCase(
+            name="follow logs",
+            expected_status=SUCCESS,
+            config={
+                "follow": True,
+            },
+            expected_output=[
+                "log line 1",
+                "log line 2",
+            ],
+        ),
+        TestCase(
+            name="driver pod missing",
+            expected_status=FAILED,
+            config={
+                "driver_pod_name": None,
+            },
+            expected_error=RuntimeError,
+        ),
+        TestCase(
+            name="timeout reading logs",
+            expected_status=FAILED,
+            config={
+                "read_logs_error": TimeoutError(),
+            },
+            expected_error=TimeoutError,
+        ),
+        TestCase(
+            name="runtime error reading logs",
+            expected_status=FAILED,
+            config={
+                "read_logs_error": RuntimeError(),
+            },
+            expected_error=RuntimeError,
+        ),
+    ],
+)
+def test_get_job_logs(kubernetes_backend, test_case):
+    """Test get_job_logs."""
+    print("Executing test:", test_case.name)
+
+    try:
+        mock_job = Mock()
+
+        if "driver_pod_name" in test_case.config:
+            mock_job.driver_pod_name = test_case.config["driver_pod_name"]
+        else:
+            mock_job.driver_pod_name = "spark-job-driver"
+
+        with (
+            patch.object(
+                kubernetes_backend,
+                "get_job",
+                return_value=mock_job,
+            ),
+            patch(
+                "kubeflow.spark.backends.kubernetes.backend.read_pod_logs",
+            ) as mock_read_pod_logs,
+        ):
+            if test_case.expected_status == SUCCESS:
+                mock_read_pod_logs.return_value = iter(
+                    [
+                        "log line 1",
+                        "log line 2",
+                    ]
+                )
+
+                logs = list(
+                    kubernetes_backend.get_job_logs(
+                        "spark-job",
+                        follow=test_case.config.get("follow", False),
+                    )
+                )
+
+                assert logs == test_case.expected_output
+
+                mock_read_pod_logs.assert_called_once_with(
+                    core_api=kubernetes_backend.core_api,
+                    namespace=kubernetes_backend.namespace,
+                    pod_name="spark-job-driver",
+                    follow=test_case.config.get("follow", False),
+                )
+
+            elif "driver_pod_name" in test_case.config:
+                with pytest.raises(test_case.expected_error):
+                    list(
+                        kubernetes_backend.get_job_logs(
+                            "spark-job",
+                            follow=test_case.config.get("follow", False),
+                        )
+                    )
+
+                mock_read_pod_logs.assert_not_called()
+
+            else:
+                mock_read_pod_logs.side_effect = test_case.config["read_logs_error"]
+
+                with pytest.raises(test_case.expected_error):
+                    list(
+                        kubernetes_backend.get_job_logs(
+                            "spark-job",
+                            follow=test_case.config.get("follow", False),
+                        )
+                    )
+
+                mock_read_pod_logs.assert_called_once()
+
+    except Exception as e:
+        if test_case.expected_status == FAILED:
+            assert type(e) is test_case.expected_error
+        else:
+            raise
+
     print("test execution complete")

--- a/kubeflow/spark/backends/kubernetes/constants.py
+++ b/kubeflow/spark/backends/kubernetes/constants.py
@@ -20,6 +20,24 @@ SPARK_CONNECT_VERSION = "v1alpha1"
 SPARK_CONNECT_PLURAL = "sparkconnects"
 SPARK_CONNECT_KIND = "SparkConnect"
 
+# Spark Connect server port (must match Spark ConnectCommon.CONNECT_GRPC_BINDING_PORT)
+SPARK_CONNECT_PORT = 15002
+
+# Session name prefix
+SESSION_NAME_PREFIX = "spark-connect"
+
+# Spark Connect Maven package (required for Connect server main class on classpath)
+SPARK_CONNECT_PACKAGE_SCALA_VERSION = "2.13"
+
+# Spark job name prefix
+JOB_NAME_PREFIX = "spark-job"
+
+# SparkApplication CRD
+SPARK_APPLICATION_GROUP = "sparkoperator.k8s.io"
+SPARK_APPLICATION_VERSION = "v1beta2"
+SPARK_APPLICATION_PLURAL = "sparkapplications"
+SPARK_APPLICATION_KIND = "SparkApplication"
+
 # Default values; keep major.minor aligned with pyspark-connect in pyproject.toml
 DEFAULT_SPARK_VERSION = "4.0.1"
 DEFAULT_SPARK_IMAGE = "apache/spark:4.0.1"
@@ -31,12 +49,4 @@ DEFAULT_DRIVER_CPU = 1
 DEFAULT_DRIVER_MEMORY = "512Mi"
 DEFAULT_EXECUTOR_CPU = 1
 DEFAULT_EXECUTOR_MEMORY = "512Mi"
-
-# Spark Connect server port (must match Spark ConnectCommon.CONNECT_GRPC_BINDING_PORT)
-SPARK_CONNECT_PORT = 15002
-
-# Session name prefix
-SESSION_NAME_PREFIX = "spark-connect"
-
-# Spark Connect Maven package (required for Connect server main class on classpath)
-SPARK_CONNECT_PACKAGE_SCALA_VERSION = "2.13"
+DEFAULT_SERVICE_ACCOUNT = "spark-operator-spark"

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -14,15 +14,285 @@
 
 """Utility functions for Kubernetes Spark backend."""
 
+from collections.abc import Iterator
+import logging
+import math
+import multiprocessing
+import os
 import re
 from typing import Any
 from urllib.parse import urlparse
 import uuid
 
 from kubeflow_spark_api import models
+from kubernetes import client
 
+from kubeflow.common import constants as common_constants
 from kubeflow.spark.backends.kubernetes import constants
-from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo, SparkConnectState
+from kubeflow.spark.types.types import (
+    Driver,
+    Executor,
+    SparkConnectInfo,
+    SparkConnectState,
+    SparkJob,
+    SparkJobStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+# ----------------------------------------------------------------------
+# Shared utility functions
+# ----------------------------------------------------------------------
+
+
+def read_pod_logs(
+    core_api: client.CoreV1Api,
+    namespace: str,
+    pod_name: str,
+    follow: bool = False,
+) -> Iterator[str]:
+    """Read logs from a Kubernetes pod.
+
+    Args:
+        core_api: Kubernetes CoreV1Api client.
+        namespace: Kubernetes namespace.
+        pod_name: Name of the pod.
+        follow: Whether to stream logs continuously.
+
+    Yields:
+        Log lines from the pod.
+
+    Raises:
+        TimeoutError: If retrieving pod logs times out.
+        RuntimeError: If pod logs cannot be retrieved.
+    """
+    try:
+        if follow:
+            thread = core_api.read_namespaced_pod_log(
+                name=pod_name,
+                namespace=namespace,
+                follow=True,
+                _preload_content=False,
+                async_req=True,
+            )
+
+            resp = thread.get(common_constants.DEFAULT_TIMEOUT)
+
+            for line in resp.stream():
+                yield line.decode("utf-8").rstrip("\n")
+        else:
+            thread = core_api.read_namespaced_pod_log(
+                name=pod_name,
+                namespace=namespace,
+                async_req=True,
+            )
+
+            logs = thread.get(common_constants.DEFAULT_TIMEOUT)
+
+            for line in logs.split("\n"):
+                yield line
+
+    except multiprocessing.TimeoutError as e:
+        raise TimeoutError("Timeout while retrieving pod logs.") from e
+
+    except Exception as e:
+        raise RuntimeError("Failed to retrieve pod logs.") from e
+
+
+def _resolve_driver_resources(
+    driver: Driver | None = None,
+) -> tuple[int, str]:
+    """Resolve driver resource configuration.
+
+    Args:
+        driver: Driver configuration.
+
+    Returns:
+        Tuple of (cores, memory).
+
+    Raises:
+        ValueError:
+            If the configured CPU or memory values are invalid.
+    """
+
+    cores = constants.DEFAULT_DRIVER_CPU
+    memory = _memory_kubernetes_to_spark(constants.DEFAULT_DRIVER_MEMORY)
+
+    if driver and driver.resources:
+        if "cpu" in driver.resources:
+            cores = _validate_cpu_value(driver.resources["cpu"])
+
+        if "memory" in driver.resources:
+            memory = _memory_kubernetes_to_spark(
+                driver.resources["memory"],
+            )
+
+    return cores, memory
+
+
+def _resolve_executor_resources(
+    executor: Executor | None = None,
+    num_executors: int | None = None,
+    resources_per_executor: dict[str, str] | None = None,
+) -> tuple[int, int, str]:
+    """Resolve executor configuration.
+
+    Args:
+        executor: Executor configuration.
+        num_executors: Number of executor instances.
+        resources_per_executor: Resource requirements.
+
+    Returns:
+        Tuple containing (instances, cores, memory).
+
+    Raises:
+        ValueError:
+            If the configured CPU or memory values are invalid.
+    """
+
+    if executor and executor.num_instances is not None:
+        instances = executor.num_instances
+    elif num_executors is not None:
+        instances = num_executors
+    else:
+        instances = constants.DEFAULT_NUM_EXECUTORS
+
+    resource_dict = None
+
+    if executor and executor.resources_per_executor:
+        resource_dict = executor.resources_per_executor
+    elif resources_per_executor:
+        resource_dict = resources_per_executor
+
+    cores = constants.DEFAULT_EXECUTOR_CPU
+    memory = _memory_kubernetes_to_spark(
+        constants.DEFAULT_EXECUTOR_MEMORY,
+    )
+
+    if resource_dict:
+        if "cpu" in resource_dict:
+            cores = _validate_cpu_value(resource_dict["cpu"])
+
+        if "memory" in resource_dict:
+            memory = _memory_kubernetes_to_spark(
+                resource_dict["memory"],
+            )
+
+    return instances, cores, memory
+
+
+def _memory_kubernetes_to_spark(memory: str) -> str:
+    """Convert Kubernetes-style memory to Spark-compatible memory.
+
+    Spark accepts integer memory values with JVM suffixes (k, m, g, t).
+    Kubernetes quantities may contain fractional values (e.g. 1.5Gi), so
+    these are converted to an absolute MiB value.
+
+    Args:
+        memory: Memory value using Kubernetes or Spark notation.
+
+    Returns:
+        Memory value formatted using Spark-compatible units.
+    """
+    if not memory or not memory[-1].isalpha():
+        return memory
+
+    match = re.match(
+        r"^(\d+(?:\.\d+)?)\s*([KMGTPE]i?|[kmgtp]b?)$",
+        memory,
+        re.IGNORECASE,
+    )
+    if not match:
+        return memory
+
+    coefficient, suffix = match.group(1), (match.group(2) or "").lower()
+
+    exponent_by_suffix = {
+        "ki": 10,
+        "k": 10,
+        "kb": 10,
+        "mi": 20,
+        "m": 20,
+        "mb": 20,
+        "gi": 30,
+        "g": 30,
+        "gb": 30,
+        "ti": 40,
+        "t": 40,
+        "tb": 40,
+        "pi": 50,
+        "p": 50,
+        "pb": 50,
+        "ei": 60,
+    }
+
+    if suffix not in exponent_by_suffix:
+        return memory
+
+    exponent = exponent_by_suffix[suffix]
+
+    spark_suffix = {10: "k", 20: "m", 30: "g", 40: "t", 50: "p"}.get(exponent)
+    if "." not in coefficient and spark_suffix is not None:
+        return coefficient + spark_suffix
+
+    total_bytes = math.ceil(float(coefficient) * (2**exponent))
+    return f"{math.ceil(total_bytes / (2**20))}m"
+
+
+def _validate_cpu_value(cpu: str | int | None) -> int:
+    """Validate and normalize CPU cores value.
+
+    Args:
+        cpu: CPU value provided by user.
+
+    Returns:
+        Integer CPU core value.
+
+    Raises:
+        ValueError: If CPU value is invalid.
+    """
+    if cpu is None:
+        raise ValueError("CPU value cannot be None")
+
+    if isinstance(cpu, int):
+        cores = float(cpu)
+
+    elif isinstance(cpu, str):
+        cpu = cpu.strip()
+
+        if not cpu:
+            raise ValueError("CPU value cannot be empty")
+
+        if cpu.endswith("m"):
+            milli_cpu = cpu[:-1]
+
+            if "." in milli_cpu:
+                raise ValueError(
+                    f"Invalid CPU value '{cpu}'. Decimal milli-CPU values are not supported."
+                )
+
+            cores = int(milli_cpu) / 1000
+
+        else:
+            cores = float(cpu)
+
+    else:
+        raise ValueError(f"Invalid CPU type '{type(cpu)}'. Expected str or int.")
+
+    if not math.isfinite(cores) or cores <= 0:
+        raise ValueError(f"Invalid CPU value: {cpu!r}")
+
+    cores = math.ceil(cores)
+
+    if cores > 1024:
+        raise ValueError("CPU cores value is unrealistically large")
+
+    return cores
+
+
+# ----------------------------------------------------------------------
+# Spark Connect session utility functions
+# ----------------------------------------------------------------------
 
 
 def generate_session_name() -> str:
@@ -55,22 +325,6 @@ def validate_spark_connect_url(url: str) -> bool:
     return True
 
 
-def _memory_kubernetes_to_spark(memory: str) -> str:
-    """Convert Kubernetes-style memory (e.g. 4Gi, 512Mi) to Spark/JVM style (4g, 512m).
-
-    SparkSubmit expects JVM memory suffixes (k, m, g, t); Kubernetes uses Ki, Mi, Gi, Ti.
-    """
-    if not memory or not memory[-1].isalpha():
-        return memory
-    m = re.match(r"^(\d+(?:\.\d+)?)\s*([KMGTPE]i?|k|m|g|t|kb|mb|gb|tb)?$", memory, re.IGNORECASE)
-    if not m:
-        return memory
-    num, suffix = m.group(1), (m.group(2) or "").lower()
-    k8s_to_spark = {"ki": "k", "mi": "m", "gi": "g", "ti": "t", "pi": "p", "ei": "e"}
-    spark_suffix = k8s_to_spark.get(suffix, suffix.rstrip("b") if suffix else "")
-    return num + spark_suffix
-
-
 def build_service_url(info: SparkConnectInfo) -> str:
     """Build Spark Connect URL from session info.
 
@@ -84,7 +338,7 @@ def build_service_url(info: SparkConnectInfo) -> str:
     return f"sc://{service}.{info.namespace}.svc.cluster.local:{constants.SPARK_CONNECT_PORT}"
 
 
-def get_server_spec_from_driver(
+def get_spark_connect_driver_spec(
     driver: Driver | None = None,
 ) -> models.SparkV1alpha1ServerSpec:
     """Convert SDK Driver to API ServerSpec.
@@ -94,26 +348,22 @@ def get_server_spec_from_driver(
 
     Returns:
         API ServerSpec model.
+
+    Raises:
+        ValueError:
+            If the configured driver resources are invalid.
     """
-    cores = constants.DEFAULT_DRIVER_CPU
-    memory = _memory_kubernetes_to_spark(constants.DEFAULT_DRIVER_MEMORY)
+    cores, memory = _resolve_driver_resources(driver)
+
     template = None
 
-    if driver:
-        if driver.resources:
-            if "cpu" in driver.resources:
-                cores = int(driver.resources["cpu"])
-            if "memory" in driver.resources:
-                memory = _memory_kubernetes_to_spark(driver.resources["memory"])
-
-        if driver.service_account:
-            # PodSpec requires containers field (can be empty list)
-            template = models.IoK8sApiCoreV1PodTemplateSpec(
-                spec=models.IoK8sApiCoreV1PodSpec(
-                    containers=[],
-                    service_account_name=driver.service_account,
-                )
+    if driver and driver.service_account:
+        template = models.IoK8sApiCoreV1PodTemplateSpec(
+            spec=models.IoK8sApiCoreV1PodSpec(
+                containers=[],
+                service_account_name=driver.service_account,
             )
+        )
 
     return models.SparkV1alpha1ServerSpec(
         cores=cores,
@@ -122,7 +372,7 @@ def get_server_spec_from_driver(
     )
 
 
-def get_executor_spec_from_executor(
+def get_spark_connect_executor_spec(
     executor: Executor | None = None,
     num_executors: int | None = None,
     resources_per_executor: dict[str, str] | None = None,
@@ -140,31 +390,16 @@ def get_executor_spec_from_executor(
 
     Returns:
         API ExecutorSpec model.
+
+    Raises:
+        ValueError:
+            If the configured executor resources are invalid.
     """
-    # Determine number of instances
-    if executor and executor.num_instances:
-        instances = executor.num_instances
-    elif num_executors:
-        instances = num_executors
-    else:
-        instances = constants.DEFAULT_NUM_EXECUTORS
-
-    # Determine resource dict
-    resource_dict = None
-    if executor and executor.resources_per_executor:
-        resource_dict = executor.resources_per_executor
-    elif resources_per_executor:
-        resource_dict = resources_per_executor
-
-    # Extract cores and memory
-    cores = constants.DEFAULT_EXECUTOR_CPU
-    memory = _memory_kubernetes_to_spark(constants.DEFAULT_EXECUTOR_MEMORY)
-
-    if resource_dict:
-        if "cpu" in resource_dict:
-            cores = int(resource_dict["cpu"])
-        if "memory" in resource_dict:
-            memory = _memory_kubernetes_to_spark(resource_dict["memory"])
+    instances, cores, memory = _resolve_executor_resources(
+        executor,
+        num_executors,
+        resources_per_executor,
+    )
 
     return models.SparkV1alpha1ExecutorSpec(
         instances=instances,
@@ -196,7 +431,7 @@ def build_spark_connect_cr(
     Args:
         name: Session name.
         namespace: Kubernetes namespace.
-        spark_version: Spark version (default: 4.0.1).
+        spark_version: Spark version (default: `constants.DEFAULT_SPARK_VERSION`).
         num_executors: Number of executor instances (simple mode).
         resources_per_executor: Resource requirements per executor (simple mode).
         spark_conf: Spark configuration properties.
@@ -207,17 +442,26 @@ def build_spark_connect_cr(
 
     Returns:
         SparkConnect CR as typed Pydantic model.
+
+    Raises:
+        ValueError:
+            If the provided driver or executor resource configuration is invalid.
     """
     spark_version = spark_version or constants.DEFAULT_SPARK_VERSION
 
     # Build server spec using conversion function
-    server_spec = get_server_spec_from_driver(driver)
+    server_spec = get_spark_connect_driver_spec(driver)
 
     # Build executor spec using conversion function
-    executor_spec = get_executor_spec_from_executor(executor, num_executors, resources_per_executor)
+    executor_spec = get_spark_connect_executor_spec(executor, num_executors, resources_per_executor)
 
-    # Determine image (driver.image > default)
-    image = driver.image if driver and driver.image else constants.DEFAULT_SPARK_IMAGE
+    # Determine image (driver.image > SPARK_E2E_IMAGE > default)
+    default_image = os.environ.get(
+        "SPARK_E2E_IMAGE",
+        constants.DEFAULT_SPARK_IMAGE,
+    )
+
+    image = driver.image if driver and driver.image else default_image
 
     # Use direct JAR URL to avoid Ivy cache (container may not have writable ~/.ivy2)
     connect_jar_url = (
@@ -302,4 +546,158 @@ def get_spark_connect_info_from_cr(
         pod_ip=server_status.pod_ip if server_status else None,
         service_name=server_status.service_name if server_status else None,
         creation_timestamp=spark_connect_cr.metadata.creation_timestamp,
+    )
+
+
+# ----------------------------------------------------------------------
+# Spark batch job utility functions
+# ----------------------------------------------------------------------
+
+
+def generate_job_name() -> str:
+    """Generate a unique batch job name.
+
+    Returns:
+        Job name in format: spark-job-{uuid}.
+    """
+    short_uuid = str(uuid.uuid4())[:8]
+    return f"{constants.JOB_NAME_PREFIX}-{short_uuid}"
+
+
+def get_spark_job_driver_spec(
+    driver: Driver | None = None,
+) -> models.SparkV1beta2DriverSpec:
+    """Build DriverSpec for SparkApplication.
+
+    Returns:
+        SparkApplication DriverSpec model.
+
+    Raises:
+        ValueError:
+            If the default driver resource configuration is invalid.
+    """
+    cores, memory = _resolve_driver_resources(driver)
+
+    return models.SparkV1beta2DriverSpec(
+        cores=cores,
+        memory=memory,
+        service_account=constants.DEFAULT_SERVICE_ACCOUNT,
+    )
+
+
+def get_spark_job_executor_spec(
+    num_executors: int | None = None,
+    resources_per_executor: dict[str, str] | None = None,
+) -> models.SparkV1beta2ExecutorSpec:
+    """Build ExecutorSpec for SparkApplication.
+
+    Args:
+        num_executors: Number of executor instances.
+        resources_per_executor: Resource requirements for each executor.
+
+    Returns:
+        SparkApplication ExecutorSpec model.
+
+    Raises:
+        ValueError:
+            If the configured executor resources are invalid.
+    """
+    instances, cores, memory = _resolve_executor_resources(
+        num_executors=num_executors,
+        resources_per_executor=resources_per_executor,
+    )
+
+    return models.SparkV1beta2ExecutorSpec(
+        instances=instances,
+        cores=cores,
+        memory=memory,
+    )
+
+
+def build_spark_application_cr(
+    name: str,
+    namespace: str,
+    main_file: str,
+    arguments: list[str] | None = None,
+    num_executors: int | None = None,
+    resources_per_executor: dict[str, str] | None = None,
+) -> models.SparkV1beta2SparkApplication:
+    """Build a SparkApplication custom resource.
+
+    Args:
+        name: Job name.
+        namespace: Kubernetes namespace.
+        main_file: Application file path or URI.
+        arguments: Command-line arguments.
+        num_executors: Number of executor instances.
+        resources_per_executor: Resource requirements for each executor.
+
+    Returns:
+        SparkApplication custom resource model.
+
+    Raises:
+        ValueError:
+            If the executor resource configuration is invalid.
+    """
+    return models.SparkV1beta2SparkApplication(
+        api_version=f"{constants.SPARK_APPLICATION_GROUP}/{constants.SPARK_APPLICATION_VERSION}",
+        kind=constants.SPARK_APPLICATION_KIND,
+        metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+            name=name,
+            namespace=namespace,
+        ),
+        spec=models.SparkV1beta2SparkApplicationSpec(
+            spark_version=constants.DEFAULT_SPARK_VERSION,
+            type="Python",
+            mode="cluster",
+            image=constants.DEFAULT_SPARK_IMAGE,
+            main_application_file=main_file,
+            arguments=arguments or None,
+            driver=get_spark_job_driver_spec(),
+            executor=get_spark_job_executor_spec(
+                num_executors=num_executors,
+                resources_per_executor=resources_per_executor,
+            ),
+        ),
+    )
+
+
+def get_spark_application_info_from_cr(
+    cr: models.SparkV1beta2SparkApplication,
+) -> SparkJob:
+    """Convert SparkApplication CR to SparkJob.
+
+    Args:
+        cr: SparkApplication custom resource.
+
+    Returns:
+        SparkJob information object.
+    """
+    if not (cr.metadata and cr.metadata.name):
+        raise ValueError(f"SparkApplication CR is invalid: {cr}")
+
+    status = SparkJobStatus.CREATED
+    creation_timestamp = cr.metadata.creation_timestamp
+    num_executors = None
+    driver_pod_name = None
+
+    if cr.spec and cr.spec.executor:
+        num_executors = cr.spec.executor.instances
+
+    if cr.status:
+        if cr.status.application_state:
+            status = SparkJobStatus.from_operator_state(
+                cr.status.application_state.state,
+            )
+
+        if cr.status.driver_info:
+            driver_pod_name = cr.status.driver_info.pod_name
+
+    return SparkJob(
+        name=cr.metadata.name,
+        namespace=cr.metadata.namespace or "",
+        status=status,
+        creation_timestamp=creation_timestamp,
+        num_executors=num_executors,
+        driver_pod_name=driver_pod_name,
     )

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -621,6 +621,8 @@ def build_spark_application_cr(
     arguments: list[str] | None = None,
     num_executors: int | None = None,
     resources_per_executor: dict[str, str] | None = None,
+    options: list | None = None,
+    backend: Any | None = None,
 ) -> models.SparkV1beta2SparkApplication:
     """Build a SparkApplication custom resource.
 
@@ -631,6 +633,8 @@ def build_spark_application_cr(
         arguments: Command-line arguments.
         num_executors: Number of executor instances.
         resources_per_executor: Resource requirements for each executor.
+        options: List of configuration options (e.g. DriverResources).
+        backend: Backend instance for option validation.
 
     Returns:
         SparkApplication custom resource model.
@@ -639,7 +643,7 @@ def build_spark_application_cr(
         ValueError:
             If the executor resource configuration is invalid.
     """
-    return models.SparkV1beta2SparkApplication(
+    spark_application = models.SparkV1beta2SparkApplication(
         api_version=f"{constants.SPARK_APPLICATION_GROUP}/{constants.SPARK_APPLICATION_VERSION}",
         kind=constants.SPARK_APPLICATION_KIND,
         metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
@@ -660,6 +664,14 @@ def build_spark_application_cr(
             ),
         ),
     )
+
+    # Apply options - extensibility without API changes (callable pattern)
+    if options and backend is not None:
+        for option in options:
+            if callable(option):
+                option(spark_application, backend)
+
+    return spark_application
 
 
 def get_spark_application_info_from_cr(

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -14,19 +14,38 @@
 
 """Unit tests for Kubernetes Spark backend utilities."""
 
+from datetime import datetime
+import multiprocessing
+from unittest.mock import Mock, patch
+
 from kubeflow_spark_api import models
 import pytest
 
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.utils import (
     _memory_kubernetes_to_spark,
+    _resolve_driver_resources,
+    _resolve_executor_resources,
+    _validate_cpu_value,
     build_service_url,
+    build_spark_application_cr,
     build_spark_connect_cr,
+    generate_job_name,
     generate_session_name,
+    get_spark_application_info_from_cr,
     get_spark_connect_info_from_cr,
+    get_spark_job_driver_spec,
+    get_spark_job_executor_spec,
+    read_pod_logs,
     validate_spark_connect_url,
 )
-from kubeflow.spark.types.types import Driver, Executor, SparkConnectInfo, SparkConnectState
+from kubeflow.spark.types.types import (
+    Driver,
+    Executor,
+    SparkConnectInfo,
+    SparkConnectState,
+    SparkJobStatus,
+)
 
 
 class TestMemoryKubernetesToSpark:
@@ -42,6 +61,7 @@ class TestMemoryKubernetesToSpark:
             ("4g", "4g"),
             ("512m", "512m"),
             ("2G", "2g"),
+            ("1.5Gi", "1536m"),
         ],
     )
     def test_conversion(self, k8s_memory: str, expected_spark: str) -> None:
@@ -405,3 +425,496 @@ class TestGetSparkConnectInfoFromCr:
         )
         with pytest.raises(ValueError, match="SparkConnect CR is invalid"):
             get_spark_connect_info_from_cr(spark_connect_cr)
+
+
+class TestGenerateJobName:
+    """Tests for generate_job_name function."""
+
+    def test_generates_unique_name(self):
+        name = generate_job_name()
+
+        assert name.startswith("spark-job-")
+        assert len(name) > len("spark-job-")
+
+    def test_generates_different_names(self):
+        names = {generate_job_name() for _ in range(10)}
+
+        assert len(names) == 10
+
+
+class TestValidateCpuValue:
+    """Tests for _validate_cpu_value."""
+
+    @pytest.mark.parametrize(
+        "cpu,expected",
+        [
+            ("1", 1),
+            ("4", 4),
+            ("1.5", 2),
+            ("500m", 1),
+            ("1500m", 2),
+            ("2500m", 3),
+            (" 1500m ", 2),
+            (2, 2),
+            (16, 16),
+        ],
+    )
+    def test_valid_cpu_values(self, cpu, expected):
+        """Valid CPU values are converted to Spark cores."""
+        assert _validate_cpu_value(cpu) == expected
+
+    @pytest.mark.parametrize(
+        "cpu",
+        [
+            None,
+            "",
+            " ",
+            "abc",
+            "50O0m",
+            "0",
+            "-1",
+            "-500m",
+            "1.5m",
+            "nan",
+            "inf",
+            0,
+            -1,
+            2048,
+        ],
+    )
+    def test_invalid_cpu_values(self, cpu):
+        """Invalid CPU values raise ValueError."""
+        with pytest.raises(ValueError):
+            _validate_cpu_value(cpu)
+
+
+class TestResolveDriverResources:
+    """Tests for _resolve_driver_resources."""
+
+    def test_defaults(self):
+        """Default driver resources are returned when no Driver is provided."""
+
+        cores, memory = _resolve_driver_resources()
+
+        assert cores == constants.DEFAULT_DRIVER_CPU
+        assert memory == _memory_kubernetes_to_spark(
+            constants.DEFAULT_DRIVER_MEMORY,
+        )
+
+    def test_driver_resources(self):
+        """Driver resources override defaults."""
+
+        driver = Driver(
+            resources={
+                "cpu": "2",
+                "memory": "4Gi",
+            },
+        )
+
+        cores, memory = _resolve_driver_resources(driver)
+
+        assert cores == 2
+        assert memory == "4g"
+
+    def test_driver_fractional_memory(self):
+        """Fractional Kubernetes memory is converted to MiB."""
+
+        driver = Driver(
+            resources={
+                "cpu": "2",
+                "memory": "1.5Gi",
+            },
+        )
+
+        cores, memory = _resolve_driver_resources(driver)
+
+        assert cores == 2
+        assert memory == "1536m"
+
+
+class TestResolveExecutorResources:
+    """Tests for _resolve_executor_resources."""
+
+    def test_defaults(self):
+        """Default executor resources are returned."""
+
+        instances, cores, memory = _resolve_executor_resources()
+
+        assert instances == constants.DEFAULT_NUM_EXECUTORS
+        assert cores == constants.DEFAULT_EXECUTOR_CPU
+        assert memory == _memory_kubernetes_to_spark(
+            constants.DEFAULT_EXECUTOR_MEMORY,
+        )
+
+    def test_simple_parameters(self):
+        """Simple executor parameters override defaults."""
+
+        instances, cores, memory = _resolve_executor_resources(
+            num_executors=3,
+            resources_per_executor={
+                "cpu": "2",
+                "memory": "4Gi",
+            },
+        )
+
+        assert instances == 3
+        assert cores == 2
+        assert memory == "4g"
+
+    def test_executor_precedence(self):
+        """Executor configuration takes precedence over simple parameters."""
+
+        executor = Executor(
+            num_instances=5,
+            resources_per_executor={
+                "cpu": "8",
+                "memory": "16Gi",
+            },
+        )
+
+        instances, cores, memory = _resolve_executor_resources(
+            executor=executor,
+            num_executors=2,
+            resources_per_executor={
+                "cpu": "4",
+                "memory": "8Gi",
+            },
+        )
+
+        assert instances == 5
+        assert cores == 8
+        assert memory == "16g"
+
+    def test_executor_fractional_memory(self):
+        """Fractional executor memory is converted to MiB."""
+
+        instances, cores, memory = _resolve_executor_resources(
+            resources_per_executor={
+                "cpu": "2",
+                "memory": "1.5Gi",
+            },
+        )
+
+        assert instances == constants.DEFAULT_NUM_EXECUTORS
+        assert cores == 2
+        assert memory == "1536m"
+
+
+class TestReadPodLogs:
+    """Tests for read_pod_logs."""
+
+    def test_read_logs(self):
+        """Read pod logs without following."""
+
+        core_api = Mock()
+
+        thread = Mock()
+        thread.get.return_value = "log line 1\nlog line 2"
+
+        core_api.read_namespaced_pod_log.return_value = thread
+
+        logs = list(
+            read_pod_logs(
+                core_api=core_api,
+                namespace="default",
+                pod_name="driver-pod",
+            )
+        )
+
+        assert logs == [
+            "log line 1",
+            "log line 2",
+        ]
+
+        core_api.read_namespaced_pod_log.assert_called_once_with(
+            name="driver-pod",
+            namespace="default",
+            async_req=True,
+        )
+
+    def test_follow_logs(self):
+        """Stream pod logs."""
+
+        core_api = Mock()
+
+        stream = Mock()
+        stream.stream.return_value = iter(
+            [
+                b"log line 1\n",
+                b"log line 2\n",
+            ]
+        )
+
+        thread = Mock()
+        thread.get.return_value = stream
+
+        core_api.read_namespaced_pod_log.return_value = thread
+
+        logs = list(
+            read_pod_logs(
+                core_api=core_api,
+                namespace="default",
+                pod_name="driver-pod",
+                follow=True,
+            )
+        )
+
+        assert logs == [
+            "log line 1",
+            "log line 2",
+        ]
+
+        core_api.read_namespaced_pod_log.assert_called_once_with(
+            name="driver-pod",
+            namespace="default",
+            follow=True,
+            _preload_content=False,
+            async_req=True,
+        )
+
+    def test_timeout(self):
+        """Timeout while reading pod logs."""
+
+        core_api = Mock()
+
+        thread = Mock()
+        thread.get.side_effect = multiprocessing.TimeoutError()
+
+        core_api.read_namespaced_pod_log.return_value = thread
+
+        with pytest.raises(TimeoutError):
+            list(
+                read_pod_logs(
+                    core_api=core_api,
+                    namespace="default",
+                    pod_name="driver-pod",
+                )
+            )
+
+    def test_runtime_error(self):
+        """Runtime error while reading pod logs."""
+
+        core_api = Mock()
+
+        thread = Mock()
+        thread.get.side_effect = RuntimeError()
+
+        core_api.read_namespaced_pod_log.return_value = thread
+
+        with pytest.raises(RuntimeError):
+            list(
+                read_pod_logs(
+                    core_api=core_api,
+                    namespace="default",
+                    pod_name="driver-pod",
+                )
+            )
+
+
+class TestGetSparkJobDriverSpec:
+    """Tests for get_spark_job_driver_spec."""
+
+    def test_defaults(self):
+        """Default SparkApplication driver spec."""
+        spec = get_spark_job_driver_spec()
+
+        assert spec.cores == constants.DEFAULT_DRIVER_CPU
+        assert spec.memory == _memory_kubernetes_to_spark(constants.DEFAULT_DRIVER_MEMORY)
+        assert spec.service_account == constants.DEFAULT_SERVICE_ACCOUNT
+
+
+class TestGetSparkJobExecutorSpec:
+    """Tests for get_spark_job_executor_spec."""
+
+    def test_defaults(self):
+        """Default SparkApplication executor spec."""
+        spec = get_spark_job_executor_spec()
+
+        assert spec.cores == constants.DEFAULT_EXECUTOR_CPU
+        assert spec.memory == _memory_kubernetes_to_spark(constants.DEFAULT_EXECUTOR_MEMORY)
+        assert spec.instances == constants.DEFAULT_NUM_EXECUTORS
+
+
+class TestBuildSparkApplicationCr:
+    """Tests for build_spark_application_cr."""
+
+    def test_remote_uri_job(self):
+        app = build_spark_application_cr(
+            name="test-job",
+            namespace="default",
+            main_file="s3://bucket/job.py",
+            arguments=["--date", "2026-06-30"],
+            num_executors=3,
+            resources_per_executor={
+                "cpu": "2",
+                "memory": "4Gi",
+            },
+        )
+
+        assert app.metadata.name == "test-job"
+        assert app.metadata.namespace == "default"
+
+        assert app.spec.main_application_file == "s3://bucket/job.py"
+        assert app.spec.arguments == ["--date", "2026-06-30"]
+
+        assert app.spec.driver.cores == 1
+        assert app.spec.driver.memory == _memory_kubernetes_to_spark(
+            constants.DEFAULT_DRIVER_MEMORY
+        )
+        assert app.spec.driver.service_account == constants.DEFAULT_SERVICE_ACCOUNT
+
+        assert app.spec.executor.instances == 3
+        assert app.spec.executor.cores == 2
+        assert app.spec.executor.memory == _memory_kubernetes_to_spark("4Gi")
+
+
+class TestGetSparkApplicationInfoFromCr:
+    """Tests for get_spark_application_info_from_cr."""
+
+    @pytest.fixture
+    def minimal_spec(self):
+        """Create minimal SparkApplication spec."""
+        return models.SparkV1beta2SparkApplicationSpec(
+            spark_version=constants.DEFAULT_SPARK_VERSION,
+            type="Python",
+            mode="cluster",
+            image=constants.DEFAULT_SPARK_IMAGE,
+            main_application_file="s3://bucket/job.py",
+            driver=models.SparkV1beta2DriverSpec(
+                cores=1,
+                memory="1g",
+            ),
+            executor=models.SparkV1beta2ExecutorSpec(
+                cores=2,
+                memory="2g",
+                instances=5,
+            ),
+        )
+
+    @pytest.mark.parametrize(
+        "spark_state,expected_status",
+        [
+            ("SUBMITTED", SparkJobStatus.CREATED),
+            ("RUNNING", SparkJobStatus.RUNNING),
+            ("SUCCEEDING", SparkJobStatus.RUNNING),
+            ("SUSPENDING", SparkJobStatus.RUNNING),
+            ("SUSPENDED", SparkJobStatus.RUNNING),
+            ("RESUMING", SparkJobStatus.RUNNING),
+            ("COMPLETED", SparkJobStatus.COMPLETED),
+            ("FAILED", SparkJobStatus.FAILED),
+            ("SUBMISSION_FAILED", SparkJobStatus.FAILED),
+            ("FAILING", SparkJobStatus.FAILED),
+            ("PENDING_RERUN", SparkJobStatus.FAILED),
+            ("INVALIDATING", SparkJobStatus.FAILED),
+        ],
+    )
+    def test_status_mapping(
+        self,
+        minimal_spec,
+        spark_state,
+        expected_status,
+    ):
+        creation_timestamp = datetime.now()
+
+        spark_app = models.SparkV1beta2SparkApplication(
+            metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+                name="test-job",
+                namespace="default",
+                creation_timestamp=creation_timestamp,
+            ),
+            spec=minimal_spec,
+            status=models.SparkV1beta2SparkApplicationStatus(
+                application_state=models.SparkV1beta2ApplicationState(
+                    state=spark_state,
+                ),
+                driver_info=models.SparkV1beta2DriverInfo(
+                    pod_name="test-driver",
+                ),
+            ),
+        )
+
+        job = get_spark_application_info_from_cr(
+            spark_app,
+        )
+
+        assert job.name == "test-job"
+        assert job.namespace == "default"
+        assert job.status == expected_status
+        assert job.driver_pod_name == "test-driver"
+        assert job.creation_timestamp == creation_timestamp
+        assert job.num_executors == 5
+
+    def test_without_status(self, minimal_spec):
+        creation_timestamp = datetime.now()
+
+        spark_app = models.SparkV1beta2SparkApplication(
+            metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+                name="new-job",
+                namespace="default",
+                creation_timestamp=creation_timestamp,
+            ),
+            spec=minimal_spec,
+        )
+
+        job = get_spark_application_info_from_cr(
+            spark_app,
+        )
+
+        assert job.name == "new-job"
+        assert job.namespace == "default"
+        assert job.status == SparkJobStatus.CREATED
+        assert job.driver_pod_name is None
+        assert job.creation_timestamp == creation_timestamp
+        assert job.num_executors == 5
+
+    def test_uses_from_operator_state(self, minimal_spec):
+        """Verify SparkApplication status is mapped to SparkJobStatus."""
+
+        creation_timestamp = datetime.now()
+
+        spark_app = models.SparkV1beta2SparkApplication(
+            metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+                name="test-job",
+                namespace="default",
+                creation_timestamp=creation_timestamp,
+            ),
+            spec=minimal_spec,
+            status=models.SparkV1beta2SparkApplicationStatus(
+                application_state=models.SparkV1beta2ApplicationState(
+                    state="RUNNING",
+                ),
+                driver_info=models.SparkV1beta2DriverInfo(
+                    pod_name="test-driver",
+                ),
+            ),
+        )
+
+        with patch.object(
+            SparkJobStatus,
+            "from_operator_state",
+            return_value=SparkJobStatus.RUNNING,
+        ) as mock_from_operator_state:
+            job = get_spark_application_info_from_cr(spark_app)
+
+        mock_from_operator_state.assert_called_once_with("RUNNING")
+
+        assert job.name == "test-job"
+        assert job.namespace == "default"
+        assert job.status == SparkJobStatus.RUNNING
+        assert job.driver_pod_name == "test-driver"
+        assert job.creation_timestamp == creation_timestamp
+        assert job.num_executors == 5
+
+    def test_invalid_metadata(self, minimal_spec):
+        """Test invalid SparkApplication CR raises ValueError."""
+
+        spark_app = models.SparkV1beta2SparkApplication.model_construct(
+            metadata=None,
+            spec=minimal_spec,
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="SparkApplication CR is invalid",
+        ):
+            get_spark_application_info_from_cr(spark_app)

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -16,12 +16,13 @@
 
 from datetime import datetime
 import multiprocessing
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from kubeflow_spark_api import models
 import pytest
 
 from kubeflow.spark.backends.kubernetes import constants
+from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
 from kubeflow.spark.backends.kubernetes.utils import (
     _memory_kubernetes_to_spark,
     _resolve_driver_resources,
@@ -39,6 +40,7 @@ from kubeflow.spark.backends.kubernetes.utils import (
     read_pod_logs,
     validate_spark_connect_url,
 )
+from kubeflow.spark.types.options import DriverResources
 from kubeflow.spark.types.types import (
     Driver,
     Executor,
@@ -766,6 +768,23 @@ class TestBuildSparkApplicationCr:
         assert app.spec.executor.instances == 3
         assert app.spec.executor.cores == 2
         assert app.spec.executor.memory == _memory_kubernetes_to_spark("4Gi")
+
+    def test_with_driver_resources_option(self):
+        """DriverResources option overrides default driver cores and memory."""
+        backend = MagicMock(spec=KubernetesBackend)
+        backend.__class__ = KubernetesBackend
+
+        app = build_spark_application_cr(
+            name="test-job",
+            namespace="default",
+            main_file="s3://bucket/job.py",
+            options=[DriverResources({"cpu": "2", "memory": "4Gi"})],
+            backend=backend,
+        )
+
+        assert app.spec.driver.cores == 2
+        assert app.spec.driver.memory == _memory_kubernetes_to_spark("4Gi")
+        assert app.spec.driver.service_account == constants.DEFAULT_SERVICE_ACCOUNT
 
 
 class TestGetSparkApplicationInfoFromCr:

--- a/kubeflow/spark/types/options.py
+++ b/kubeflow/spark/types/options.py
@@ -409,3 +409,67 @@ class Name:
             )
 
         spark_connect.metadata.name = self.name
+
+
+@dataclass
+class DriverResources:
+    """Override SparkApplication driver CPU and memory resources.
+
+    By default, SparkJob driver resources use ``DEFAULT_DRIVER_CPU`` and
+    ``DEFAULT_DRIVER_MEMORY`` from the Spark Kubernetes constants module.
+    This option overrides those defaults when submitting a batch job.
+
+    Supported backends:
+        - Kubernetes
+
+    Args:
+        resources: Resource requirements as a dict
+            (e.g., ``{"cpu": "2", "memory": "4Gi"}``).
+
+    Example:
+        ```python
+        from kubeflow.spark import SparkClient, FileJob, DriverResources
+
+        client = SparkClient()
+        job_name = client.submit_job(
+            job=FileJob(file_source="s3a://bucket/job.py"),
+            options=[DriverResources({"cpu": "2", "memory": "4Gi"})],
+        )
+        ```
+    """
+
+    resources: dict[str, str]
+
+    def __call__(
+        self,
+        spark_application: models.SparkV1beta2SparkApplication,
+        backend: RuntimeBackend,
+    ) -> None:
+        """Apply driver resource overrides to a SparkApplication model.
+
+        Args:
+            spark_application: SparkApplication model to modify.
+            backend: Backend instance for validation.
+
+        Raises:
+            ValueError: If backend does not support driver resources, the
+                SparkApplication has no driver spec, or resource values are invalid.
+        """
+        from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
+        from kubeflow.spark.backends.kubernetes.utils import _resolve_driver_resources
+        from kubeflow.spark.types.types import Driver
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"DriverResources option is not compatible with {type(backend).__name__}. "
+                f"Supported backends: KubernetesBackend"
+            )
+
+        if spark_application.spec is None or spark_application.spec.driver is None:
+            raise ValueError(
+                "SparkApplication must have a driver spec before applying DriverResources."
+            )
+
+        cores, memory = _resolve_driver_resources(Driver(resources=self.resources))
+        spark_application.spec.driver.cores = cores
+        spark_application.spec.driver.memory = memory

--- a/kubeflow/spark/types/options_test.py
+++ b/kubeflow/spark/types/options_test.py
@@ -23,6 +23,7 @@ from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
 from kubeflow.spark.types.options import (
     Annotations,
+    DriverResources,
     Labels,
     Name,
     NodeSelector,
@@ -276,3 +277,87 @@ class TestNameOption:
 
         with pytest.raises(ValueError, match="not compatible"):
             option(spark_connect_model, mock_non_k8s_backend)
+
+
+@pytest.fixture
+def spark_application_model():
+    """Create a minimal SparkApplication model for testing."""
+    return models.SparkV1beta2SparkApplication(
+        api_version=f"{constants.SPARK_APPLICATION_GROUP}/{constants.SPARK_APPLICATION_VERSION}",
+        kind=constants.SPARK_APPLICATION_KIND,
+        metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+            name="test-job",
+            namespace="default",
+        ),
+        spec=models.SparkV1beta2SparkApplicationSpec(
+            spark_version=constants.DEFAULT_SPARK_VERSION,
+            type="Python",
+            mode="cluster",
+            image=constants.DEFAULT_SPARK_IMAGE,
+            main_application_file="s3://bucket/job.py",
+            driver=models.SparkV1beta2DriverSpec(
+                cores=constants.DEFAULT_DRIVER_CPU,
+                memory=constants.DEFAULT_DRIVER_MEMORY,
+            ),
+            executor=models.SparkV1beta2ExecutorSpec(
+                instances=1,
+                cores=constants.DEFAULT_EXECUTOR_CPU,
+                memory=constants.DEFAULT_EXECUTOR_MEMORY,
+            ),
+        ),
+    )
+
+
+class TestDriverResources:
+    """Tests for DriverResources option."""
+
+    def test_driver_resources_apply_to_crd(self, mock_k8s_backend, spark_application_model):
+        """DriverResources option overrides driver cores and memory."""
+        option = DriverResources({"cpu": "2", "memory": "4Gi"})
+
+        option(spark_application_model, mock_k8s_backend)
+
+        assert spark_application_model.spec.driver.cores == 2
+        assert spark_application_model.spec.driver.memory == "4g"
+
+    def test_driver_resources_cpu_only(self, mock_k8s_backend, spark_application_model):
+        """DriverResources with only CPU leaves memory at the existing value after resolve."""
+        option = DriverResources({"cpu": "4"})
+
+        option(spark_application_model, mock_k8s_backend)
+
+        assert spark_application_model.spec.driver.cores == 4
+        # Memory falls back to DEFAULT_DRIVER_MEMORY when not provided
+        assert spark_application_model.spec.driver.memory == "512m"
+
+    def test_driver_resources_incompatible_backend(
+        self, mock_non_k8s_backend, spark_application_model
+    ):
+        """DriverResources option raises error for incompatible backend."""
+        option = DriverResources({"cpu": "2", "memory": "4Gi"})
+
+        with pytest.raises(ValueError, match="not compatible"):
+            option(spark_application_model, mock_non_k8s_backend)
+
+    def test_driver_resources_missing_driver_spec(self, mock_k8s_backend):
+        """DriverResources raises when SparkApplication has no driver spec."""
+        spark_application = models.SparkV1beta2SparkApplication.model_construct(
+            api_version=f"{constants.SPARK_APPLICATION_GROUP}/{constants.SPARK_APPLICATION_VERSION}",
+            kind=constants.SPARK_APPLICATION_KIND,
+            metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+                name="test-job",
+                namespace="default",
+            ),
+            spec=None,
+        )
+        option = DriverResources({"cpu": "2", "memory": "4Gi"})
+
+        with pytest.raises(ValueError, match="must have a driver spec"):
+            option(spark_application, mock_k8s_backend)
+
+    def test_driver_resources_invalid_cpu(self, mock_k8s_backend, spark_application_model):
+        """DriverResources raises for invalid CPU values."""
+        option = DriverResources({"cpu": "invalid", "memory": "4Gi"})
+
+        with pytest.raises(ValueError):
+            option(spark_application_model, mock_k8s_backend)

--- a/kubeflow/spark/types/types.py
+++ b/kubeflow/spark/types/types.py
@@ -14,9 +14,14 @@
 
 """Types for Kubeflow Spark SDK."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class SparkConnectState(str, Enum):
@@ -55,7 +60,7 @@ class SparkConnectInfo:
 
 @dataclass
 class Driver:
-    """Driver configuration for Spark Connect session (KEP-107 lines 165-170).
+    """Driver configuration for Spark Connect session.
 
     The Driver configuration allows fine-grained control over the Spark driver pod.
     All fields are optional, with sensible defaults applied by the backend.
@@ -63,7 +68,6 @@ class Driver:
     Args:
         image: Custom container image for the driver.
         resources: Resource requirements as dict (e.g., {"cpu": "2", "memory": "4Gi"}).
-            Supports arbitrary Kubernetes resources including GPUs (nvidia.com/gpu).
         java_options: JVM options for the driver (e.g., "-Xmx4g -XX:+UseG1GC").
         service_account: Kubernetes service account name for RBAC.
 
@@ -75,7 +79,7 @@ class Driver:
 
     Note:
         The resources dict is extensible - any valid Kubernetes resource name is supported.
-        This design allows GPU support and future resource types without API changes.
+        This design allows future resource types without API changes.
     """
 
     image: str | None = None
@@ -86,7 +90,7 @@ class Driver:
 
 @dataclass
 class Executor:
-    """Executor configuration for Spark Connect session (KEP-107 lines 172-177).
+    """Executor configuration for Spark Connect session.
 
     The Executor configuration controls the worker pods that execute Spark tasks.
     All fields are optional, with sensible defaults applied by the backend.
@@ -94,22 +98,135 @@ class Executor:
     Args:
         num_instances: Number of executor instances (pods).
         resources_per_executor: Resource requirements per executor as dict
-            (e.g., {"cpu": "4", "memory": "8Gi", "nvidia.com/gpu": "1"}).
-            Supports arbitrary Kubernetes resources for future extensibility.
+            (e.g., {"cpu": "4", "memory": "8Gi"}).
         java_options: JVM options for executors (e.g., "-Xmx28g -XX:+UseG1GC").
 
     Example:
         executor = Executor(
             num_instances=20,
-            resources_per_executor={"cpu": "8", "memory": "32Gi", "nvidia.com/gpu": "2"}
+            resources_per_executor={"cpu": "8", "memory": "32Gi"}
         )
 
     Note:
         The resources_per_executor dict is extensible - any valid Kubernetes resource
-        name is supported. This design allows GPU support, custom devices, and future
-        resource types without API changes.
+        name is supported. This design allows future resource types without API changes.
     """
 
     num_instances: int | None = None
     resources_per_executor: dict[str, str] | None = None
     java_options: str | None = None
+
+
+class SparkJobStatus(str, Enum):
+    """State of a Spark batch job."""
+
+    CREATED = "Created"
+    RUNNING = "Running"
+    COMPLETED = "Completed"
+    FAILED = "Failed"
+
+    @classmethod
+    def from_operator_state(
+        cls,
+        raw_state: str | None,
+    ) -> "SparkJobStatus":
+        """Map a SparkApplication state to a SparkJobStatus.
+
+        Args:
+            raw_state: SparkApplication ``applicationState.state`` value.
+
+        Returns:
+            Corresponding SparkJobStatus.
+
+        Note:
+            Unknown SparkApplication states default to FAILED so newly
+            introduced operator states are handled conservatively.
+        """
+        normalized_state = (raw_state or "").upper()
+
+        status = _SDK_STATE_BY_OPERATOR_STATE.get(normalized_state)
+
+        if status is None:
+            logger.warning("Unknown SparkApplication state '%s'. Defaulting to FAILED.", raw_state)
+            return cls.FAILED
+
+        return status
+
+
+_SDK_STATE_BY_OPERATOR_STATE: dict[str, SparkJobStatus] = {
+    state: sdk_status
+    for sdk_status, operator_states in {
+        SparkJobStatus.CREATED: (
+            "",
+            "SUBMITTED",
+        ),
+        SparkJobStatus.RUNNING: (
+            "RUNNING",
+            "SUCCEEDING",
+            "SUSPENDING",
+            "SUSPENDED",
+            "RESUMING",
+        ),
+        SparkJobStatus.COMPLETED: ("COMPLETED",),
+        SparkJobStatus.FAILED: (
+            "FAILED",
+            "SUBMISSION_FAILED",
+            "FAILING",
+            "PENDING_RERUN",
+            "INVALIDATING",
+            "UNKNOWN",
+        ),
+    }.items()
+    for state in operator_states
+}
+
+
+@dataclass
+class SparkJob:
+    """Information about a Spark batch job.
+
+    Args:
+        name: Name of the SparkApplication.
+        namespace: Kubernetes namespace containing the SparkApplication.
+            Included in SparkJob for standalone usage and passing job information
+            between components without requiring SparkClient context.
+        status: Current state of the Spark batch job.
+        creation_timestamp: Timestamp when the SparkApplication was created.
+        num_executors: Number of configured Spark executor instances.
+        driver_pod_name: Name of the Spark driver pod, if available.
+    """
+
+    name: str
+    namespace: str
+    status: SparkJobStatus | None = None
+    creation_timestamp: datetime | None = None
+    num_executors: int | None = None
+    driver_pod_name: str | None = None
+
+
+@dataclass
+class FileJob:
+    """Spark application referenced by a local or remote file source.
+
+    Args:
+        file_source: Path or URI of the Spark application.
+            Supports local paths available to the Spark cluster as well as
+            remote URIs such as s3a://, gs://, hdfs:// and https://.
+        args: Optional command-line arguments passed to the application.
+    """
+
+    file_source: str
+    args: list[str] | None = None
+
+
+@dataclass
+class FuncJob:
+    """Function-based Spark application.
+
+    Args:
+        func: Python function executed as a Spark batch job.
+        func_args: Optional keyword arguments passed to the function.
+    """
+
+    func: Callable
+    func_args: dict[str, Any] | None = None

--- a/kubeflow/spark/types/types_test.py
+++ b/kubeflow/spark/types/types_test.py
@@ -15,160 +15,428 @@
 """Unit tests for Kubeflow Spark types."""
 
 from datetime import datetime
+from unittest.mock import patch
+
+import pytest
 
 from kubeflow.spark.types.types import (
     Driver,
     Executor,
+    FileJob,
+    FuncJob,
     SparkConnectInfo,
     SparkConnectState,
+    SparkJob,
+    SparkJobStatus,
 )
+from kubeflow.trainer.test.common import SUCCESS, TestCase
 
 
-class TestSparkConnectState:
-    """Tests for SparkConnectState enum."""
-
-    def test_enum_values(self):
-        """T01: Verify SparkConnectState enum has expected values."""
-        assert SparkConnectState.PROVISIONING == "Provisioning"
-        assert SparkConnectState.READY == "Ready"
-        assert SparkConnectState.RUNNING == "Running"
-        assert SparkConnectState.NOT_READY == "NotReady"
-        assert SparkConnectState.FAILED == "Failed"
-
-    def test_enum_is_string(self):
-        """Verify SparkConnectState inherits from str."""
-        assert isinstance(SparkConnectState.READY, str)
-        assert SparkConnectState.READY == "Ready"
+@pytest.mark.parametrize(
+    "state, expected",
+    [
+        (SparkConnectState.PROVISIONING, "Provisioning"),
+        (SparkConnectState.READY, "Ready"),
+        (SparkConnectState.RUNNING, "Running"),
+        (SparkConnectState.NOT_READY, "NotReady"),
+        (SparkConnectState.FAILED, "Failed"),
+    ],
+)
+def test_spark_connect_state_values(state, expected):
+    """Test SparkConnectState enum values."""
+    assert state == expected
 
 
-class TestSparkConnectInfo:
-    """Tests for SparkConnectInfo dataclass."""
+@pytest.mark.parametrize(
+    "state",
+    [
+        SparkConnectState.PROVISIONING,
+        SparkConnectState.READY,
+        SparkConnectState.RUNNING,
+        SparkConnectState.NOT_READY,
+        SparkConnectState.FAILED,
+    ],
+)
+def test_spark_connect_state_is_string(state):
+    """Test SparkConnectState inherits from str."""
+    assert isinstance(state, str)
 
-    def test_defaults(self):
-        """T02: SparkConnectInfo with only required fields has None for optional."""
-        info = SparkConnectInfo(
-            name="test-session",
-            namespace="default",
-            state=SparkConnectState.READY,
-        )
-        assert info.name == "test-session"
-        assert info.namespace == "default"
-        assert info.state == SparkConnectState.READY
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="spark connect info with required fields",
+            expected_status=SUCCESS,
+            config={
+                "name": "test-session",
+                "namespace": "default",
+                "state": SparkConnectState.READY,
+            },
+        ),
+        TestCase(
+            name="spark connect info with all fields",
+            expected_status=SUCCESS,
+            config={
+                "name": "full-session",
+                "namespace": "spark-ns",
+                "state": SparkConnectState.READY,
+                "driver_pod_name": "spark-connect-server-0",
+                "pod_ip": "10.0.0.5",
+                "service_name": "spark-connect-svc",
+                "creation_timestamp": datetime(2025, 1, 12, 10, 30, 0),
+            },
+        ),
+    ],
+)
+def test_spark_connect_info(test_case: TestCase):
+    """Test SparkConnectInfo creation."""
+
+    print("Executing test:", test_case.name)
+
+    info = SparkConnectInfo(**test_case.config)
+
+    assert test_case.expected_status == SUCCESS
+
+    for key, value in test_case.config.items():
+        assert getattr(info, key) == value
+
+    if test_case.name == "spark connect info with required fields":
         assert info.driver_pod_name is None
         assert info.pod_ip is None
         assert info.service_name is None
         assert info.creation_timestamp is None
 
-    def test_all_fields(self):
-        """T03: SparkConnectInfo with all fields set."""
-        created = datetime(2025, 1, 12, 10, 30, 0)
-        info = SparkConnectInfo(
-            name="full-session",
-            namespace="spark-ns",
-            state=SparkConnectState.READY,
-            driver_pod_name="spark-connect-server-0",
-            pod_ip="10.0.0.5",
-            service_name="spark-connect-svc",
-            creation_timestamp=created,
-        )
-        assert info.name == "full-session"
-        assert info.namespace == "spark-ns"
-        assert info.state == SparkConnectState.READY
-        assert info.driver_pod_name == "spark-connect-server-0"
-        assert info.pod_ip == "10.0.0.5"
-        assert info.service_name == "spark-connect-svc"
-        assert info.creation_timestamp == created
+    print("test execution complete")
 
 
-class TestDriver:
-    """Tests for Driver dataclass (KEP-107 compliant)."""
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="default driver",
+            expected_status=SUCCESS,
+            config={},
+        ),
+        TestCase(
+            name="driver with resources",
+            expected_status=SUCCESS,
+            config={
+                "resources": {
+                    "cpu": "2",
+                    "memory": "4Gi",
+                },
+            },
+        ),
+        TestCase(
+            name="driver with gpu resources",
+            expected_status=SUCCESS,
+            config={
+                "resources": {
+                    "cpu": "4",
+                    "memory": "8Gi",
+                    "nvidia.com/gpu": "1",
+                },
+            },
+        ),
+        TestCase(
+            name="driver with service account",
+            expected_status=SUCCESS,
+            config={
+                "service_account": "spark-sa",
+            },
+        ),
+        TestCase(
+            name="kep107 driver example",
+            expected_status=SUCCESS,
+            config={
+                "resources": {
+                    "cpu": "4",
+                    "memory": "8Gi",
+                },
+                "service_account": "spark-driver-prod",
+            },
+        ),
+    ],
+)
+def test_driver(test_case: TestCase):
+    """Test Driver creation."""
 
-    def test_defaults(self):
-        """T04: Driver with no arguments has all fields None."""
-        driver = Driver()
+    print("Executing test:", test_case.name)
+
+    driver = Driver(**test_case.config)
+
+    assert test_case.expected_status == SUCCESS
+
+    if not test_case.config:
         assert driver.image is None
         assert driver.resources is None
         assert driver.java_options is None
         assert driver.service_account is None
+    else:
+        for key, value in test_case.config.items():
+            assert getattr(driver, key) == value
 
-    def test_with_resources(self):
-        """T06: Driver with resources dict (KEP-107 pattern)."""
-        driver = Driver(
-            resources={"cpu": "2", "memory": "4Gi"},
-        )
-        assert driver.resources == {"cpu": "2", "memory": "4Gi"}
-
-    def test_with_gpu_resources(self):
-        """Driver with GPU resources (KEP-107 pattern)."""
-        driver = Driver(
-            resources={"cpu": "4", "memory": "8Gi", "nvidia.com/gpu": "1"},
-        )
-        assert driver.resources["cpu"] == "4"
-        assert driver.resources["memory"] == "8Gi"
-        assert driver.resources["nvidia.com/gpu"] == "1"
-
-    def test_with_service_account(self):
-        """Driver with service account."""
-        driver = Driver(service_account="spark-sa")
-        assert driver.service_account == "spark-sa"
-
-    def test_kep107_example(self):
-        """Test KEP-107 example from lines 165-170."""
-        driver = Driver(
-            resources={"cpu": "4", "memory": "8Gi"},
-            service_account="spark-driver-prod",
-        )
-        assert driver.resources["cpu"] == "4"
-        assert driver.resources["memory"] == "8Gi"
-        assert driver.service_account == "spark-driver-prod"
+    print("test execution complete")
 
 
-class TestExecutor:
-    """Tests for Executor dataclass (KEP-107 compliant)."""
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="default executor",
+            expected_status=SUCCESS,
+            config={},
+        ),
+        TestCase(
+            name="executor with num instances",
+            expected_status=SUCCESS,
+            config={
+                "num_instances": 5,
+            },
+        ),
+        TestCase(
+            name="executor with resources per executor",
+            expected_status=SUCCESS,
+            config={
+                "num_instances": 3,
+                "resources_per_executor": {
+                    "cpu": "4",
+                    "memory": "8Gi",
+                },
+            },
+        ),
+        TestCase(
+            name="executor with gpu resources",
+            expected_status=SUCCESS,
+            config={
+                "num_instances": 10,
+                "resources_per_executor": {
+                    "cpu": "8",
+                    "memory": "32Gi",
+                    "nvidia.com/gpu": "2",
+                },
+            },
+        ),
+        TestCase(
+            name="kep107 executor example",
+            expected_status=SUCCESS,
+            config={
+                "num_instances": 20,
+                "resources_per_executor": {
+                    "cpu": "8",
+                    "memory": "32Gi",
+                    "nvidia.com/gpu": "2",
+                },
+            },
+        ),
+    ],
+)
+def test_executor(test_case: TestCase):
+    """Test Executor creation."""
 
-    def test_defaults(self):
-        """T05: Executor with no arguments has all fields None."""
-        executor = Executor()
+    print("Executing test:", test_case.name)
+
+    executor = Executor(**test_case.config)
+
+    assert test_case.expected_status == SUCCESS
+
+    if test_case.name == "default executor":
         assert executor.num_instances is None
         assert executor.resources_per_executor is None
         assert executor.java_options is None
+    else:
+        for key, value in test_case.config.items():
+            assert getattr(executor, key) == value
 
-    def test_with_num_instances(self):
-        """T07: Executor with num_instances set."""
-        executor = Executor(num_instances=5)
-        assert executor.num_instances == 5
+    print("test execution complete")
 
-    def test_with_resources_per_executor(self):
-        """Executor with resources_per_executor dict (KEP-107 pattern)."""
-        executor = Executor(
-            num_instances=3,
-            resources_per_executor={"cpu": "4", "memory": "8Gi"},
-        )
-        assert executor.num_instances == 3
-        assert executor.resources_per_executor == {"cpu": "4", "memory": "8Gi"}
 
-    def test_with_gpu_resources(self):
-        """Executor with GPU resources (KEP-107 pattern)."""
-        executor = Executor(
-            num_instances=10,
-            resources_per_executor={
-                "cpu": "8",
-                "memory": "32Gi",
-                "nvidia.com/gpu": "2",
+@pytest.mark.parametrize(
+    "status, expected",
+    [
+        (SparkJobStatus.CREATED, "Created"),
+        (SparkJobStatus.RUNNING, "Running"),
+        (SparkJobStatus.COMPLETED, "Completed"),
+        (SparkJobStatus.FAILED, "Failed"),
+    ],
+)
+def test_spark_job_status_values(status, expected):
+    """Test SparkJobStatus enum values."""
+    assert status == expected
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        SparkJobStatus.CREATED,
+        SparkJobStatus.RUNNING,
+        SparkJobStatus.COMPLETED,
+        SparkJobStatus.FAILED,
+    ],
+)
+def test_spark_job_status_is_string(status):
+    """Test SparkJobStatus inherits from str."""
+    assert isinstance(status, str)
+
+
+@pytest.mark.parametrize(
+    "operator_state, expected_status",
+    [
+        (None, SparkJobStatus.CREATED),
+        ("", SparkJobStatus.CREATED),
+        ("SUBMITTED", SparkJobStatus.CREATED),
+        ("RUNNING", SparkJobStatus.RUNNING),
+        ("SUCCEEDING", SparkJobStatus.RUNNING),
+        ("SUSPENDING", SparkJobStatus.RUNNING),
+        ("SUSPENDED", SparkJobStatus.RUNNING),
+        ("RESUMING", SparkJobStatus.RUNNING),
+        ("COMPLETED", SparkJobStatus.COMPLETED),
+        ("FAILED", SparkJobStatus.FAILED),
+        ("SUBMISSION_FAILED", SparkJobStatus.FAILED),
+        ("FAILING", SparkJobStatus.FAILED),
+        ("PENDING_RERUN", SparkJobStatus.FAILED),
+        ("INVALIDATING", SparkJobStatus.FAILED),
+        ("UNKNOWN", SparkJobStatus.FAILED),
+    ],
+)
+def test_from_operator_state(operator_state, expected_status):
+    """Verify SparkApplication states map to SparkJobStatus."""
+    assert SparkJobStatus.from_operator_state(operator_state) == expected_status
+
+
+def test_unknown_operator_state():
+    """Verify unknown SparkApplication states default to FAILED."""
+    with patch("kubeflow.spark.types.types.logger") as mock_logger:
+        status = SparkJobStatus.from_operator_state("SOME_NEW_STATE")
+
+    assert status == SparkJobStatus.FAILED
+    mock_logger.warning.assert_called_once_with(
+        "Unknown SparkApplication state '%s'. Defaulting to FAILED.",
+        "SOME_NEW_STATE",
+    )
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="default spark job",
+            expected_status=SUCCESS,
+            config={
+                "name": "test-job",
+                "namespace": "default",
             },
-        )
-        assert executor.num_instances == 10
-        assert executor.resources_per_executor["cpu"] == "8"
-        assert executor.resources_per_executor["memory"] == "32Gi"
-        assert executor.resources_per_executor["nvidia.com/gpu"] == "2"
+        ),
+        TestCase(
+            name="spark job with all fields",
+            expected_status=SUCCESS,
+            config={
+                "name": "full-job",
+                "namespace": "spark-ns",
+                "status": SparkJobStatus.RUNNING,
+                "creation_timestamp": datetime(2025, 1, 12, 10, 30, 0),
+                "num_executors": 10,
+                "driver_pod_name": "driver-pod-1",
+            },
+        ),
+    ],
+)
+def test_spark_job(test_case: TestCase):
+    """Test SparkJob creation."""
 
-    def test_kep107_example(self):
-        """Test KEP-107 example from lines 172-177."""
-        executor = Executor(
-            num_instances=20,
-            resources_per_executor={"cpu": "8", "memory": "32Gi", "nvidia.com/gpu": "2"},
-        )
-        assert executor.num_instances == 20
-        assert executor.resources_per_executor["cpu"] == "8"
-        assert executor.resources_per_executor["memory"] == "32Gi"
-        assert executor.resources_per_executor["nvidia.com/gpu"] == "2"
+    print("Executing test:", test_case.name)
+
+    job = SparkJob(**test_case.config)
+
+    assert test_case.expected_status == SUCCESS
+
+    for key, value in test_case.config.items():
+        assert getattr(job, key) == value
+
+    if test_case.name == "default spark job":
+        assert job.status is None
+        assert job.creation_timestamp is None
+        assert job.num_executors is None
+        assert job.driver_pod_name is None
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="default file job",
+            expected_status=SUCCESS,
+            config={
+                "file_source": "s3://bucket/job.py",
+            },
+        ),
+        TestCase(
+            name="file job with all fields",
+            expected_status=SUCCESS,
+            config={
+                "file_source": "local:///opt/spark/app.py",
+                "args": ["--date", "2026-06-30"],
+            },
+        ),
+    ],
+)
+def test_file_job(test_case: TestCase):
+    """Test FileJob creation."""
+
+    print("Executing test:", test_case.name)
+
+    job = FileJob(**test_case.config)
+
+    assert test_case.expected_status == SUCCESS
+
+    for key, value in test_case.config.items():
+        assert getattr(job, key) == value
+
+    if test_case.name == "default file job":
+        assert job.args is None
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="default func job",
+            expected_status=SUCCESS,
+            config={
+                "func": lambda: "ok",
+            },
+        ),
+        TestCase(
+            name="func job with arguments",
+            expected_status=SUCCESS,
+            config={
+                "func": lambda x, y: x + y,
+                "func_args": {
+                    "x": 1,
+                    "y": 2,
+                },
+            },
+        ),
+    ],
+)
+def test_func_job(test_case: TestCase):
+    """Test FuncJob creation."""
+
+    print("Executing test:", test_case.name)
+
+    job = FuncJob(**test_case.config)
+
+    assert test_case.expected_status == SUCCESS
+
+    for key, value in test_case.config.items():
+        assert getattr(job, key) == value
+
+    if test_case.name == "default func job":
+        assert job.func_args is None
+
+    print("test execution complete")

--- a/proposals/107-spark-client/README.md
+++ b/proposals/107-spark-client/README.md
@@ -149,7 +149,7 @@ spark.stop()
 
 ```python
 from kubeflow.spark import SparkClient
-from kubeflow.spark.types.jobs import FileJob
+from kubeflow.spark.types.types import FileJob
 from kubeflow.common.types import KubernetesBackendConfig
 
 client = SparkClient(backend_config=KubernetesBackendConfig(namespace="etl-jobs"))
@@ -590,9 +590,13 @@ class SparkClient:
 
     def list_jobs(
         self,
-        status: Optional[SparkJobStatus] = None,
+        status: Optional[Set[SparkJobStatus]] = None,
     ) -> List[SparkJob]:
-        """List batch Spark jobs."""
+        """List batch Spark jobs.
+
+        Args:
+            status: Optional set of job statuses used to filter returned jobs.
+        """
 
     def get_job(self, name: str) -> SparkJob:
         """Get a specific Spark job by name."""
@@ -615,6 +619,7 @@ class SparkClient:
         name: str,
         status: Set[SparkJobStatus] = {SparkJobStatus.COMPLETED},
         timeout: int = 600,
+        polling_interval: int = 2,
     ) -> SparkJob:
         """Wait for a job to reach desired status."""
 

--- a/test/e2e/spark/test_spark_examples.py
+++ b/test/e2e/spark/test_spark_examples.py
@@ -210,3 +210,26 @@ class TestSparkExamples:
             pytest.skip("Requires in-cluster execution (SPARK_E2E_RUN_IN_CLUSTER=1)")
 
         self._run_example("connect_existing_session.py", namespace)
+
+    def test_batch_job_lifecycle_example(self):
+        """EX04: Validate batch_job_lifecycle.py runs without errors."""
+        namespace = os.environ.get("SPARK_TEST_NAMESPACE", "spark-test")
+
+        if USE_IN_CLUSTER and RUNNER_IMAGE:
+            self._run_example("batch_job_lifecycle.py", namespace)
+            return
+
+        stdout = self._run_example("batch_job_lifecycle.py", namespace)
+
+        assert "BATCH JOB LIFECYCLE COMPLETE!" in stdout
+
+    def test_batch_failed_job_example(self):
+        """EX05: Validate batch_failed_job.py handles failed Spark jobs."""
+        namespace = os.environ.get("SPARK_TEST_NAMESPACE", "spark-test")
+
+        if USE_IN_CLUSTER and RUNNER_IMAGE:
+            self._run_example("batch_failed_job.py", namespace)
+            return
+
+        stdout = self._run_example("batch_failed_job.py", namespace)
+        assert "Job failed as expected." in stdout


### PR DESCRIPTION
## What this PR does / why we need it

SparkJob driver CPU and memory are currently hardcoded to the
`DEFAULT_DRIVER_*` constants when building `SparkApplication` CRs.

This PR adds a callable `DriverResources` option so callers can override
driver resources through the KEP-107 options mechanism when submitting batch
jobs.

### Example

```python
client.submit_job(
    job=FileJob(file_source="s3a://bucket/job.py"),
    options=[DriverResources({"cpu": "2", "memory": "4Gi"})],
)
```

## Which issue(s) this PR fixes

Fixes #613

## Checklist

- [x] Docs included for user-facing changes (Google-style docstring + usage example on `DriverResources`)

## Testing

```bash
uv run pytest -q \
  kubeflow/spark/types/options_test.py \
  kubeflow/spark/backends/kubernetes/utils_test.py \
  kubeflow/spark/api/spark_client_test.py

uv run ruff check \
  kubeflow/spark/types/options.py \
  kubeflow/spark/backends/kubernetes/utils.py \
  kubeflow/spark/api/spark_client.py
```

## Notes

This branch is based on **#521** (`feature/submit-job`), which introduces the
`SparkJob` / `submit_job` APIs that #613 depends on.