### PR TITLE
docs(spark): add dedicated examples guide

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -168,6 +168,7 @@ Getting Involved
    :caption: Spark
 
    spark/index
+   spark/examples
    spark/api
 
 .. toctree::

--- a/docs/source/spark/examples.rst
+++ b/docs/source/spark/examples.rst
@@ -1,0 +1,113 @@
+Spark Examples
+==============
+
+Use these examples to create Spark sessions, run distributed data operations, and manage sessions with the Kubeflow SDK.
+
+Create a Spark Session
+----------------------
+
+Create a session with five executors and configure the resources available to each executor:
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+
+   client = SparkClient()
+
+   spark = client.connect(
+       num_executors=5,
+       resources_per_executor={
+           "cpu": "2",
+           "memory": "2Gi",
+       },
+   )
+
+   spark.range(10).show()
+
+Run Data Operations
+-------------------
+
+Once connected, use the standard PySpark DataFrame and SQL APIs.
+
+**Perform transformations:**
+
+.. code-block:: python
+
+   df = spark.range(10)
+   result = df.withColumn("value_squared", df.id * df.id)
+   result.show()
+
+**Run SQL queries:**
+
+.. code-block:: python
+
+   df = spark.range(10)
+   df.createOrReplaceTempView("numbers")
+
+   result = spark.sql("SELECT id, id * id AS square FROM numbers")
+   result.show()
+
+**Aggregate data:**
+
+.. code-block:: python
+
+   df = spark.range(100)
+   result = df.groupBy().count()
+   result.show()
+
+Connect to an Existing Server
+-----------------------------
+
+Connect to an existing Spark Connect server instead of creating a Kubernetes session:
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+
+   client = SparkClient()
+   spark = client.connect(base_url="sc://localhost:15002")
+
+   spark.range(10).show()
+
+This pattern is useful when Spark Connect is already running and managed independently of your application.
+
+Manage Spark Sessions
+---------------------
+
+Use the Spark SDK to inspect and manage Spark Connect sessions in the configured Kubernetes namespace, which defaults to ``default``.
+
+**List active sessions:**
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+
+   client = SparkClient()
+   sessions = client.list_sessions()
+
+   for session in sessions:
+       print(session.name)
+       print(session.state.value)
+
+**Get session information:**
+
+.. code-block:: python
+
+   session = client.get_session("spark-connect-example")
+
+   print(f"Name: {session.name}")
+   print(f"State: {session.state.value}")
+   print(f"Namespace: {session.namespace}")
+
+**View session logs:**
+
+.. code-block:: python
+
+   for line in client.get_session_logs("spark-connect-example"):
+       print(line)
+
+**Delete a session:**
+
+.. code-block:: python
+
+   client.delete_session("spark-connect-example")

--- a/docs/source/spark/index.rst
+++ b/docs/source/spark/index.rst
@@ -31,31 +31,7 @@ To use Spark with the Kubeflow SDK, install the Spark dependencies:
 
    pip install "kubeflow[spark]"
 
-For full setup instructions, see `the Spark installation guide. <https://www.kubeflow.org/docs/components/spark-operator/getting-started/>` _
-
-Quick Example
--------------
-
-.. code-block:: python
-
-   from kubeflow.spark import SparkClient
-
-   # Connect to a Spark cluster
-   client = SparkClient()
-
-   spark = client.connect(
-       num_executors=5,
-       resources_per_executor={
-           "cpu": "2",
-           "memory": "2Gi",
-       },
-   )
-
-   # Create a distributed DataFrame
-   df = spark.range(10)
-
-   # Run a distributed computation
-   df.show()
+For full setup instructions, see `the Spark installation guide <https://www.kubeflow.org/docs/components/spark-operator/getting-started/>`_.
 
 How It Works
 ------------
@@ -78,121 +54,23 @@ Key Concepts
 
 **Spark Operator**: A Kubernetes controller that manages the lifecycle of Spark applications.
 
-Common Patterns
----------------
+Guides
+------
 
-**Configure executor resources:**
+.. grid:: 2
+   :gutter: 3
 
-.. code-block:: python
+   .. grid-item-card:: Spark Examples
+      :link: examples
+      :link-type: doc
 
-   spark = client.connect(
-       num_executors=3,
-       resources_per_executor={
-           "cpu": "4",
-           "memory": "4Gi",
-       },
-   )
+      Create sessions, run distributed operations, and manage Spark workloads.
 
-**Create a DataFrame from a range:**
+   .. grid-item-card:: API Reference
+      :link: api
+      :link-type: doc
 
-.. code-block:: python
-
-   df = spark.range(100)
-   df.show()
-
-**Perform transformations:**
-
-.. code-block:: python
-
-   df = spark.range(10)
-   result = df.withColumn("value_squared", df.id * df.id)
-   result.show()
-
-**Run SQL queries:**
-
-.. code-block:: python
-
-   df = spark.range(10)
-   df.createOrReplaceTempView("numbers")
-
-   result = spark.sql("SELECT id, id * id AS square FROM numbers")
-   result.show()
-
-**Aggregate data:**
-
-.. code-block:: python
-
-   df = spark.range(100)
-
-   result = df.groupBy().count()
-   result.show()
-
-Connecting to Existing Spark Connect Servers
---------------------------------------------
-
-You can connect to an existing Spark Connect server instead of creating a new Spark session.
-
-.. code-block:: python
-
-   from kubeflow.spark import SparkClient
-
-   client = SparkClient()
-
-   spark = client.connect(
-       base_url="sc://localhost:15002"
-   )
-
-   spark.range(10).show()
-
-This pattern is useful when Spark Connect is already running and managed independently of your application.
-
-Session Management
-------------------
-
-Use the Spark SDK to inspect and manage Spark Connect sessions in the configured Kubernetes namespace (defaults to ``default``).
-
-**List active sessions:**
-
-.. code-block:: python
-
-   from kubeflow.spark import SparkClient
-
-   client = SparkClient()
-
-   sessions = client.list_sessions()
-
-   for session in sessions:
-       print(session.name)
-       print(session.state.value)
-
-**Get session information:**
-
-.. code-block:: python
-
-   session = client.get_session(
-       "spark-connect-example"
-   )
-
-   print(f"Name: {session.name}")
-   print(f"State: {session.state.value}")
-   print(f"Namespace: {session.namespace}")
-
-**View session logs:**
-
-.. code-block:: python
-
-   for line in client.get_session_logs(
-       "spark-connect-example"
-   ):
-       print(line)
-
-**Delete a session:**
-
-.. code-block:: python
-
-   client.delete_session(
-       "spark-connect-example"
-   )
+      Explore the Spark client, configuration types, and public methods.
 
 When Things Go Wrong
 --------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

This begins the Spark documentation restructuring from #618 by moving the existing runnable examples and session-management workflows into a dedicated `spark/examples` guide. The Spark landing page now follows the Trainer and Optimizer navigation pattern with guide cards, and the new page is included in the root documentation toctree.

The examples remain aligned with the current `SparkClient` API. This also fixes the existing Spark installation link markup while touching the landing page.

AI assistance was used to inspect the documentation structure and prepare the reorganization. I reviewed every moved example against the current client signatures and ran the repository validation locally.

**Which issue(s) this PR fixes**:

Part of #618

**Validation**:

- `make docs`
- `make verify`
- `uv run pre-commit run --all-files`

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing