### PR TITLE
fix(trainer): remove HuggingFace storage URI validation

### DIFF
--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -17,7 +17,6 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from urllib.parse import urlparse
 
 import kubeflow.common.constants as common_constants
 from kubeflow.trainer.constants import constants
@@ -329,36 +328,18 @@ class BaseInitializer(abc.ABC):
     storage_uri: str
 
 
-def _validate_hf_storage_uri(storage_uri: str, entity: str) -> None:
-    """Validate an 'hf://<user_name>/<repo_name>' storage URI."""
-    if not storage_uri.startswith("hf://"):
-        raise ValueError(f"storage_uri must start with 'hf://', got {storage_uri}")
-
-    parsed = urlparse(storage_uri)
-    if not parsed.netloc or not parsed.path.strip("/"):
-        raise ValueError(
-            f"storage_uri: must have absolute path with 'hf://<user_name>/<{entity}>', got "
-            f"{storage_uri}"
-        )
-
-
 @dataclass
 class HuggingFaceDatasetInitializer(BaseInitializer):
     """Configuration for downloading datasets from HuggingFace Hub.
 
     Args:
-        storage_uri (`str`): The HuggingFace Hub dataset identifier in the format 'hf://username/repo_name'.
+        storage_uri (`str`): The HuggingFace Hub dataset identifier.
         ignore_patterns (`Optional[list[str]]`): List of file patterns to ignore during download.
         access_token (`Optional[str]`): HuggingFace Hub access token for private datasets.
     """
 
     ignore_patterns: list[str] | None = None
     access_token: str | None = None
-
-    def __post_init__(self):
-        """Validate HuggingFaceDatasetInitializer parameters."""
-
-        _validate_hf_storage_uri(self.storage_uri, "dataset_name")
 
 
 @dataclass
@@ -440,7 +421,7 @@ class HuggingFaceModelInitializer(BaseInitializer):
     """Configuration for downloading models from HuggingFace Hub.
 
     Args:
-        storage_uri (`str`): The HuggingFace Hub model identifier in the format 'hf://username/repo_name'.
+        storage_uri (`str`): The HuggingFace Hub model identifier.
         ignore_patterns (`Optional[list[str]]`): List of file patterns to ignore during download.
         access_token (`Optional[str]`): HuggingFace Hub access token.
     """
@@ -449,11 +430,6 @@ class HuggingFaceModelInitializer(BaseInitializer):
         default_factory=lambda: constants.INITIALIZER_DEFAULT_IGNORE_PATTERNS
     )
     access_token: str | None = None
-
-    def __post_init__(self):
-        """Validate HuggingFaceModelInitializer parameters."""
-
-        _validate_hf_storage_uri(self.storage_uri, "model_name")
 
 
 @dataclass

--- a/kubeflow/trainer/types/types_test.py
+++ b/kubeflow/trainer/types/types_test.py
@@ -124,33 +124,14 @@ def test_data_cache_initializer(test_case: TestCase):
             config={"storage_uri": "hf://user/model"},
         ),
         TestCase(
-            name="invalid storage_uri without hf prefix raises ValueError",
-            expected_status=FAILED,
-            config={"storage_uri": "user/model"},
-            expected_error=ValueError,
-        ),
-        TestCase(
-            name="invalid storage_uri without repo path raises ValueError",
-            expected_status=FAILED,
+            name="valid storage_uri with unscoped model",
+            expected_status=SUCCESS,
             config={"storage_uri": "hf://model"},
-            expected_error=ValueError,
-        ),
-        TestCase(
-            name="invalid storage_uri with user but no repo raises ValueError",
-            expected_status=FAILED,
-            config={"storage_uri": "hf://user/"},
-            expected_error=ValueError,
-        ),
-        TestCase(
-            name="invalid storage_uri with empty user raises ValueError",
-            expected_status=FAILED,
-            config={"storage_uri": "hf:///model"},
-            expected_error=ValueError,
         ),
     ],
 )
 def test_hugging_face_model_initializer(test_case: TestCase):
-    """Test HuggingFaceModelInitializer creation and validation."""
+    """Test HuggingFaceModelInitializer creation."""
     print("Executing test:", test_case.name)
 
     try:
@@ -176,33 +157,14 @@ def test_hugging_face_model_initializer(test_case: TestCase):
             config={"storage_uri": "hf://user/dataset"},
         ),
         TestCase(
-            name="invalid storage_uri without hf prefix raises ValueError",
-            expected_status=FAILED,
-            config={"storage_uri": "user/dataset"},
-            expected_error=ValueError,
-        ),
-        TestCase(
-            name="invalid storage_uri without repo path raises ValueError",
-            expected_status=FAILED,
+            name="valid storage_uri with unscoped dataset",
+            expected_status=SUCCESS,
             config={"storage_uri": "hf://dataset"},
-            expected_error=ValueError,
-        ),
-        TestCase(
-            name="invalid storage_uri with user but no repo raises ValueError",
-            expected_status=FAILED,
-            config={"storage_uri": "hf://user/"},
-            expected_error=ValueError,
-        ),
-        TestCase(
-            name="invalid storage_uri with empty user raises ValueError",
-            expected_status=FAILED,
-            config={"storage_uri": "hf:///dataset"},
-            expected_error=ValueError,
         ),
     ],
 )
 def test_hugging_face_dataset_initializer(test_case: TestCase):
-    """Test HuggingFaceDatasetInitializer creation and validation."""
+    """Test HuggingFaceDatasetInitializer creation."""
     print("Executing test:", test_case.name)
 
     try:


### PR DESCRIPTION
## What this PR does

This PR removes SDK-level Hugging Face storage URI validation introduced in #564 and #575.

The removed validation required both a user/organization and repository name. However, Hugging Face supports unscoped repository IDs such as `hf://model` and `hf://dataset`.

This change removes `_validate_hf_storage_uri` and its use from `HuggingFaceModelInitializer` and `HuggingFaceDatasetInitializer`. Validation of Hugging Face repository IDs is delegated to the Hugging Face client when the repository is used.

## Testing

- `python -m pytest kubeflow/trainer/types/types_test.py`
- `uv run --with pytest pytest kubeflow/trainer/types/types_test.py`

Follow-up to the maintainer suggestion in kubeflow/trainer#3741.