### PR TITLE
refactor: move shared job utilities to common module

### DIFF
--- a/kubeflow/common/types.py
+++ b/kubeflow/common/types.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 
+from dataclasses import dataclass
+from datetime import datetime
+
 from kubernetes import client
 from pydantic import BaseModel
 
@@ -25,3 +28,24 @@ class KubernetesBackendConfig(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
+
+
+# Representation for Kubernetes events.
+@dataclass
+class Event:
+    """Event object that represents a Kubernetes event related to a resource.
+
+    Args:
+        involved_object_kind (`str`): The kind of object this event is about.
+        involved_object_name (`str`): The name of the object this event is about.
+        message (`str`): Human-readable description of the event.
+        reason (`str`): Short, machine understandable string describing why
+            this event was generated.
+        event_time (`datetime`): The time at which the event was first recorded.
+    """
+
+    involved_object_kind: str
+    involved_object_name: str
+    message: str
+    reason: str
+    event_time: datetime

--- a/kubeflow/common/utils.py
+++ b/kubeflow/common/utils.py
@@ -11,11 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections.abc import Iterator
+import multiprocessing
 import os
+import random
+import string
+import uuid
 
-from kubernetes import config
+from kubernetes import client, config, watch
 
-from kubeflow.common import constants
+from kubeflow.common import constants, types
+from kubeflow.common.types import KubernetesBackendConfig
 
 
 def is_running_in_k8s() -> bool:
@@ -61,3 +67,138 @@ def validate_wait_for_job_status(polling_interval: int, timeout: int) -> None:
             "Polling interval must be strictly less than timeout. "
             f"Received polling_interval={polling_interval}, timeout={timeout}"
         )
+
+
+def load_kube_config(cfg: KubernetesBackendConfig) -> None:
+    """Load Kubernetes configuration based on the provided backend config."""
+    if cfg.namespace is None:
+        cfg.namespace = get_default_target_namespace(cfg.context)
+
+    if cfg.client_configuration is None:
+        if cfg.config_file or not is_running_in_k8s():
+            config.load_kube_config(config_file=cfg.config_file, context=cfg.context)
+        else:
+            config.load_incluster_config()
+
+
+def generate_random_name(prefix: str = "", length: int = 11) -> str:
+    """Generate a random name with an optional prefix.
+
+    Note: when a prefix is given the total length is ``len(prefix) + 1 + length``
+    (prefix, hyphen, random hex); without a prefix the total length is ``length + 1``
+    (one leading lowercase letter followed by ``length`` hex characters).
+    """
+    if prefix:
+        return f"{prefix}-{uuid.uuid4().hex[:length]}"
+    return random.choice(string.ascii_lowercase) + uuid.uuid4().hex[:length]
+
+
+def read_pod_logs(
+    core_api: client.CoreV1Api,
+    pod_name: str,
+    namespace: str,
+    container_name: str | None = None,
+    follow: bool = False,
+    timeout: int = constants.DEFAULT_TIMEOUT,
+) -> Iterator[str]:
+    """Read logs from a Kubernetes pod.
+
+    Args:
+        core_api: Kubernetes CoreV1Api client.
+        pod_name: Name of the pod.
+        namespace: Kubernetes namespace.
+        container_name: Name of the container.
+        follow: Whether to stream logs continuously.
+        timeout: Timeout in seconds for the API call.
+
+    Yields:
+        Log lines from the pod.
+
+    Raises:
+        TimeoutError: If the API call times out.
+        RuntimeError: If pod logs cannot be retrieved.
+    """
+    try:
+        kwargs: dict = {
+            "name": pod_name,
+            "namespace": namespace,
+        }
+        if container_name:
+            kwargs["container"] = container_name
+
+        if follow:
+            # watch.Watch().stream() returns a plain generator — it is a synchronous
+            # blocking HTTP stream and has no .get() method. Do NOT pass async_req here.
+            log_stream = watch.Watch().stream(
+                core_api.read_namespaced_pod_log, follow=True, **kwargs
+            )
+            yield from log_stream
+        else:
+            # async_req=True makes the k8s client return an ApplyResult whose
+            # .get(timeout) blocks until the response arrives or raises
+            # multiprocessing.TimeoutError — the same pattern as get_job_events.
+            logs = core_api.read_namespaced_pod_log(**kwargs, async_req=True).get(timeout)
+            if logs:
+                yield from logs.splitlines()
+
+    except multiprocessing.TimeoutError as e:
+        raise TimeoutError(f"Timeout while reading logs for the pod {namespace}/{pod_name}") from e
+    except Exception as e:
+        raise RuntimeError(f"Failed to read logs for the pod {namespace}/{pod_name}") from e
+
+
+def get_job_events(
+    core_api: client.CoreV1Api,
+    namespace: str,
+    job_resources: set[str],
+    job_kinds: set[str],
+    timeout: int = constants.DEFAULT_TIMEOUT,
+) -> list[types.Event]:
+    """Retrieve Kubernetes events related to a specific job and its resources.
+
+    Args:
+        core_api: Kubernetes CoreV1Api client.
+        namespace: The namespace to get the events from.
+        job_resources: A set of resource names (e.g., job name, pod names, trial names).
+        job_kinds: A set of Kubernetes resource kinds (e.g., {"TrainJob", "Pod"}).
+        timeout: Timeout in seconds for the API call.
+
+    Returns:
+        List of Kubernetes events related to the given resources, sorted by time.
+
+    Raises:
+        TimeoutError: If the API call times out.
+    """
+    events = []
+    try:
+        # Retrieve events from the namespace
+        event_response: client.V1EventList = core_api.list_namespaced_event(
+            namespace=namespace,
+            async_req=True,
+        ).get(timeout)
+
+        # Filter events related to the given resources
+        for event in event_response.items:
+            if not (event.metadata and event.involved_object and event.first_timestamp):
+                continue
+
+            involved_object = event.involved_object
+
+            # Check if event is related to the job resources
+            if involved_object.kind in job_kinds and involved_object.name in job_resources:
+                events.append(
+                    types.Event(
+                        involved_object_kind=involved_object.kind,
+                        involved_object_name=involved_object.name,
+                        message=event.message or "",
+                        reason=event.reason or "",
+                        event_time=event.first_timestamp,
+                    )
+                )
+
+        # Sort events by first occurrence time
+        events.sort(key=lambda e: e.event_time)
+
+        return events
+    except multiprocessing.TimeoutError as e:
+        raise TimeoutError("Timeout while retrieving job events") from e

--- a/kubeflow/common/utils_test.py
+++ b/kubeflow/common/utils_test.py
@@ -11,10 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import multiprocessing
+from unittest.mock import MagicMock, Mock, patch
+
 import pytest
 
 from kubeflow.common import utils
-from kubeflow.trainer.test.common import SUCCESS, TestCase
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
 
 
 @pytest.mark.parametrize(
@@ -67,3 +70,158 @@ def test_validate_wait_for_job_status(test_case):
             utils.validate_wait_for_job_status(polling_interval, timeout)
     else:
         utils.validate_wait_for_job_status(polling_interval, timeout)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for read_pod_logs tests
+# ---------------------------------------------------------------------------
+
+
+def _make_apply_result(return_value=None, side_effect=None):
+    """Return a mock shaped like a k8s ApplyResult (has .get(timeout))."""
+    thread = Mock()
+    if side_effect is not None:
+        thread.get.side_effect = side_effect
+    else:
+        thread.get.return_value = return_value
+    return thread
+
+
+def _real_generator(*lines):
+    """Return a real Python generator — NOT a Mock — to prevent .get() being silently absorbed."""
+    yield from lines
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="non-follow: yields split log lines",
+            expected_status=SUCCESS,
+            config={"follow": False, "log_text": "line1\nline2\nline3"},
+            expected_output=["line1", "line2", "line3"],
+        ),
+        TestCase(
+            name="non-follow: empty response yields nothing",
+            expected_status=SUCCESS,
+            config={"follow": False, "log_text": ""},
+            expected_output=[],
+        ),
+        TestCase(
+            name="non-follow: timeout raises TimeoutError",
+            expected_status=FAILED,
+            config={"follow": False, "api_error": multiprocessing.TimeoutError()},
+            expected_error=TimeoutError,
+        ),
+        TestCase(
+            name="non-follow: k8s exception raises RuntimeError",
+            expected_status=FAILED,
+            config={"follow": False, "api_error": Exception("k8s error")},
+            expected_error=RuntimeError,
+        ),
+        TestCase(
+            name="follow: yields each streamed line",
+            expected_status=SUCCESS,
+            config={"follow": True, "stream_lines": ["stream-line-1", "stream-line-2"]},
+            expected_output=["stream-line-1", "stream-line-2"],
+        ),
+        TestCase(
+            name="follow: stream exception raises RuntimeError",
+            expected_status=FAILED,
+            config={"follow": True, "stream_error": Exception("stream broken")},
+            expected_error=RuntimeError,
+        ),
+    ],
+)
+def test_read_pod_logs(test_case):
+    """Test read_pod_logs for both follow and non-follow paths with shape-faithful mocks.
+
+    The follow-mode mock uses a real Python generator (not Mock) so that any regression
+    that calls .get() on the stream would raise AttributeError rather than silently
+    returning another Mock and masking the bug.
+    """
+    print("Executing test:", test_case.name)
+
+    core_api = MagicMock()
+    follow = test_case.config.get("follow", False)
+
+    if follow:
+        stream_error = test_case.config.get("stream_error")
+        stream_lines = test_case.config.get("stream_lines", [])
+
+        if stream_error:
+            # Simulate the generator raising on iteration.
+            def _error_gen():
+                raise stream_error
+                yield  # make it a generator
+
+            mock_stream = _error_gen()
+        else:
+            # Use a *real* generator — not Mock() — so .get() would crash if called,
+            # catching any future regression that re-introduces .get(timeout) on the stream.
+            mock_stream = _real_generator(*stream_lines)
+
+        with patch("kubeflow.common.utils.watch") as mock_watch:
+            mock_watch.Watch.return_value.stream.return_value = mock_stream
+
+            if test_case.expected_status == SUCCESS:
+                result = list(
+                    utils.read_pod_logs(
+                        core_api=core_api,
+                        pod_name="test-pod",
+                        namespace="default",
+                        follow=True,
+                    )
+                )
+                assert result == test_case.expected_output
+                # Verify async_req was NOT passed to stream() — it doesn't belong there.
+                call_kwargs = mock_watch.Watch.return_value.stream.call_args[1]
+                assert "async_req" not in call_kwargs
+            else:
+                with pytest.raises(test_case.expected_error):
+                    list(
+                        utils.read_pod_logs(
+                            core_api=core_api,
+                            pod_name="test-pod",
+                            namespace="default",
+                            follow=True,
+                        )
+                    )
+    else:
+        api_error = test_case.config.get("api_error")
+        log_text = test_case.config.get("log_text", "")
+
+        if api_error is not None:
+            core_api.read_namespaced_pod_log.return_value = _make_apply_result(
+                side_effect=api_error
+            )
+        else:
+            core_api.read_namespaced_pod_log.return_value = _make_apply_result(
+                return_value=log_text
+            )
+
+        if test_case.expected_status == SUCCESS:
+            result = list(
+                utils.read_pod_logs(
+                    core_api=core_api,
+                    pod_name="test-pod",
+                    namespace="default",
+                    follow=False,
+                )
+            )
+            assert result == test_case.expected_output
+            # Verify async_req=True was passed to the API call.
+            call_kwargs = core_api.read_namespaced_pod_log.call_args[1]
+            assert call_kwargs.get("async_req") is True
+        else:
+            with pytest.raises(test_case.expected_error):
+                list(
+                    utils.read_pod_logs(
+                        core_api=core_api,
+                        pod_name="test-pod",
+                        namespace="default",
+                        follow=False,
+                    )
+                )
+
+    print("test execution complete")

--- a/kubeflow/optimizer/backends/kubernetes/backend.py
+++ b/kubeflow/optimizer/backends/kubernetes/backend.py
@@ -16,17 +16,14 @@ from collections.abc import Callable, Iterator
 import copy
 import logging
 import multiprocessing
-import random
-import string
 import time
 from typing import Any
-import uuid
 
 from kubeflow_katib_api import models
-from kubernetes import client, config
+from kubernetes import client
 
 import kubeflow.common.constants as common_constants
-from kubeflow.common.types import KubernetesBackendConfig
+from kubeflow.common.types import Event, KubernetesBackendConfig
 import kubeflow.common.utils as common_utils
 from kubeflow.optimizer.backends.base import RuntimeBackend
 from kubeflow.optimizer.backends.kubernetes import utils
@@ -42,23 +39,14 @@ from kubeflow.optimizer.types.optimization_types import (
 )
 from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend as TrainerBackend
 import kubeflow.trainer.constants.constants as trainer_constants
-from kubeflow.trainer.types.types import Event, TrainJobTemplate
+from kubeflow.trainer.types.types import TrainJobTemplate
 
 logger = logging.getLogger(__name__)
 
 
 class KubernetesBackend(RuntimeBackend):
     def __init__(self, cfg: KubernetesBackendConfig):
-        if cfg.namespace is None:
-            cfg.namespace = common_utils.get_default_target_namespace(cfg.context)
-
-        # If client configuration is not set, use kube-config to access Kubernetes APIs.
-        if cfg.client_configuration is None:
-            # Load kube-config or in-cluster config.
-            if cfg.config_file or not common_utils.is_running_in_k8s():
-                config.load_kube_config(config_file=cfg.config_file, context=cfg.context)
-            else:
-                config.load_incluster_config()
+        common_utils.load_kube_config(cfg)
 
         k8s_client = client.ApiClient(cfg.client_configuration)
         self.custom_api = client.CustomObjectsApi(k8s_client)
@@ -77,7 +65,7 @@ class KubernetesBackend(RuntimeBackend):
         algorithm: BaseAlgorithm | None = None,
     ) -> str:
         # Generate unique name for the OptimizationJob.
-        optimization_job_name = random.choice(string.ascii_lowercase) + uuid.uuid4().hex[:11]
+        optimization_job_name = common_utils.generate_random_name()
 
         # Validate search_space
         if not search_space:
@@ -249,9 +237,12 @@ class KubernetesBackend(RuntimeBackend):
         if pod_name is None:
             return
 
-        container_name = constants.METRICS_COLLECTOR_CONTAINER
-        yield from self.trainer_backend._read_pod_logs(
-            pod_name=pod_name, container_name=container_name, follow=follow
+        yield from common_utils.read_pod_logs(
+            core_api=self.core_api,
+            pod_name=pod_name,
+            namespace=self.namespace,
+            container_name=constants.METRICS_COLLECTOR_CONTAINER,
+            follow=follow,
         )
 
     def get_best_results(self, name: str) -> Result | None:
@@ -352,40 +343,14 @@ class KubernetesBackend(RuntimeBackend):
         for trial in job.trials:
             optimization_job_resources.add(trial.name)
 
-        events = []
         try:
-            # Retrieve events from the namespace
-            event_response: models.IoK8sApiCoreV1EventList = self.core_api.list_namespaced_event(
+            return common_utils.get_job_events(
+                core_api=self.core_api,
                 namespace=self.namespace,
-                async_req=True,
-            ).get(common_constants.DEFAULT_TIMEOUT)
-
-            # Filter events related to OptimizationJob resources
-            for event in event_response.items:
-                if not (event.metadata and event.involved_object and event.first_timestamp):
-                    continue
-
-                involved_object = event.involved_object
-
-                # Check if event is related to OptimizationJob resources
-                if (
-                    involved_object.kind in {constants.EXPERIMENT_KIND, constants.TRIAL_KIND}
-                    and involved_object.name in optimization_job_resources
-                ):
-                    events.append(
-                        Event(
-                            involved_object_kind=involved_object.kind,
-                            involved_object_name=involved_object.name,
-                            message=event.message or "",
-                            reason=event.reason or "",
-                            event_time=event.first_timestamp,
-                        )
-                    )
-
-            # Sort events by first occurrence time
-            events.sort(key=lambda e: e.event_time)
-            return events
-        except multiprocessing.TimeoutError as e:
+                job_resources=optimization_job_resources,
+                job_kinds={constants.EXPERIMENT_KIND, constants.TRIAL_KIND},
+            )
+        except TimeoutError as e:
             raise TimeoutError(
                 f"Timeout getting {constants.OPTIMIZATION_JOB_KIND} events: {self.namespace}/{name}"
             ) from e

--- a/kubeflow/optimizer/backends/kubernetes/backend_test.py
+++ b/kubeflow/optimizer/backends/kubernetes/backend_test.py
@@ -111,7 +111,6 @@ def optimizer_backend():
             return_value=Mock(to_dict=Mock(return_value={}))
         )
         backend.trainer_backend.get_job = Mock(side_effect=mock_trainer_get_job)
-        backend.trainer_backend._read_pod_logs = Mock(return_value=iter(["test log content"]))
         yield backend
 
 
@@ -795,21 +794,33 @@ def test_get_job_logs(optimizer_backend, test_case):
 
     try:
         optimizer_backend.namespace = test_case.config.get("namespace", DEFAULT_NAMESPACE)
-        logs = optimizer_backend.get_job_logs(
-            test_case.config.get("name"),
-            trial_name=test_case.config.get("trial_name"),
-            follow=test_case.config.get("follow", False),
-        )
-        logs_list = list(logs)
-        assert test_case.expected_status == SUCCESS
-        assert logs_list == test_case.expected_output
+        with patch(
+            "kubeflow.optimizer.backends.kubernetes.backend.common_utils.read_pod_logs"
+        ) as mock_read:
+            if test_case.config.get("name") == TIMEOUT:
+                mock_read.side_effect = TimeoutError()
+            elif test_case.config.get("name") == RUNTIME:
+                mock_read.side_effect = RuntimeError()
+            else:
+                mock_read.return_value = iter(["test log content"])
 
-        if test_case.config.get("follow"):
-            optimizer_backend.trainer_backend._read_pod_logs.assert_called_once_with(
-                pod_name=f"{BASIC_TRIAL_NAME}-node-0-pod",
-                container_name=constants.METRICS_COLLECTOR_CONTAINER,
-                follow=True,
+            logs = optimizer_backend.get_job_logs(
+                test_case.config.get("name"),
+                trial_name=test_case.config.get("trial_name"),
+                follow=test_case.config.get("follow", False),
             )
+            logs_list = list(logs)
+            assert test_case.expected_status == SUCCESS
+            assert logs_list == test_case.expected_output
+
+            if test_case.config.get("follow"):
+                mock_read.assert_called_once_with(
+                    core_api=optimizer_backend.core_api,
+                    pod_name=f"{BASIC_TRIAL_NAME}-node-0-pod",
+                    namespace=optimizer_backend.namespace,
+                    container_name=constants.METRICS_COLLECTOR_CONTAINER,
+                    follow=True,
+                )
 
     except Exception as e:
         assert test_case.expected_status != SUCCESS

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -32,10 +32,10 @@ import time
 from typing import Any
 
 from kubeflow_spark_api import models
-from kubernetes import client, config
+from kubernetes import client
 from pyspark.sql import SparkSession
 
-from kubeflow.common import constants as common_constants
+from kubeflow.common import constants as common_constants, utils as common_utils
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.backends.base import RuntimeBackend
 from kubeflow.spark.backends.kubernetes import constants
@@ -48,7 +48,6 @@ from kubeflow.spark.backends.kubernetes.utils import (
     get_spark_application_cr_from_func_job,
     get_spark_application_info_from_cr,
     get_spark_connect_info_from_cr,
-    read_pod_logs,
 )
 from kubeflow.spark.types.options import Name
 from kubeflow.spark.types.types import (
@@ -100,17 +99,8 @@ class KubernetesBackend(RuntimeBackend):
             ConfigException:
                 If the Kubernetes configuration cannot be loaded.
         """
+        common_utils.load_kube_config(backend_config)
         self.namespace = backend_config.namespace or "default"
-
-        if backend_config.config_file:
-            config.load_kube_config(config_file=backend_config.config_file)
-        elif backend_config.context:
-            config.load_kube_config(context=backend_config.context)
-        else:
-            try:
-                config.load_incluster_config()
-            except config.ConfigException:
-                config.load_kube_config()
 
         self.custom_api = client.CustomObjectsApi()
         self.core_api = client.CoreV1Api()
@@ -737,32 +727,30 @@ class KubernetesBackend(RuntimeBackend):
                 If retrieving the driver pod logs times out.
         """
         info = self.get_session(name)
+        pod_name = info.driver_pod_name
 
-        if not info.driver_pod_name:
+        if not pod_name:
             raise RuntimeError(
                 f"No driver pod for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
             )
 
-        def _stream() -> Iterator[str]:
-            try:
-                yield from read_pod_logs(
-                    core_api=self.core_api,
-                    namespace=self.namespace,
-                    pod_name=info.driver_pod_name,
-                    follow=follow,
-                )
+        try:
+            return common_utils.read_pod_logs(
+                core_api=self.core_api,
+                namespace=self.namespace,
+                pod_name=pod_name,
+                follow=follow,
+            )
 
-            except TimeoutError as e:
-                raise TimeoutError(
-                    f"Timeout to get logs for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
-                ) from e
+        except TimeoutError as e:
+            raise TimeoutError(
+                f"Timeout to get logs for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
+            ) from e
 
-            except RuntimeError as e:
-                raise RuntimeError(
-                    f"Failed to get logs for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
-                ) from e
-
-        return _stream()
+        except RuntimeError as e:
+            raise RuntimeError(
+                f"Failed to get logs for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
+            ) from e
 
     # ------------------------------------------------------------------
     # Spark batch jobs
@@ -1231,33 +1219,29 @@ class KubernetesBackend(RuntimeBackend):
         """
 
         job = self.get_job(name)
+        pod_name = job.driver_pod_name
 
-        if not job.driver_pod_name:
+        if not pod_name:
             raise RuntimeError(
                 f"No driver pod for {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{name}"
             )
 
-        def _stream() -> Iterator[str]:
-            try:
-                yield from read_pod_logs(
-                    core_api=self.core_api,
-                    namespace=self.namespace,
-                    pod_name=job.driver_pod_name,
-                    follow=follow,
-                )
-
-            except TimeoutError as e:
-                raise TimeoutError(
-                    f"Timeout to get logs for "
-                    f"{constants.SPARK_APPLICATION_KIND}: "
-                    f"{self.namespace}/{name}"
-                ) from e
-
-            except RuntimeError as e:
-                raise RuntimeError(
-                    f"Failed to get logs for "
-                    f"{constants.SPARK_APPLICATION_KIND}: "
-                    f"{self.namespace}/{name}"
-                ) from e
-
-        return _stream()
+        try:
+            return common_utils.read_pod_logs(
+                core_api=self.core_api,
+                namespace=self.namespace,
+                pod_name=pod_name,
+                follow=follow,
+            )
+        except TimeoutError as e:
+            raise TimeoutError(
+                f"Timeout to get logs for "
+                f"{constants.SPARK_APPLICATION_KIND}: "
+                f"{self.namespace}/{name}"
+            ) from e
+        except RuntimeError as e:
+            raise RuntimeError(
+                f"Failed to get logs for "
+                f"{constants.SPARK_APPLICATION_KIND}: "
+                f"{self.namespace}/{name}"
+            ) from e

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -637,7 +637,7 @@ def test_get_session_logs(kubernetes_backend, test_case):
         kubernetes_backend.get_session = Mock(return_value=Mock(driver_pod_name=pod_name))
 
         with patch(
-            "kubeflow.spark.backends.kubernetes.backend.read_pod_logs",
+            "kubeflow.spark.backends.kubernetes.backend.common_utils.read_pod_logs",
         ) as mock_read_pod_logs:
             if test_case.expected_status == SUCCESS:
                 mock_read_pod_logs.return_value = iter(
@@ -1871,7 +1871,7 @@ def test_get_job_logs(kubernetes_backend, test_case):
                 return_value=mock_job,
             ),
             patch(
-                "kubeflow.spark.backends.kubernetes.backend.read_pod_logs",
+                "kubeflow.spark.backends.kubernetes.backend.common_utils.read_pod_logs",
             ) as mock_read_pod_logs,
         ):
             if test_case.expected_status == SUCCESS:

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -14,22 +14,19 @@
 
 """Utility functions for Kubernetes Spark backend."""
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 import inspect
 import logging
 import math
-import multiprocessing
 import os
 import re
 import textwrap
 from typing import Any
 from urllib.parse import urlparse
-import uuid
 
 from kubeflow_spark_api import models
-from kubernetes import client
 
-from kubeflow.common import constants as common_constants
+from kubeflow.common import utils as common_utils
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.types.types import (
     Driver,
@@ -45,60 +42,6 @@ logger = logging.getLogger(__name__)
 # ----------------------------------------------------------------------
 # Shared utility functions
 # ----------------------------------------------------------------------
-
-
-def read_pod_logs(
-    core_api: client.CoreV1Api,
-    namespace: str,
-    pod_name: str,
-    follow: bool = False,
-) -> Iterator[str]:
-    """Read logs from a Kubernetes pod.
-
-    Args:
-        core_api: Kubernetes CoreV1Api client.
-        namespace: Kubernetes namespace.
-        pod_name: Name of the pod.
-        follow: Whether to stream logs continuously.
-
-    Yields:
-        Log lines from the pod.
-
-    Raises:
-        TimeoutError: If retrieving pod logs times out.
-        RuntimeError: If pod logs cannot be retrieved.
-    """
-    try:
-        if follow:
-            thread = core_api.read_namespaced_pod_log(
-                name=pod_name,
-                namespace=namespace,
-                follow=True,
-                _preload_content=False,
-                async_req=True,
-            )
-
-            resp = thread.get(common_constants.DEFAULT_TIMEOUT)
-
-            for line in resp.stream():
-                yield line.decode("utf-8").rstrip("\n")
-        else:
-            thread = core_api.read_namespaced_pod_log(
-                name=pod_name,
-                namespace=namespace,
-                async_req=True,
-            )
-
-            logs = thread.get(common_constants.DEFAULT_TIMEOUT)
-
-            for line in logs.split("\n"):
-                yield line
-
-    except multiprocessing.TimeoutError as e:
-        raise TimeoutError("Timeout while retrieving pod logs.") from e
-
-    except Exception as e:
-        raise RuntimeError("Failed to retrieve pod logs.") from e
 
 
 def _resolve_driver_resources(
@@ -298,13 +241,8 @@ def _validate_cpu_value(cpu: str | int | None) -> int:
 
 
 def generate_session_name() -> str:
-    """Generate a unique session name.
-
-    Returns:
-        Session name in format: spark-connect-{uuid}.
-    """
-    short_uuid = str(uuid.uuid4())[:8]
-    return f"{constants.SESSION_NAME_PREFIX}-{short_uuid}"
+    """Generate a unique session name."""
+    return common_utils.generate_random_name(prefix="spark-connect", length=8)
 
 
 def validate_spark_connect_url(url: str) -> bool:
@@ -557,13 +495,8 @@ def get_spark_connect_info_from_cr(
 
 
 def generate_job_name() -> str:
-    """Generate a unique batch job name.
-
-    Returns:
-        Job name in format: spark-job-{uuid}.
-    """
-    short_uuid = str(uuid.uuid4())[:8]
-    return f"{constants.JOB_NAME_PREFIX}-{short_uuid}"
+    """Generate a unique batch job name."""
+    return common_utils.generate_random_name(prefix="spark-job", length=8)
 
 
 def get_spark_job_driver_spec(

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -15,8 +15,7 @@
 """Unit tests for Kubernetes Spark backend utilities."""
 
 from datetime import datetime
-import multiprocessing
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from kubeflow_spark_api import models
 import pytest
@@ -39,7 +38,6 @@ from kubeflow.spark.backends.kubernetes.utils import (
     get_spark_connect_info_from_cr,
     get_spark_job_driver_spec,
     get_spark_job_executor_spec,
-    read_pod_logs,
     validate_spark_connect_url,
 )
 from kubeflow.spark.test.common import FAILED, SUCCESS, TestCase
@@ -913,113 +911,6 @@ def test_resolve_executor_resources(test_case: TestCase) -> None:
         assert instances == constants.DEFAULT_NUM_EXECUTORS
         assert cores == 2
         assert memory == "1536m"
-
-    print("test execution complete")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        TestCase(
-            name="read logs",
-            expected_status=SUCCESS,
-            config={
-                "follow": False,
-            },
-            expected_output=[
-                "log line 1",
-                "log line 2",
-            ],
-        ),
-        TestCase(
-            name="follow logs",
-            expected_status=SUCCESS,
-            config={
-                "follow": True,
-            },
-            expected_output=[
-                "log line 1",
-                "log line 2",
-            ],
-        ),
-        TestCase(
-            name="timeout",
-            expected_status=FAILED,
-            expected_error=TimeoutError,
-        ),
-        TestCase(
-            name="runtime error",
-            expected_status=FAILED,
-            expected_error=RuntimeError,
-        ),
-    ],
-)
-def test_read_pod_logs(test_case: TestCase) -> None:
-    """Tests read_pod_logs."""
-
-    print("Executing test:", test_case.name)
-
-    core_api = Mock()
-    thread = Mock()
-
-    if test_case.name == "read logs":
-        thread.get.return_value = "log line 1\nlog line 2"
-
-    elif test_case.name == "follow logs":
-        stream = Mock()
-        stream.stream.return_value = iter(
-            [
-                b"log line 1\n",
-                b"log line 2\n",
-            ]
-        )
-        thread.get.return_value = stream
-
-    elif test_case.name == "timeout":
-        thread.get.side_effect = multiprocessing.TimeoutError()
-
-    elif test_case.name == "runtime error":
-        thread.get.side_effect = RuntimeError()
-
-    core_api.read_namespaced_pod_log.return_value = thread
-
-    if test_case.expected_status == SUCCESS:
-        logs = list(
-            read_pod_logs(
-                core_api=core_api,
-                namespace="default",
-                pod_name="driver-pod",
-                follow=test_case.config["follow"],
-            )
-        )
-
-        assert logs == test_case.expected_output
-
-        if test_case.name == "read logs":
-            core_api.read_namespaced_pod_log.assert_called_once_with(
-                name="driver-pod",
-                namespace="default",
-                async_req=True,
-            )
-
-        elif test_case.name == "follow logs":
-            core_api.read_namespaced_pod_log.assert_called_once_with(
-                name="driver-pod",
-                namespace="default",
-                follow=True,
-                _preload_content=False,
-                async_req=True,
-            )
-
-    else:
-        with pytest.raises(test_case.expected_error):
-            list(
-                read_pod_logs(
-                    core_api=core_api,
-                    namespace="default",
-                    pod_name="driver-pod",
-                )
-            )
 
     print("test execution complete")
 

--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -42,11 +42,9 @@ import concurrent.futures
 from datetime import datetime
 import logging
 import os
-import random
 import shutil
-import string
-import uuid
 
+from kubeflow.common import utils as common_utils
 from kubeflow.trainer.backends.base import RuntimeBackend
 from kubeflow.trainer.backends.container import utils as container_utils
 from kubeflow.trainer.backends.container.adapters.base import (
@@ -282,9 +280,8 @@ class ContainerBackend(RuntimeBackend):
             raise ValueError(f"{self.__class__.__name__} supports only CustomTrainer in v1")
 
         # Generate train job name if not provided via options
-        trainjob_name = name or (
-            random.choice(string.ascii_lowercase)
-            + uuid.uuid4().hex[: constants.JOB_NAME_UUID_LENGTH]
+        trainjob_name = name or common_utils.generate_random_name(
+            length=constants.JOB_NAME_UUID_LENGTH
         )
 
         logger.debug(f"Starting training job: {trainjob_name}")

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -17,15 +17,12 @@ import copy
 import logging
 import multiprocessing
 import os
-import random
 import re
-import string
 import time
 from typing import Any
-import uuid
 
 from kubeflow_trainer_api import models
-from kubernetes import client, config, watch
+from kubernetes import client
 
 import kubeflow.common.constants as common_constants
 from kubeflow.common.types import KubernetesBackendConfig
@@ -40,16 +37,7 @@ logger = logging.getLogger(__name__)
 
 class KubernetesBackend(RuntimeBackend):
     def __init__(self, cfg: KubernetesBackendConfig):
-        if cfg.namespace is None:
-            cfg.namespace = common_utils.get_default_target_namespace(cfg.context)
-
-        # If client configuration is not set, use kube-config to access Kubernetes APIs.
-        if cfg.client_configuration is None:
-            # Load kube-config or in-cluster config.
-            if cfg.config_file or not common_utils.is_running_in_k8s():
-                config.load_kube_config(config_file=cfg.config_file, context=cfg.context)
-            else:
-                config.load_incluster_config()
+        common_utils.load_kube_config(cfg)
 
         k8s_client = client.ApiClient(cfg.client_configuration)
         self.custom_api = client.CustomObjectsApi(k8s_client)
@@ -325,9 +313,8 @@ class KubernetesBackend(RuntimeBackend):
             runtime_patches = spec_section.get("runtimePatches")
 
         # Generate unique name for the TrainJob if not provided
-        train_job_name = name or (
-            random.choice(string.ascii_lowercase)
-            + uuid.uuid4().hex[: constants.JOB_NAME_UUID_LENGTH]
+        train_job_name = name or common_utils.generate_random_name(
+            length=constants.JOB_NAME_UUID_LENGTH
         )
 
         # Build the TrainJob spec using the common _get_trainjob_spec method
@@ -460,8 +447,12 @@ class KubernetesBackend(RuntimeBackend):
 
         # Remove the number for the node step.
         container_name = re.sub(r"-\d+$", "", step)
-        yield from self._read_pod_logs(
-            pod_name=pod_name, container_name=container_name, follow=follow
+        yield from common_utils.read_pod_logs(
+            core_api=self.core_api,
+            pod_name=pod_name,
+            namespace=self.namespace,
+            container_name=container_name,
+            follow=follow,
         )
 
     def wait_for_job_status(
@@ -547,41 +538,14 @@ class KubernetesBackend(RuntimeBackend):
             if step.pod_name:
                 trainjob_resources.add(step.pod_name)
 
-        events = []
         try:
-            # Retrieve events from the namespace
-            event_response: models.IoK8sApiCoreV1EventList = self.core_api.list_namespaced_event(
+            return common_utils.get_job_events(
+                core_api=self.core_api,
                 namespace=self.namespace,
-                async_req=True,
-            ).get(common_constants.DEFAULT_TIMEOUT)
-
-            # Filter events related to this TrainJob or its pods
-            for event in event_response.items:
-                if not (event.metadata and event.involved_object and event.first_timestamp):
-                    continue
-
-                involved_object = event.involved_object
-
-                # Check if event is related to TrainJob resources
-                if (
-                    involved_object.kind in {constants.TRAINJOB_KIND, "JobSet", "Job", "Pod"}
-                    and involved_object.name in trainjob_resources
-                ):
-                    events.append(
-                        types.Event(
-                            involved_object_kind=involved_object.kind,
-                            involved_object_name=involved_object.name,
-                            message=event.message or "",
-                            reason=event.reason or "",
-                            event_time=event.first_timestamp,
-                        )
-                    )
-
-            # Sort events by first occurrence time
-            events.sort(key=lambda e: e.event_time)
-
-            return events
-        except multiprocessing.TimeoutError as e:
+                job_resources=trainjob_resources,
+                job_kinds={constants.TRAINJOB_KIND, "JobSet", "Job", "Pod"},
+            )
+        except TimeoutError as e:
             raise TimeoutError(
                 f"Timeout getting {constants.TRAINJOB_KIND} events: {self.namespace}/{name}"
             ) from e
@@ -622,34 +586,6 @@ class KubernetesBackend(RuntimeBackend):
                 runtime_cr.spec.ml_policy,
             ),
         )
-
-    def _read_pod_logs(self, pod_name: str, container_name: str, follow: bool) -> Iterator[str]:
-        """Read logs from a pod container."""
-        try:
-            if follow:
-                log_stream = watch.Watch().stream(
-                    self.core_api.read_namespaced_pod_log,
-                    name=pod_name,
-                    namespace=self.namespace,
-                    container=container_name,
-                    follow=True,
-                )
-
-                # Stream logs incrementally.
-                yield from log_stream  # type: ignore
-            else:
-                logs = self.core_api.read_namespaced_pod_log(
-                    name=pod_name,
-                    namespace=self.namespace,
-                    container=container_name,
-                )
-
-                yield from logs.splitlines()
-
-        except Exception as e:
-            raise RuntimeError(
-                f"Failed to read logs for the pod {self.namespace}/{pod_name}"
-            ) from e
 
     def __get_trainjob_from_cr(
         self,

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -502,10 +502,12 @@ def list_cluster_custom_object(*args, **kwargs):
 
 
 def mock_read_namespaced_pod_log(*args, **kwargs):
-    """Simulate log retrieval from a pod."""
+    """Simulate async log retrieval from a pod."""
     if kwargs.get("namespace") == FAIL_LOGS:
         raise Exception("Failed to read logs")
-    return "test log content"
+    mock_thread = Mock()
+    mock_thread.get.return_value = "test log content"
+    return mock_thread
 
 
 def mock_list_namespaced_event(*args, **kwargs):

--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -14,12 +14,10 @@
 from collections.abc import Callable, Iterator
 from datetime import datetime
 import logging
-import random
-import string
 import tempfile
 import time
-import uuid
 
+from kubeflow.common import utils as common_utils
 from kubeflow.trainer.backends.base import RuntimeBackend
 from kubeflow.trainer.backends.localprocess import utils as local_utils
 from kubeflow.trainer.backends.localprocess.constants import local_runtimes
@@ -94,9 +92,8 @@ class LocalProcessBackend(RuntimeBackend):
             name = metadata_section.get("name")
 
         # Generate train job name if not provided via options
-        trainjob_name = name or (
-            random.choice(string.ascii_lowercase)
-            + uuid.uuid4().hex[: constants.JOB_NAME_UUID_LENGTH]
+        trainjob_name = name or common_utils.generate_random_name(
+            length=constants.JOB_NAME_UUID_LENGTH
         )
 
         # localprocess backend only supports CustomTrainer

--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -20,6 +20,7 @@ from enum import Enum
 from urllib.parse import urlparse
 
 import kubeflow.common.constants as common_constants
+from kubeflow.common.types import Event  # noqa: F401
 from kubeflow.trainer.constants import constants
 
 
@@ -298,28 +299,6 @@ class TrainJob:
     num_nodes: int
     creation_timestamp: datetime
     status: str = common_constants.UNKNOWN
-
-
-# Representation for TrainJob events.
-@dataclass
-class Event:
-    """Event object that represents a Kubernetes event related to a TrainJob.
-
-    Args:
-        involved_object_kind (`str`): The kind of object this event is about
-            (e.g., 'TrainJob', 'Pod').
-        involved_object_name (`str`): The name of the object this event is about.
-        message (`str`): Human-readable description of the event.
-        reason (`str`): Short, machine understandable string describing why
-            this event was generated.
-        event_time (`datetime`): The time at which the event was first recorded.
-    """
-
-    involved_object_kind: str
-    involved_object_name: str
-    message: str
-    reason: str
-    event_time: datetime
 
 
 @dataclass


### PR DESCRIPTION
# What this PR does / why we need it

Implements **KEP-107** by moving shared job-submission utilities used by the **Trainer, Optimizer, and Spark** clients into `kubeflow.common`.

## Changes

* Adds shared Kubernetes utilities for:

  * Job event retrieval
  * Pod log retrieval
  * Random name generation
* Adds a shared `Event` dataclass to `kubeflow.common.types`.
* Refactors Trainer, Optimizer, and Spark backends to use the common utilities.
* Re-exports `Event` through Trainer types for compatibility.
* Removes duplicated utility implementations and redundant tests.
* Adds unit tests covering shared utilities, timeout handling, and pod log streaming.

This reduces duplication across the three clients and improves long-term maintainability and consistency.

## Testing

* `make test-python` — **642 tests passed**
* `make verify` — **All checks passed**

## Which issue(s) this PR fixes

Fixes #608

## Checklist

* [ ] [[Docs](https://www.kubeflow.org/docs/)](https://www.kubeflow.org/docs/) included if any changes are user facing