### PR TITLE
fix(trainer): preserve local job runtime metadata

### DIFF
--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -156,7 +156,7 @@ class LocalProcessBackend(RuntimeBackend):
                 types.TrainJob(
                     name=_job.name,
                     creation_timestamp=_job.created,
-                    runtime=runtime,
+                    runtime=_job.runtime,
                     num_nodes=1,
                     steps=[
                         types.Step(name=s.step_name, pod_name=s.step_name, status=s.job.status)

--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -411,6 +411,28 @@ def test_list_jobs(local_backend, test_case):
     assert isinstance(jobs, list)
 
 
+def test_list_jobs_without_runtime_filter_preserves_stored_runtime(
+    local_backend, mock_train_environment
+):
+    """Test unfiltered job listings retain each job's runtime metadata."""
+    runtime = types.Runtime(
+        name=TORCH_RUNTIME,
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="torch",
+            image=LOCAL_RUNTIME_IMAGE,
+        ),
+        kind=types.RuntimeKind.TRAINING_RUNTIME,
+    )
+
+    local_backend.train(runtime=runtime, trainer=types.CustomTrainer(func=dummy_training_function))
+
+    jobs = local_backend.list_jobs()
+
+    assert len(jobs) == 1
+    assert jobs[0].runtime == runtime
+
+
 @pytest.mark.parametrize(
     "test_case",
     [


### PR DESCRIPTION
Summary:
- Return each local job's stored runtime from unfiltered listings.
- Add regression coverage for list_jobs without a runtime filter.

Fixes #653

Validation:
- make test-python
- make verify
- uv run pytest kubeflow/trainer/backends/localprocess/backend_test.py -q