### PR TITLE
fix(trainer): handle empty pip_index_urls in get_script_for_python_packages

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -287,11 +287,13 @@ def get_script_for_python_packages(
     packages_str = " ".join(shlex.quote(pkg) for pkg in packages_to_install)
 
     # first url will be the index-url.
-    options = [f"--index-url {shlex.quote(pip_index_urls[0])}"]
-    options.extend(
-        f"--extra-index-url {shlex.quote(extra_index_url)}"
-        for extra_index_url in pip_index_urls[1:]
-    )
+    options = []
+    if pip_index_urls:
+        options.append(f"--index-url {shlex.quote(pip_index_urls[0])}")
+        options.extend(
+            f"--extra-index-url {shlex.quote(extra_index_url)}"
+            for extra_index_url in pip_index_urls[1:]
+        )
     options_str = " ".join(options)
 
     header_script = textwrap.dedent(

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -274,6 +274,36 @@ def test_get_resources_per_node(test_case: TestCase):
             ),
         ),
         TestCase(
+            name="empty pip index URLs",
+            config={
+                "packages_to_install": ["numpy"],
+                "pip_index_urls": [],
+                "is_mpi": False,
+            },
+            expected_output=(
+                '\nif ! [ -x "$(command -v pip)" ]; then\n'
+                "    python -m ensurepip || python -m ensurepip --user || "
+                "apt-get install python-pip\n"
+                "fi\n\n\n"
+                "PACKAGES=(numpy)\n"
+                "PIP_OPTS=()\n"
+                'LOG_FILE="pip_install.log"\n'
+                'rm -f "$LOG_FILE"\n'
+                "\n"
+                "if PIP_DISABLE_PIP_VERSION_CHECK=1 PIP_BREAK_SYSTEM_PACKAGES=1 python -m pip install --quiet \\\n"
+                '    --no-warn-script-location "${PIP_OPTS[@]}" --user "${PACKAGES[@]}" >"$LOG_FILE" 2>&1; then\n'
+                '    echo "Successfully installed Python packages (user): ${PACKAGES[*]}"\n'
+                "elif PIP_DISABLE_PIP_VERSION_CHECK=1 PIP_BREAK_SYSTEM_PACKAGES=1 python -m pip install --quiet \\\n"
+                '    --no-warn-script-location "${PIP_OPTS[@]}" "${PACKAGES[@]}" >>"$LOG_FILE" 2>&1; then\n'
+                '    echo "Successfully installed Python packages (system-wide): ${PACKAGES[*]}"\n'
+                "else\n"
+                '    echo "ERROR: Failed to install Python packages: ${PACKAGES[*]}" >&2\n'
+                '    cat "$LOG_FILE" >&2\n'
+                "    exit 1\n"
+                "fi\n\n"
+            ),
+        ),
+        TestCase(
             name="multiple pip index URLs with MPI",
             config={
                 "packages_to_install": ["torch", "numpy", "custom-package"],


### PR DESCRIPTION

**What this PR does / why we need it**:

In [`kubeflow/trainer/backends/kubernetes/utils.py`](file:///c:/Users/Vishal/Code_File/Repo%20Folder/sdk/kubeflow/trainer/backends/kubernetes/utils.py#L289-L295), `get_script_for_python_packages` directly accessed `pip_index_urls[0]` when generating package installation scripts for `CustomTrainer`. If `packages_to_install` was provided but `pip_index_urls` was set to an empty list `[]`, evaluating `pip_index_urls[0]` raised an uncaught `IndexError: list index out of range`.

This PR updates `get_script_for_python_packages` to verify `if pip_index_urls:` before accessing index 0. If `pip_index_urls` is empty, `--index-url` and `--extra-index-url` flags are omitted, allowing `pip` to run without error.

**Changes**:
1. Check `if pip_index_urls:` before building `--index-url` and `--extra-index-url` options in `get_script_for_python_packages`.
2. Add unit test case `empty pip index URLs` to `test_get_script_for_python_packages` in `utils_test.py`.

**Verification**:
- `python -m uv run pytest kubeflow/trainer/backends/kubernetes/utils_test.py` (73/73 passed)
- `python -m uv run ruff check .` (All checks passed)
- `python -m uv run ruff format --check kubeflow` (94 files formatted)

**Which issue(s) this PR fixes**:

Fixes #665

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
