### PR TITLE
feat(docs): add dedicated Spark examples guide

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -168,6 +168,7 @@ Getting Involved
    :caption: Spark
 
    spark/index
+   spark/examples
    spark/api
 
 .. toctree::

--- a/docs/source/spark/examples.rst
+++ b/docs/source/spark/examples.rst
@@ -1,0 +1,113 @@
+Spark Examples
+==============
+
+Use these examples to create Spark sessions, run distributed data operations, and manage sessions with the Kubeflow SDK.
+
+Create a Spark Session
+----------------------
+
+Create a session with five executors and configure the resources available to each executor:
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+
+   client = SparkClient()
+
+   spark = client.connect(
+       num_executors=5,
+       resources_per_executor={
+           "cpu": "2",
+           "memory": "2Gi",
+       },
+   )
+
+   spark.range(10).show()
+
+Run Data Operations
+-------------------
+
+Once connected, use the standard PySpark DataFrame and SQL APIs.
+
+**Perform transformations:**
+
+.. code-block:: python
+
+   df = spark.range(10)
+   result = df.withColumn("value_squared", df.id * df.id)
+   result.show()
+
+**Run SQL queries:**
+
+.. code-block:: python
+
+   df = spark.range(10)
+   df.createOrReplaceTempView("numbers")
+
+   result = spark.sql("SELECT id, id * id AS square FROM numbers")
+   result.show()
+
+**Aggregate data:**
+
+.. code-block:: python
+
+   df = spark.range(100)
+   result = df.groupBy().count()
+   result.show()
+
+Connect to an Existing Server
+-----------------------------
+
+Connect to an existing Spark Connect server instead of creating a Kubernetes session:
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+
+   client = SparkClient()
+   spark = client.connect(base_url="sc://localhost:15002")
+
+   spark.range(10).show()
+
+This pattern is useful when Spark Connect is already running and managed independently of your application.
+
+Manage Spark Sessions
+---------------------
+
+Use the Spark SDK to inspect and manage Spark Connect sessions in the configured Kubernetes namespace, which defaults to ``default``.
+
+**List active sessions:**
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+
+   client = SparkClient()
+   sessions = client.list_sessions()
+
+   for session in sessions:
+       print(session.name)
+       print(session.state.value)
+
+**Get session information:**
+
+.. code-block:: python
+
+   session = client.get_session("spark-connect-example")
+
+   print(f"Name: {session.name}")
+   print(f"State: {session.state.value}")
+   print(f"Namespace: {session.namespace}")
+
+**View session logs:**
+
+.. code-block:: python
+
+   for line in client.get_session_logs("spark-connect-example"):
+       print(line)
+
+**Delete a session:**
+
+.. code-block:: python
+
+   client.delete_session("spark-connect-example")

--- a/docs/source/spark/examples.rst
+++ b/docs/source/spark/examples.rst
@@ -1,113 +1,202 @@
 Spark Examples
 ==============
 
-Use these examples to create Spark sessions, run distributed data operations, and manage sessions with the Kubeflow SDK.
+Use these end-to-end examples as starting points for data engineering workloads
+with Spark Connect. For installation, basic usage, and session management, start
+with the :doc:`Spark overview <index>`.
 
-Create a Spark Session
-----------------------
+.. note::
 
-Create a session with five executors and configure the resources available to each executor:
+   ``SparkClient`` creates or connects to interactive Spark Connect sessions. It
+   does not currently submit Python files or JARs. Package application and data
+   source dependencies in the Spark image, or make them available to an existing
+   Spark Connect server, before running these workflows.
+
+Spark SQL Analytics
+-------------------
+
+Create a DataFrame, expose it as a temporary view, and use Spark SQL to calculate
+daily revenue by region:
 
 .. code-block:: python
 
    from kubeflow.spark import SparkClient
 
    client = SparkClient()
+   spark = client.connect(
+       num_executors=3,
+       resources_per_executor={"cpu": "2", "memory": "4Gi"},
+       spark_conf={"spark.sql.adaptive.enabled": "true"},
+   )
 
+   orders = spark.createDataFrame(
+       [
+           ("2025-01-15", "apac", 120.0),
+           ("2025-01-15", "emea", 85.5),
+           ("2025-01-15", "apac", 64.0),
+           ("2025-01-16", "emea", 140.0),
+       ],
+       schema="order_date string, region string, amount double",
+   )
+   orders.createOrReplaceTempView("orders")
+
+   daily_revenue = spark.sql(
+       """
+       SELECT order_date, region, ROUND(SUM(amount), 2) AS revenue
+       FROM orders
+       GROUP BY order_date, region
+       ORDER BY order_date, revenue DESC
+       """
+   )
+   daily_revenue.show()
+   spark.stop()
+
+DataFrame ETL Pipeline
+----------------------
+
+Spark DataFrame readers and writers accept filesystem URIs supported by the
+configured Spark runtime. This pipeline reads partitioned Parquet data, validates
+records, enriches them, and writes a partitioned analytics dataset:
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+   from pyspark.sql import functions as F
+
+   client = SparkClient()
    spark = client.connect(
        num_executors=5,
-       resources_per_executor={
-           "cpu": "2",
-           "memory": "2Gi",
+       resources_per_executor={"cpu": "4", "memory": "8Gi"},
+       spark_conf={
+           "spark.sql.adaptive.enabled": "true",
+           "spark.sql.sources.partitionOverwriteMode": "dynamic",
        },
    )
 
-   spark.range(10).show()
+   input_uri = "s3a://raw-data/orders/"
+   output_uri = "s3a://analytics/orders-by-day/"
 
-Run Data Operations
--------------------
+   orders = spark.read.parquet(input_uri)
+   cleaned = (
+       orders.filter(F.col("order_id").isNotNull())
+       .filter(F.col("amount") > 0)
+       .withColumn("order_day", F.to_date("created_at"))
+       .withColumn("net_amount", F.round(F.col("amount") - F.col("discount"), 2))
+       .dropDuplicates(["order_id"])
+   )
 
-Once connected, use the standard PySpark DataFrame and SQL APIs.
+   daily_summary = cleaned.groupBy("order_day", "region").agg(
+       F.count("order_id").alias("order_count"),
+       F.round(F.sum("net_amount"), 2).alias("net_revenue"),
+   )
 
-**Perform transformations:**
+   daily_summary.write.mode("overwrite").partitionBy("order_day").parquet(output_uri)
+   spark.stop()
 
-.. code-block:: python
+The Spark image must include the connector for the URI scheme. Configure
+credentials through your platform's workload identity or Kubernetes Secrets
+rather than embedding credentials in source code.
 
-   df = spark.range(10)
-   result = df.withColumn("value_squared", df.id * df.id)
-   result.show()
+Iceberg Tables on MinIO
+-----------------------
 
-**Run SQL queries:**
-
-.. code-block:: python
-
-   df = spark.range(10)
-   df.createOrReplaceTempView("numbers")
-
-   result = spark.sql("SELECT id, id * id AS square FROM numbers")
-   result.show()
-
-**Aggregate data:**
-
-.. code-block:: python
-
-   df = spark.range(100)
-   result = df.groupBy().count()
-   result.show()
-
-Connect to an Existing Server
------------------------------
-
-Connect to an existing Spark Connect server instead of creating a Kubernetes session:
+Use ``spark_conf`` to configure an Iceberg catalog backed by an S3-compatible
+MinIO service. The Spark image must contain compatible Iceberg and S3A runtime
+dependencies, and the driver and executors must receive credentials through a
+secure credential provider.
 
 .. code-block:: python
 
    from kubeflow.spark import SparkClient
 
    client = SparkClient()
-   spark = client.connect(base_url="sc://localhost:15002")
+   spark = client.connect(
+       num_executors=4,
+       resources_per_executor={"cpu": "2", "memory": "6Gi"},
+       spark_conf={
+           "spark.sql.catalog.lakehouse": "org.apache.iceberg.spark.SparkCatalog",
+           "spark.sql.catalog.lakehouse.type": "hadoop",
+           "spark.sql.catalog.lakehouse.warehouse": "s3a://warehouse/iceberg/",
+           "spark.hadoop.fs.s3a.endpoint": "http://minio.minio.svc:9000",
+           "spark.hadoop.fs.s3a.path.style.access": "true",
+           "spark.hadoop.fs.s3a.connection.ssl.enabled": "false",
+       },
+   )
 
-   spark.range(10).show()
+   spark.sql("CREATE NAMESPACE IF NOT EXISTS lakehouse.analytics")
+   spark.sql(
+       """
+       CREATE TABLE IF NOT EXISTS lakehouse.analytics.daily_orders (
+           order_day DATE,
+           region STRING,
+           order_count BIGINT,
+           net_revenue DOUBLE
+       ) USING iceberg
+       PARTITIONED BY (order_day)
+       """
+   )
 
-This pattern is useful when Spark Connect is already running and managed independently of your application.
+   spark.sql(
+       """
+       INSERT INTO lakehouse.analytics.daily_orders VALUES
+           (DATE '2025-01-15', 'apac', 42, 12050.25),
+           (DATE '2025-01-15', 'emea', 31, 9980.00)
+       """
+   )
 
-Manage Spark Sessions
----------------------
+   spark.sql(
+       "SELECT * FROM lakehouse.analytics.daily_orders ORDER BY net_revenue DESC"
+   ).show()
+   spark.stop()
 
-Use the Spark SDK to inspect and manage Spark Connect sessions in the configured Kubernetes namespace, which defaults to ``default``.
+Production Session Configuration
+--------------------------------
 
-**List active sessions:**
+Combine explicit driver and executor resources with Kubernetes metadata and
+scheduling constraints for a production ETL session:
 
 .. code-block:: python
 
-   from kubeflow.spark import SparkClient
+   from kubeflow.spark import (
+       Annotations,
+       Driver,
+       Executor,
+       Labels,
+       Name,
+       NodeSelector,
+       SparkClient,
+   )
 
+   session_name = "daily-orders-etl"
    client = SparkClient()
-   sessions = client.list_sessions()
+   spark = client.connect(
+       driver=Driver(
+           resources={"cpu": "2", "memory": "4Gi"},
+           service_account="spark-data-pipeline",
+       ),
+       executor=Executor(
+           num_instances=10,
+           resources_per_executor={"cpu": "4", "memory": "16Gi"},
+       ),
+       spark_conf={
+           "spark.app.name": "daily-orders-etl",
+           "spark.sql.adaptive.enabled": "true",
+           "spark.sql.adaptive.coalescePartitions.enabled": "true",
+       },
+       options=[
+           Name(session_name),
+           Labels({"team": "data-platform", "workload": "orders-etl"}),
+           Annotations({"owner": "data-platform@example.com"}),
+           NodeSelector({"node-pool": "data-processing"}),
+       ],
+   )
 
-   for session in sessions:
-       print(session.name)
-       print(session.state.value)
+   try:
+       spark.read.parquet("s3a://raw-data/orders/").groupBy("region").count().show()
+   finally:
+       spark.stop()
+       client.delete_session(session_name)
 
-**Get session information:**
-
-.. code-block:: python
-
-   session = client.get_session("spark-connect-example")
-
-   print(f"Name: {session.name}")
-   print(f"State: {session.state.value}")
-   print(f"Namespace: {session.namespace}")
-
-**View session logs:**
-
-.. code-block:: python
-
-   for line in client.get_session_logs("spark-connect-example"):
-       print(line)
-
-**Delete a session:**
-
-.. code-block:: python
-
-   client.delete_session("spark-connect-example")
+Use :class:`~kubeflow.spark.types.options.PodTemplateOverride` only when the
+higher-level resource and scheduling options cannot express a required pod
+configuration, because pod template changes can conflict with SDK-managed fields.

--- a/docs/source/spark/index.rst
+++ b/docs/source/spark/index.rst
@@ -33,6 +33,30 @@ To use Spark with the Kubeflow SDK, install the Spark dependencies:
 
 For full setup instructions, see `the Spark installation guide <https://www.kubeflow.org/docs/components/spark-operator/getting-started/>`_.
 
+Quick Example
+-------------
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+
+   # Connect to a Spark cluster
+   client = SparkClient()
+
+   spark = client.connect(
+       num_executors=5,
+       resources_per_executor={
+           "cpu": "2",
+           "memory": "2Gi",
+       },
+   )
+
+   # Create a distributed DataFrame
+   df = spark.range(10)
+
+   # Run a distributed computation
+   df.show()
+
 How It Works
 ------------
 
@@ -54,6 +78,122 @@ Key Concepts
 
 **Spark Operator**: A Kubernetes controller that manages the lifecycle of Spark applications.
 
+Common Patterns
+---------------
+
+**Configure executor resources:**
+
+.. code-block:: python
+
+   spark = client.connect(
+       num_executors=3,
+       resources_per_executor={
+           "cpu": "4",
+           "memory": "4Gi",
+       },
+   )
+
+**Create a DataFrame from a range:**
+
+.. code-block:: python
+
+   df = spark.range(100)
+   df.show()
+
+**Perform transformations:**
+
+.. code-block:: python
+
+   df = spark.range(10)
+   result = df.withColumn("value_squared", df.id * df.id)
+   result.show()
+
+**Run SQL queries:**
+
+.. code-block:: python
+
+   df = spark.range(10)
+   df.createOrReplaceTempView("numbers")
+
+   result = spark.sql("SELECT id, id * id AS square FROM numbers")
+   result.show()
+
+**Aggregate data:**
+
+.. code-block:: python
+
+   df = spark.range(100)
+
+   result = df.groupBy().count()
+   result.show()
+
+Connecting to Existing Spark Connect Servers
+--------------------------------------------
+
+You can connect to an existing Spark Connect server instead of creating a new Spark session.
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+
+   client = SparkClient()
+
+   spark = client.connect(
+       base_url="sc://localhost:15002"
+   )
+
+   spark.range(10).show()
+
+This pattern is useful when Spark Connect is already running and managed independently of your application.
+
+Session Management
+------------------
+
+Use the Spark SDK to inspect and manage Spark Connect sessions in the configured Kubernetes namespace (defaults to ``default``).
+
+**List active sessions:**
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+
+   client = SparkClient()
+
+   sessions = client.list_sessions()
+
+   for session in sessions:
+       print(session.name)
+       print(session.state.value)
+
+**Get session information:**
+
+.. code-block:: python
+
+   session = client.get_session(
+       "spark-connect-example"
+   )
+
+   print(f"Name: {session.name}")
+   print(f"State: {session.state.value}")
+   print(f"Namespace: {session.namespace}")
+
+**View session logs:**
+
+.. code-block:: python
+
+   for line in client.get_session_logs(
+       "spark-connect-example"
+   ):
+       print(line)
+
+**Delete a session:**
+
+.. code-block:: python
+
+   client.delete_session(
+       "spark-connect-example"
+   )
+
 Guides
 ------
 
@@ -64,7 +204,7 @@ Guides
       :link: examples
       :link-type: doc
 
-      Create sessions, run distributed operations, and manage Spark workloads.
+      Build advanced SQL, ETL, object-storage, and production workflows.
 
    .. grid-item-card:: API Reference
       :link: api

--- a/docs/source/spark/index.rst
+++ b/docs/source/spark/index.rst
@@ -31,31 +31,7 @@ To use Spark with the Kubeflow SDK, install the Spark dependencies:
 
    pip install "kubeflow[spark]"
 
-For full setup instructions, see `the Spark installation guide. <https://www.kubeflow.org/docs/components/spark-operator/getting-started/>` _
-
-Quick Example
--------------
-
-.. code-block:: python
-
-   from kubeflow.spark import SparkClient
-
-   # Connect to a Spark cluster
-   client = SparkClient()
-
-   spark = client.connect(
-       num_executors=5,
-       resources_per_executor={
-           "cpu": "2",
-           "memory": "2Gi",
-       },
-   )
-
-   # Create a distributed DataFrame
-   df = spark.range(10)
-
-   # Run a distributed computation
-   df.show()
+For full setup instructions, see `the Spark installation guide <https://www.kubeflow.org/docs/components/spark-operator/getting-started/>`_.
 
 How It Works
 ------------
@@ -78,121 +54,23 @@ Key Concepts
 
 **Spark Operator**: A Kubernetes controller that manages the lifecycle of Spark applications.
 
-Common Patterns
----------------
+Guides
+------
 
-**Configure executor resources:**
+.. grid:: 2
+   :gutter: 3
 
-.. code-block:: python
+   .. grid-item-card:: Spark Examples
+      :link: examples
+      :link-type: doc
 
-   spark = client.connect(
-       num_executors=3,
-       resources_per_executor={
-           "cpu": "4",
-           "memory": "4Gi",
-       },
-   )
+      Create sessions, run distributed operations, and manage Spark workloads.
 
-**Create a DataFrame from a range:**
+   .. grid-item-card:: API Reference
+      :link: api
+      :link-type: doc
 
-.. code-block:: python
-
-   df = spark.range(100)
-   df.show()
-
-**Perform transformations:**
-
-.. code-block:: python
-
-   df = spark.range(10)
-   result = df.withColumn("value_squared", df.id * df.id)
-   result.show()
-
-**Run SQL queries:**
-
-.. code-block:: python
-
-   df = spark.range(10)
-   df.createOrReplaceTempView("numbers")
-
-   result = spark.sql("SELECT id, id * id AS square FROM numbers")
-   result.show()
-
-**Aggregate data:**
-
-.. code-block:: python
-
-   df = spark.range(100)
-
-   result = df.groupBy().count()
-   result.show()
-
-Connecting to Existing Spark Connect Servers
---------------------------------------------
-
-You can connect to an existing Spark Connect server instead of creating a new Spark session.
-
-.. code-block:: python
-
-   from kubeflow.spark import SparkClient
-
-   client = SparkClient()
-
-   spark = client.connect(
-       base_url="sc://localhost:15002"
-   )
-
-   spark.range(10).show()
-
-This pattern is useful when Spark Connect is already running and managed independently of your application.
-
-Session Management
-------------------
-
-Use the Spark SDK to inspect and manage Spark Connect sessions in the configured Kubernetes namespace (defaults to ``default``).
-
-**List active sessions:**
-
-.. code-block:: python
-
-   from kubeflow.spark import SparkClient
-
-   client = SparkClient()
-
-   sessions = client.list_sessions()
-
-   for session in sessions:
-       print(session.name)
-       print(session.state.value)
-
-**Get session information:**
-
-.. code-block:: python
-
-   session = client.get_session(
-       "spark-connect-example"
-   )
-
-   print(f"Name: {session.name}")
-   print(f"State: {session.state.value}")
-   print(f"Namespace: {session.namespace}")
-
-**View session logs:**
-
-.. code-block:: python
-
-   for line in client.get_session_logs(
-       "spark-connect-example"
-   ):
-       print(line)
-
-**Delete a session:**
-
-.. code-block:: python
-
-   client.delete_session(
-       "spark-connect-example"
-   )
+      Explore the Spark client, configuration types, and public methods.
 
 When Things Go Wrong
 --------------------


### PR DESCRIPTION
**What this PR does / why we need it**:

This begins the Spark documentation restructuring from #618 while preserving the existing Spark landing page as the onboarding entry point. The landing page keeps its installation, quick example, concepts, common patterns, existing-server connection, session-management, and troubleshooting content, and adds guide navigation consistent with Trainer and Optimizer.

The new `spark/examples` guide now focuses on advanced, end-to-end workflows supported by the current `SparkClient` API:

- Spark SQL analytics
- DataFrame ETL with filesystem URIs
- Iceberg tables backed by MinIO/S3-compatible storage
- Production resource, metadata, and scheduling configuration

The guide explicitly notes that `SparkClient` currently creates or connects to interactive Spark Connect sessions and does not submit Python files or JARs. External connectors and catalog dependencies must be available in the Spark runtime image.

This also fixes the existing Spark installation link markup.

AI assistance was used to inspect the documentation structure and prepare the examples. I reviewed every example against the current client signatures and supported options and ran the repository validation locally.

**Which issue(s) this PR fixes**:

Part of #618

**Validation**:

- `make docs`
- `make verify`
- `uv run pre-commit run --all-files`

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing