### PR TITLE
docs: Fix grammar and formatting typos in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ the guidelines and responsibilities for such contributions.
 
 The Kubeflow SDK project includes a Makefile with several helpful commands to streamline your development workflow.
 
-To install all dependencies (including dev tools) and create virtual environment, run
+To install all dependencies (including dev tools) and create a virtual environment, run
 
 ```sh
 make install-dev
@@ -44,14 +44,14 @@ make verify
 The Kubeflow SDK project includes several types of tests to ensure code quality and functionality.
 
 ### Unit Testing
-To run unit tests locally use the following make command:
+To run unit tests locally, use the following make command:
 
 ```shell
 make test-python
 ```
 
 ### E2E Tests
-E2E test run in CI on a kind cluster using [Kubeflow Trainer E2E Scripts](https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md#e2e-tests).
+E2E tests run in CI on a kind cluster using [Kubeflow Trainer E2E Scripts](https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md#e2e-tests).
 Clone the `Kubeflow Trainer` repo and run the provided commands against `Trainer` Makefile.
 For more details check [the Kubeflow Trainer Contributing Guide](https://github.com/kubeflow/trainer/blob/master/CONTRIBUTING.md#e2e-tests).
 


### PR DESCRIPTION
## Description
This PR fixes minor grammar and punctuation issues in `CONTRIBUTING.md`.

## Details
1. Fixed `create virtual environment` -> `create a virtual environment` under Development.
2. Added missing comma in `To run unit tests locally, use the following make command:`.
3. Fixed plural subject `E2E test run` -> `E2E tests run` under E2E Tests.