### PR TITLE
fix(spark): require host in Spark Connect URL validation

### DIFF
--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -802,6 +802,18 @@ def test_wait_for_connect_port(kubernetes_backend, test_case):
             config={"url": ""},
             expected_error=ValueError,
         ),
+        TestCase(
+            name="missing hostname error",
+            expected_status=FAILED,
+            config={"url": "sc://:15002"},
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="missing hostname and malformed port error",
+            expected_status=FAILED,
+            config={"url": "sc://:abc"},
+            expected_error=ValueError,
+        ),
     ],
 )
 def test_validate_spark_connect_url(test_case):

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -322,6 +322,8 @@ def validate_spark_connect_url(url: str) -> bool:
     parsed = urlparse(url)
     if parsed.scheme != "sc":
         raise ValueError(f"Invalid scheme '{parsed.scheme}'. Expected 'sc://'")
+    if not parsed.hostname:
+        raise ValueError("Host is required in Spark Connect URL")
     if not parsed.port:
         raise ValueError("Port is required in Spark Connect URL")
     return True

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -222,6 +222,20 @@ def test_generate_session_name(test_case: TestCase) -> None:
             expected_error=ValueError,
             expected_output="Port is required",
         ),
+        TestCase(
+            name="missing hostname",
+            expected_status=FAILED,
+            config={"url": "sc://:15002"},
+            expected_error=ValueError,
+            expected_output="Host is required",
+        ),
+        TestCase(
+            name="missing hostname with malformed port",
+            expected_status=FAILED,
+            config={"url": "sc://:abc"},
+            expected_error=ValueError,
+            expected_output="Host is required",
+        ),
     ],
 )
 def test_validate_spark_connect_url(test_case: TestCase) -> None:


### PR DESCRIPTION
**What this PR does / why we need it**:

`validate_spark_connect_url()` checks the scheme and the port, but not the host. So `sc://:15002` passes validation and returns `True`.

For that input `urlparse()` returns `hostname=None` but `port=15002`. Both existing checks pass and the missing host is never seen. This is reachable when the host comes from config. An empty value in `f"sc://{os.environ['SPARK_HOST']}:15002"` gives `sc://:15002`.

`SparkClient.connect()` passes `base_url` straight to `SparkSession.builder.remote()`. Spark Connect builds the session lazily, so nothing fails there. The first operation then retries against an unreachable address. That retry is the same for any unreachable host, so it is not caused by the missing host. The difference is that a missing host can be caught up front, while an unreachable hostname cannot. `connect()` already documents `ValueError` for an invalid `base_url`.

Note that `sc://:15002` is not interpreted as localhost. PySpark resolves it to the endpoint `:15002` with an empty host, so no existing behaviour depends on omitting it. `sc://localhost:15002` is unaffected.

This adds a host check between the scheme and port checks. The order matters because `parsed.port` raises its own `ValueError` on a malformed port, which would otherwise mask a missing host. It also improves the message for `sc://:abc`, which previously reported a port-casting error.

Adds four unit tests using the existing TestCase pattern. Two in utils_test.py and the same two in backend_test.py, since both files carry a parametrized test_validate_spark_connect_url and should stay in sync. One case covers the missing host; one covers a missing host with a malformed port, to lock in the check ordering. Happy to consolidate the duplicated coverage into a single site in a follow-up if preferred.

Validation

- `uv run pytest ./kubeflow/ -q` gives 642 passed
- `make verify` gives All checks passed
- A differential check over 26 URLs confirms only inputs with `hostname=None` change behaviour. IPv4, IPv6, cluster-local FQDNs and `build_service_url()` output are unaffected.

**Checklist:**

- [ ] Docs included if any changes are user facing