### PR TITLE
chore(docs): restructure Spark documentation navigation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -168,6 +168,8 @@ Getting Involved
    :caption: Spark
 
    spark/index
+   spark/connecting
+   spark/sessions
    spark/api
 
 .. toctree::

--- a/docs/source/spark/connecting.rst
+++ b/docs/source/spark/connecting.rst
@@ -1,0 +1,20 @@
+Connecting to Existing Spark Connect Servers
+============================================
+
+You can connect to an existing Spark Connect server instead of creating a new
+Spark session.
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+
+   client = SparkClient()
+
+   spark = client.connect(
+       base_url="sc://localhost:15002"
+   )
+
+   spark.range(10).show()
+
+This pattern is useful when Spark Connect is already running and managed
+independently of your application.

--- a/docs/source/spark/index.rst
+++ b/docs/source/spark/index.rst
@@ -127,72 +127,30 @@ Common Patterns
    result = df.groupBy().count()
    result.show()
 
-Connecting to Existing Spark Connect Servers
---------------------------------------------
+Guides
+------
 
-You can connect to an existing Spark Connect server instead of creating a new Spark session.
+.. grid:: 2
+   :gutter: 3
 
-.. code-block:: python
+   .. grid-item-card:: Connecting to Existing Spark Connect Servers
+      :link: connecting
+      :link-type: doc
 
-   from kubeflow.spark import SparkClient
+      Connect to an existing Spark Connect server instead of creating a new
+      session.
 
-   client = SparkClient()
+   .. grid-item-card:: Session Management
+      :link: sessions
+      :link-type: doc
 
-   spark = client.connect(
-       base_url="sc://localhost:15002"
-   )
+      Inspect and manage Spark Connect sessions.
 
-   spark.range(10).show()
+   .. grid-item-card:: API Reference
+      :link: api
+      :link-type: doc
 
-This pattern is useful when Spark Connect is already running and managed independently of your application.
-
-Session Management
-------------------
-
-Use the Spark SDK to inspect and manage Spark Connect sessions in the configured Kubernetes namespace (defaults to ``default``).
-
-**List active sessions:**
-
-.. code-block:: python
-
-   from kubeflow.spark import SparkClient
-
-   client = SparkClient()
-
-   sessions = client.list_sessions()
-
-   for session in sessions:
-       print(session.name)
-       print(session.state.value)
-
-**Get session information:**
-
-.. code-block:: python
-
-   session = client.get_session(
-       "spark-connect-example"
-   )
-
-   print(f"Name: {session.name}")
-   print(f"State: {session.state.value}")
-   print(f"Namespace: {session.namespace}")
-
-**View session logs:**
-
-.. code-block:: python
-
-   for line in client.get_session_logs(
-       "spark-connect-example"
-   ):
-       print(line)
-
-**Delete a session:**
-
-.. code-block:: python
-
-   client.delete_session(
-       "spark-connect-example"
-   )
+      Reference documentation for the Spark client and related APIs.
 
 When Things Go Wrong
 --------------------

--- a/docs/source/spark/sessions.rst
+++ b/docs/source/spark/sessions.rst
@@ -1,0 +1,48 @@
+Session Management
+==================
+
+Use the Spark SDK to inspect and manage Spark Connect sessions in the
+configured Kubernetes namespace (defaults to ``default``).
+
+**List active sessions:**
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+
+   client = SparkClient()
+
+   sessions = client.list_sessions()
+
+   for session in sessions:
+       print(session.name)
+       print(session.state.value)
+
+**Get session information:**
+
+.. code-block:: python
+
+   session = client.get_session(
+       "spark-connect-example"
+   )
+
+   print(f"Name: {session.name}")
+   print(f"State: {session.state.value}")
+   print(f"Namespace: {session.namespace}")
+
+**View session logs:**
+
+.. code-block:: python
+
+   for line in client.get_session_logs(
+       "spark-connect-example"
+   ):
+       print(line)
+
+**Delete a session:**
+
+.. code-block:: python
+
+   client.delete_session(
+       "spark-connect-example"
+   )


### PR DESCRIPTION
## Summary

This PR restructures the Spark documentation to align with the Trainer and Optimizer documentation layout.

### Changes

- Added `docs/source/spark/connecting.rst`
- Added `docs/source/spark/sessions.rst`
- Simplified the Spark landing page by moving topic-specific content into dedicated guides
- Added a Guides section with navigation cards
- Updated the root Spark toctree to include the new guides

### Notes

- Reused existing documentation content; no new tutorials were introduced.
- Did not include an examples guide because `spark/examples.rst` is not present on this branch.

Part of #618