### PR TITLE
feat(trainer): support custom env and volumes for container backend

### DIFF
--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -335,6 +335,7 @@ class ContainerBackend(RuntimeBackend):
 
             # Build base environment
             env = container_utils.build_environment(trainer)
+            env.update(self.cfg.env)
 
             # Construct pre-run command to install packages
             pre_install_cmd = container_utils.build_pip_install_cmd(trainer)
@@ -428,6 +429,7 @@ class ContainerBackend(RuntimeBackend):
                         "mode": "rw",
                     }
                 }
+                volumes.update(self.cfg.volumes)
 
                 logger.debug(f"Creating container {rank}/{num_nodes}: {container_name}")
 
@@ -600,6 +602,7 @@ class ContainerBackend(RuntimeBackend):
                 "mode": "rw",
             }
         }
+        volumes.update(self.cfg.volumes)
 
         logger.debug(f"Starting {container_init.name} container: {container_name}")
 

--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -603,6 +603,10 @@ class ContainerBackend(RuntimeBackend):
             }
         }
         volumes.update(self.cfg.volumes)
+        container_init_env = {
+            **self.cfg.env,
+            **container_init.env,
+        }
 
         logger.debug(f"Starting {container_init.name} container: {container_name}")
 
@@ -614,7 +618,7 @@ class ContainerBackend(RuntimeBackend):
             command=container_init.command,
             name=container_name,
             network_id=network_id,
-            environment=container_init.env,
+            environment=container_init_env,
             labels=labels,
             volumes=volumes,
             working_dir="/app",

--- a/kubeflow/trainer/backends/container/backend_test.py
+++ b/kubeflow/trainer/backends/container/backend_test.py
@@ -228,23 +228,12 @@ def container_backend():
     """Provide ContainerBackend with mocked adapter."""
     with patch("kubeflow.trainer.backends.container.backend.DockerClientAdapter") as mock_docker:
         mock_docker.return_value = MockContainerAdapter()
-        backend = ContainerBackend(ContainerBackendConfig())
+        backend = ContainerBackend(
+            ContainerBackendConfig(
+                env={"TEST_ENV": "test-value"},
+            )
+        )
         return backend
-
-
-@pytest.fixture
-def container_backend_with_config():
-    """Create ContainerBackend with a custom config."""
-
-    def _create(cfg: ContainerBackendConfig):
-        with patch(
-            "kubeflow.trainer.backends.container.backend.DockerClientAdapter"
-        ) as mock_docker:
-            mock_docker.return_value = MockContainerAdapter()
-            backend = ContainerBackend(cfg)
-            return backend
-
-    return _create
 
 
 def test_train_backend_env(container_backend_with_config):
@@ -294,6 +283,20 @@ def temp_workdir():
     yield tmpdir
     if os.path.exists(tmpdir):
         shutil.rmtree(tmpdir)
+
+
+@pytest.fixture
+def container_backend_with_config():
+    """Provide ContainerBackend with custom config and mocked adapter."""
+
+    def _create(cfg: ContainerBackendConfig):
+        with patch(
+            "kubeflow.trainer.backends.container.backend.DockerClientAdapter"
+        ) as mock_docker:
+            mock_docker.return_value = MockContainerAdapter()
+            return ContainerBackend(cfg)
+
+    return _create
 
 
 # Helper Function
@@ -722,6 +725,7 @@ def test_train(container_backend, test_case):
             for container in initializer_containers:
                 assert "STORAGE_URI" in container["environment"]
                 assert "OUTPUT_PATH" in container["environment"]
+                assert container["environment"].get("TEST_ENV") == "test-value"
 
                 # Verify OUTPUT_PATH is correct based on initializer type
                 if "dataset-initializer" in container["name"]:

--- a/kubeflow/trainer/backends/container/backend_test.py
+++ b/kubeflow/trainer/backends/container/backend_test.py
@@ -233,6 +233,61 @@ def container_backend():
 
 
 @pytest.fixture
+def container_backend_with_config():
+    """Create ContainerBackend with a custom config."""
+
+    def _create(cfg: ContainerBackendConfig):
+        with patch(
+            "kubeflow.trainer.backends.container.backend.DockerClientAdapter"
+        ) as mock_docker:
+            mock_docker.return_value = MockContainerAdapter()
+            backend = ContainerBackend(cfg)
+            return backend
+
+    return _create
+
+
+def test_train_backend_env(container_backend_with_config):
+    backend = container_backend_with_config(
+        ContainerBackendConfig(
+            env={"BACKEND_ENV": "backend-value"},
+        )
+    )
+
+    trainer = types.CustomTrainer(func=simple_train_func)
+    runtime = backend.get_runtime(constants.DEFAULT_TRAINING_RUNTIME)
+
+    backend.train(runtime=runtime, trainer=trainer)
+
+    container = backend._adapter.containers_created[0]
+
+    assert container["environment"]["BACKEND_ENV"] == "backend-value"
+
+
+def test_train_backend_volumes(container_backend_with_config):
+    backend = container_backend_with_config(
+        ContainerBackendConfig(
+            volumes={
+                "/host/data": {
+                    "bind": "/workspace/data",
+                    "mode": "rw",
+                }
+            }
+        )
+    )
+
+    trainer = types.CustomTrainer(func=simple_train_func)
+    runtime = backend.get_runtime(constants.DEFAULT_TRAINING_RUNTIME)
+
+    backend.train(runtime=runtime, trainer=trainer)
+
+    container = backend._adapter.containers_created[0]
+
+    assert "/host/data" in container["volumes"]
+    assert container["volumes"]["/host/data"]["bind"] == "/workspace/data"
+
+
+@pytest.fixture
 def temp_workdir():
     """Provide a temporary working directory."""
     tmpdir = tempfile.mkdtemp()

--- a/kubeflow/trainer/backends/container/types.py
+++ b/kubeflow/trainer/backends/container/types.py
@@ -77,3 +77,11 @@ class ContainerBackendConfig(BaseModel):
         default=600,
         description="Timeout in seconds for initializer containers (default 10 minutes)",
     )
+    env: dict[str, str] = Field(
+        default_factory=dict,
+        description="Additional environment variables for local containers",
+    )
+    volumes: dict[str, dict[str, str]] = Field(
+        default_factory=dict,
+        description="Additional volume mounts for local containers",
+    )

--- a/kubeflow/trainer/backends/container/types.py
+++ b/kubeflow/trainer/backends/container/types.py
@@ -61,6 +61,17 @@ class ContainerBackendConfig(BaseModel):
     auto_remove: bool = Field(default=True)
     container_host: str | None = Field(default=None)
     container_runtime: Literal["docker", "podman"] | None = Field(default=None)
+
+    env: dict[str, str] = Field(
+        default_factory=dict,
+        description="Additional environment variables for all containers.",
+    )
+
+    volumes: dict[str, dict[str, str]] = Field(
+        default_factory=dict,
+        description="Additional Docker volume mappings.",
+    )
+
     runtime_source: TrainingRuntimeSource = Field(
         default_factory=TrainingRuntimeSource,
         description="Configuration for training runtime sources",

--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -126,12 +126,15 @@ class LocalProcessBackend(RuntimeBackend):
         # set the command in the runtime trainer
         runtime.trainer.set_command(training_command)
 
+        env = dict(trainer.env or {})
+        env.update(self.cfg.env)
+
         # create subprocess object
         train_job = LocalJob(
             name=f"{trainjob_name}-train",
             command=training_command,
             execution_dir=venv_dir,
-            env=trainer.env,
+            env=env,
             dependencies=[],
         )
 

--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -58,6 +58,17 @@ def local_backend():
 
 
 @pytest.fixture
+def local_backend_with_config():
+    """Create LocalProcessBackend with a custom config."""
+
+    def _create(cfg: LocalProcessBackendConfig):
+        backend = LocalProcessBackend(cfg)
+        return backend
+
+    return _create
+
+
+@pytest.fixture
 def mock_train_environment():
     """Mock the training environment to avoid actual subprocess execution."""
     with (
@@ -364,6 +375,31 @@ def test_train(local_backend, mock_train_environment, test_case):
         # Verify job is tracked
         jobs = local_backend.list_jobs(runtime=runtime)
         assert any(job.name == train_job_name for job in jobs)
+
+
+def test_train_backend_env(local_backend_with_config, mock_train_environment):
+    """Test backend-level environment variables are passed to LocalJob."""
+
+    backend = local_backend_with_config(
+        LocalProcessBackendConfig(
+            env={"BACKEND_ENV": "backend-value"},
+        )
+    )
+
+    trainer = types.CustomTrainer(
+        func=dummy_training_function,
+    )
+    runtime = backend.get_runtime(constants.DEFAULT_TRAINING_RUNTIME)
+
+    backend.train(
+        runtime=runtime,
+        trainer=trainer,
+    )
+
+    job = backend._LocalProcessBackend__local_jobs[0]
+    train_step = job.steps[0]
+
+    assert train_step.job.env["BACKEND_ENV"] == "backend-value"
 
 
 @pytest.mark.parametrize(

--- a/kubeflow/trainer/backends/localprocess/types.py
+++ b/kubeflow/trainer/backends/localprocess/types.py
@@ -16,7 +16,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from kubeflow.trainer.backends.localprocess.job import LocalJob
 from kubeflow.trainer.types import types
@@ -24,6 +24,10 @@ from kubeflow.trainer.types import types
 
 class LocalProcessBackendConfig(BaseModel):
     cleanup_venv: bool = True
+    env: dict[str, str] = Field(
+        default_factory=dict,
+        description="Additional environment variables for local processes",
+    )
 
 
 @dataclass


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the local container backend to support additional runtime configuration.

### Changes
- Add `env` to `ContainerBackendConfig` to allow users to specify additional environment variables for local container execution.
- Add `volumes` to `ContainerBackendConfig` to allow users to mount additional host directories into training and initializer containers.
- Merge configured environment variables with the trainer environment before launching containers.
- Merge configured volume mounts with the default workspace mount for both training and initializer containers.
- Add unit tests to verify custom environment variables and volume mounts are propagated correctly.

**Which issue(s) this PR fixes**:

Fixes #624

**Checklist:**

- [ ] Docs included if any changes are user facing (not required for this internal backend change)