### PR TITLE
fix(spark): handle client_configuration, context, and default namespace  in KubernetesBackend

### DIFF
--- a/kubeflow/common/utils.py
+++ b/kubeflow/common/utils.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 import os
 
-from kubernetes import config
+from kubernetes import client, config
 
 from kubeflow.common import constants
+from kubeflow.common.types import KubernetesBackendConfig
 
 
 def is_running_in_k8s() -> bool:
@@ -61,3 +62,26 @@ def validate_wait_for_job_status(polling_interval: int, timeout: int) -> None:
             "Polling interval must be strictly less than timeout. "
             f"Received polling_interval={polling_interval}, timeout={timeout}"
         )
+
+
+def get_k8s_client(cfg: KubernetesBackendConfig) -> tuple[client.ApiClient, str]:
+    """Initialize and return the Kubernetes ApiClient and target namespace.
+
+    Args:
+        cfg: Kubernetes backend configuration.
+
+    Returns:
+        A tuple of (ApiClient, namespace).
+    """
+    if cfg.namespace is None:
+        cfg.namespace = get_default_target_namespace(cfg.context)
+
+    # If client configuration is not set, use kube-config to access Kubernetes APIs.
+    if cfg.client_configuration is None:
+        # Load kube-config or in-cluster config.
+        if cfg.config_file or not is_running_in_k8s():
+            config.load_kube_config(config_file=cfg.config_file, context=cfg.context)
+        else:
+            config.load_incluster_config()
+
+    return client.ApiClient(cfg.client_configuration), cfg.namespace

--- a/kubeflow/common/utils_test.py
+++ b/kubeflow/common/utils_test.py
@@ -11,9 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest.mock import patch
+
+from kubernetes import client
 import pytest
 
 from kubeflow.common import utils
+from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.trainer.test.common import SUCCESS, TestCase
 
 
@@ -67,3 +71,51 @@ def test_validate_wait_for_job_status(test_case):
             utils.validate_wait_for_job_status(polling_interval, timeout)
     else:
         utils.validate_wait_for_job_status(polling_interval, timeout)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="client_configuration provided explicitly",
+            config={
+                "client_configuration": client.Configuration(),
+                "expected_host": "https://custom-k8s:6443",
+            },
+        ),
+        TestCase(
+            name="load_kube_config with config_file and context",
+            config={
+                "config_file": "/path/to/kubeconfig",
+                "context": "test-context",
+                "namespace": "target-ns",
+            },
+        ),
+    ],
+)
+def test_get_k8s_client(test_case):
+    """Test get_k8s_client initialization logic."""
+    print("Executing test:", test_case.name)
+
+    if "client_configuration" in test_case.config:
+        custom_config = test_case.config["client_configuration"]
+        custom_config.host = test_case.config["expected_host"]
+        cfg = KubernetesBackendConfig(client_configuration=custom_config)
+        api_client, ns = utils.get_k8s_client(cfg)
+        assert api_client.configuration.host == test_case.config["expected_host"]
+    else:
+        with (
+            patch("kubernetes.config.load_kube_config") as mock_load_kube_config,
+            patch("kubeflow.common.utils.is_running_in_k8s", return_value=False),
+            patch("kubeflow.common.utils.get_default_target_namespace", return_value="target-ns"),
+        ):
+            cfg = KubernetesBackendConfig(
+                config_file=test_case.config["config_file"],
+                context=test_case.config["context"],
+            )
+            api_client, ns = utils.get_k8s_client(cfg)
+            mock_load_kube_config.assert_called_once_with(
+                config_file=test_case.config["config_file"],
+                context=test_case.config["context"],
+            )
+            assert ns == test_case.config["namespace"]

--- a/kubeflow/optimizer/backends/kubernetes/backend.py
+++ b/kubeflow/optimizer/backends/kubernetes/backend.py
@@ -23,7 +23,7 @@ from typing import Any
 import uuid
 
 from kubeflow_katib_api import models
-from kubernetes import client, config
+from kubernetes import client
 
 import kubeflow.common.constants as common_constants
 from kubeflow.common.types import KubernetesBackendConfig
@@ -49,22 +49,9 @@ logger = logging.getLogger(__name__)
 
 class KubernetesBackend(RuntimeBackend):
     def __init__(self, cfg: KubernetesBackendConfig):
-        if cfg.namespace is None:
-            cfg.namespace = common_utils.get_default_target_namespace(cfg.context)
-
-        # If client configuration is not set, use kube-config to access Kubernetes APIs.
-        if cfg.client_configuration is None:
-            # Load kube-config or in-cluster config.
-            if cfg.config_file or not common_utils.is_running_in_k8s():
-                config.load_kube_config(config_file=cfg.config_file, context=cfg.context)
-            else:
-                config.load_incluster_config()
-
-        k8s_client = client.ApiClient(cfg.client_configuration)
+        k8s_client, self.namespace = common_utils.get_k8s_client(cfg)
         self.custom_api = client.CustomObjectsApi(k8s_client)
         self.core_api = client.CoreV1Api(k8s_client)
-
-        self.namespace = cfg.namespace
         self.trainer_backend = TrainerBackend(cfg)
 
     def optimize(

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -37,6 +37,7 @@ from pyspark.sql import SparkSession
 
 from kubeflow.common import constants as common_constants
 from kubeflow.common.types import KubernetesBackendConfig
+import kubeflow.common.utils as common_utils
 from kubeflow.spark.backends.base import RuntimeBackend
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.utils import (
@@ -100,20 +101,25 @@ class KubernetesBackend(RuntimeBackend):
             ConfigException:
                 If the Kubernetes configuration cannot be loaded.
         """
-        self.namespace = backend_config.namespace or "default"
+        if backend_config.namespace is None:
+            backend_config.namespace = common_utils.get_default_target_namespace(
+                backend_config.context
+            )
 
-        if backend_config.config_file:
-            config.load_kube_config(config_file=backend_config.config_file)
-        elif backend_config.context:
-            config.load_kube_config(context=backend_config.context)
-        else:
-            try:
+        if backend_config.client_configuration is None:
+            if backend_config.config_file or not common_utils.is_running_in_k8s():
+                config.load_kube_config(
+                    config_file=backend_config.config_file,
+                    context=backend_config.context,
+                )
+            else:
                 config.load_incluster_config()
-            except config.ConfigException:
-                config.load_kube_config()
 
-        self.custom_api = client.CustomObjectsApi()
-        self.core_api = client.CoreV1Api()
+        k8s_client = client.ApiClient(backend_config.client_configuration)
+        self.custom_api = client.CustomObjectsApi(k8s_client)
+        self.core_api = client.CoreV1Api(k8s_client)
+
+        self.namespace = backend_config.namespace
 
     # ------------------------------------------------------------------
     # Spark Connect sessions

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -32,7 +32,7 @@ import time
 from typing import Any
 
 from kubeflow_spark_api import models
-from kubernetes import client, config
+from kubernetes import client
 from pyspark.sql import SparkSession
 
 from kubeflow.common import constants as common_constants
@@ -101,25 +101,9 @@ class KubernetesBackend(RuntimeBackend):
             ConfigException:
                 If the Kubernetes configuration cannot be loaded.
         """
-        if backend_config.namespace is None:
-            backend_config.namespace = common_utils.get_default_target_namespace(
-                backend_config.context
-            )
-
-        if backend_config.client_configuration is None:
-            if backend_config.config_file or not common_utils.is_running_in_k8s():
-                config.load_kube_config(
-                    config_file=backend_config.config_file,
-                    context=backend_config.context,
-                )
-            else:
-                config.load_incluster_config()
-
-        k8s_client = client.ApiClient(backend_config.client_configuration)
+        k8s_client, self.namespace = common_utils.get_k8s_client(backend_config)
         self.custom_api = client.CustomObjectsApi(k8s_client)
         self.core_api = client.CoreV1Api(k8s_client)
-
-        self.namespace = backend_config.namespace
 
     # ------------------------------------------------------------------
     # Spark Connect sessions

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -1931,27 +1931,50 @@ def test_get_job_logs(kubernetes_backend, test_case):
     print("test execution complete")
 
 
-def test_kubernetes_backend_initialization():
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="client_configuration passed explicitly",
+            config={
+                "client_configuration": client.Configuration(),
+                "expected_host": "https://custom-k8s-cluster:6443",
+            },
+        ),
+        TestCase(
+            name="config_file and context passed",
+            config={
+                "config_file": "/path/to/kubeconfig",
+                "context": "test-context",
+                "expected_namespace": "target-ns",
+            },
+        ),
+    ],
+)
+def test_kubernetes_backend_initialization(test_case: TestCase):
     """Test KubernetesBackend initialization with various KubernetesBackendConfig parameters."""
-    custom_config = client.Configuration()
-    custom_config.host = "https://custom-k8s-cluster:6443"
+    print("Executing test:", test_case.name)
 
-    # Test 1: client_configuration passed explicitly
-    backend = KubernetesBackend(KubernetesBackendConfig(client_configuration=custom_config))
-    assert backend.custom_api.api_client.configuration.host == "https://custom-k8s-cluster:6443"
-    assert backend.core_api.api_client.configuration.host == "https://custom-k8s-cluster:6443"
-
-    # Test 2: config_file and context passed
-    with (
-        patch("kubernetes.config.load_kube_config") as mock_load_kube_config,
-        patch("kubeflow.common.utils.is_running_in_k8s", return_value=False),
-        patch("kubeflow.common.utils.get_default_target_namespace", return_value="target-ns"),
-    ):
-        backend = KubernetesBackend(
-            KubernetesBackendConfig(config_file="/path/to/kubeconfig", context="test-context")
-        )
-        mock_load_kube_config.assert_called_once_with(
-            config_file="/path/to/kubeconfig", context="test-context"
-        )
-        assert backend.namespace == "target-ns"
-
+    if "client_configuration" in test_case.config:
+        custom_config = test_case.config["client_configuration"]
+        custom_config.host = test_case.config["expected_host"]
+        backend = KubernetesBackend(KubernetesBackendConfig(client_configuration=custom_config))
+        assert backend.custom_api.api_client.configuration.host == test_case.config["expected_host"]
+        assert backend.core_api.api_client.configuration.host == test_case.config["expected_host"]
+    else:
+        with (
+            patch("kubernetes.config.load_kube_config") as mock_load_kube_config,
+            patch("kubeflow.common.utils.is_running_in_k8s", return_value=False),
+            patch("kubeflow.common.utils.get_default_target_namespace", return_value="target-ns"),
+        ):
+            backend = KubernetesBackend(
+                KubernetesBackendConfig(
+                    config_file=test_case.config["config_file"],
+                    context=test_case.config["context"],
+                )
+            )
+            mock_load_kube_config.assert_called_once_with(
+                config_file=test_case.config["config_file"],
+                context=test_case.config["context"],
+            )
+            assert backend.namespace == test_case.config["expected_namespace"]

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -1929,3 +1929,29 @@ def test_get_job_logs(kubernetes_backend, test_case):
             raise
 
     print("test execution complete")
+
+
+def test_kubernetes_backend_initialization():
+    """Test KubernetesBackend initialization with various KubernetesBackendConfig parameters."""
+    custom_config = client.Configuration()
+    custom_config.host = "https://custom-k8s-cluster:6443"
+
+    # Test 1: client_configuration passed explicitly
+    backend = KubernetesBackend(KubernetesBackendConfig(client_configuration=custom_config))
+    assert backend.custom_api.api_client.configuration.host == "https://custom-k8s-cluster:6443"
+    assert backend.core_api.api_client.configuration.host == "https://custom-k8s-cluster:6443"
+
+    # Test 2: config_file and context passed
+    with (
+        patch("kubernetes.config.load_kube_config") as mock_load_kube_config,
+        patch("kubeflow.common.utils.is_running_in_k8s", return_value=False),
+        patch("kubeflow.common.utils.get_default_target_namespace", return_value="target-ns"),
+    ):
+        backend = KubernetesBackend(
+            KubernetesBackendConfig(config_file="/path/to/kubeconfig", context="test-context")
+        )
+        mock_load_kube_config.assert_called_once_with(
+            config_file="/path/to/kubeconfig", context="test-context"
+        )
+        assert backend.namespace == "target-ns"
+

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -25,7 +25,7 @@ from typing import Any
 import uuid
 
 from kubeflow_trainer_api import models
-from kubernetes import client, config, watch
+from kubernetes import client, watch
 
 import kubeflow.common.constants as common_constants
 from kubeflow.common.types import KubernetesBackendConfig
@@ -40,22 +40,9 @@ logger = logging.getLogger(__name__)
 
 class KubernetesBackend(RuntimeBackend):
     def __init__(self, cfg: KubernetesBackendConfig):
-        if cfg.namespace is None:
-            cfg.namespace = common_utils.get_default_target_namespace(cfg.context)
-
-        # If client configuration is not set, use kube-config to access Kubernetes APIs.
-        if cfg.client_configuration is None:
-            # Load kube-config or in-cluster config.
-            if cfg.config_file or not common_utils.is_running_in_k8s():
-                config.load_kube_config(config_file=cfg.config_file, context=cfg.context)
-            else:
-                config.load_incluster_config()
-
-        k8s_client = client.ApiClient(cfg.client_configuration)
+        k8s_client, self.namespace = common_utils.get_k8s_client(cfg)
         self.custom_api = client.CustomObjectsApi(k8s_client)
         self.core_api = client.CoreV1Api(k8s_client)
-
-        self.namespace = cfg.namespace
 
         # Perform control-plane version metadata verification.
         self.verify_backend()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Aligns `kubeflow.spark.backends.kubernetes.KubernetesBackend.__init__` with the standard `KubernetesBackendConfig` handling pattern established in `kubeflow.trainer` and `kubeflow.optimizer`.

**Key changes**:
1. **Support `client_configuration`**: Passes `backend_config.client_configuration` to `client.ApiClient` when instantiating `CustomObjectsApi` and `CoreV1Api`.
2. **Kubeconfig context support**: Passes both `config_file` and `context` to `config.load_kube_config(config_file=..., context=...)`.
3. **Dynamic target namespace resolution**: Resolves `namespace` using `common_utils.get_default_target_namespace(context)` when `backend_config.namespace` is `None` instead of statically defaulting to `"default"`.
4. **Unit tests**: Added unit tests in `kubeflow/spark/backends/kubernetes/backend_test.py` covering custom `client_configuration`, `config_file`/`context` loading, and dynamic target namespace resolution.

**Which issue(s) this PR fixes** *(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)*:

Fixes #663

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
- [x] Tests added and updated for `KubernetesBackend` initialization logic
