### PR TITLE
fix(trainer): raise RuntimeError for failed TrainJobs

### DIFF
--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -248,6 +248,11 @@ class LocalProcessBackend(RuntimeBackend):
             # Return if job has reached desired status
             if trainjob.status in status:
                 return trainjob
+            if (
+                constants.TRAINJOB_FAILED not in status
+                and trainjob.status == constants.TRAINJOB_FAILED
+            ):
+                raise RuntimeError(f"TrainJob {name} is Failed")
 
             time.sleep(polling_interval)
 

--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -574,3 +574,23 @@ def test_get_job_status(local_backend, test_case):
 
     status = local_backend._LocalProcessBackend__get_job_status(job)
     assert status == test_case.expected_output
+
+
+def test_wait_for_job_status_raises_on_failed_job(local_backend, monkeypatch):
+    """wait_for_job_status should immediately raise RuntimeError when job fails."""
+
+    trainjob = Mock()
+    trainjob.status = constants.TRAINJOB_FAILED
+
+    job = Mock()
+    job.name = "failed-job"
+    local_backend._LocalProcessBackend__local_jobs.append(job)
+
+    monkeypatch.setattr(local_backend, "get_job", lambda name: trainjob)
+
+    with pytest.raises(RuntimeError, match="TrainJob failed-job is Failed"):
+        local_backend.wait_for_job_status(
+            name="failed-job",
+            timeout=2,
+            polling_interval=1,
+        )


### PR DESCRIPTION
PR Description
**What this PR does / why we need it**:

This PR updates `LocalProcessBackend.wait_for_job_status()` to immediately raise a `RuntimeError` when a TrainJob enters the `Failed` state, unless `TRAINJOB_FAILED` is explicitly included in the expected status set.

Previously, `LocalProcessBackend.wait_for_job_status()` continued polling until the timeout even after the TrainJob had already failed. This behavior was inconsistent with the Container and Kubernetes backends, which already raise a `RuntimeError` as soon as an unexpected failed status is observed.

This change aligns the LocalProcessBackend behavior with the other backends and avoids unnecessary waiting after a job has already failed.

In addition to the implementation change, this PR includes a regression test to verify that `wait_for_job_status()` raises a `RuntimeError` immediately when a TrainJob reaches the `Failed` state unexpectedly.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<662>` format, will close the issue(s) when PR gets merged)_:

Fixes #<Fixes #662>

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing

### Testing


python -m pytest kubeflow/trainer/backends/localprocess/backend_test.py


Output:

============================= 28 passed =============================
