### PR TITLE
fix(spark): add default service account fallback for Spark Connect

### DIFF
--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -357,15 +357,19 @@ def get_spark_connect_driver_spec(
     """
     cores, memory = _resolve_driver_resources(driver)
 
-    template = None
-
-    if driver and driver.service_account:
-        template = models.IoK8sApiCoreV1PodTemplateSpec(
-            spec=models.IoK8sApiCoreV1PodSpec(
-                containers=[],
-                service_account_name=driver.service_account,
-            )
+    # Fallback to the default service account if not specified.
+    # TODO: Remove this temporary workaround once issue #617 lands.
+    service_account_name = (
+        driver.service_account
+        if driver and driver.service_account
+        else constants.DEFAULT_SERVICE_ACCOUNT
+    )
+    template = models.IoK8sApiCoreV1PodTemplateSpec(
+        spec=models.IoK8sApiCoreV1PodSpec(
+            containers=[],
+            service_account_name=service_account_name,
         )
+    )
 
     return models.SparkV1alpha1ServerSpec(
         cores=cores,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This change introduces a fallback to the `spark-operator-spark` default service account when `driver.service_account` is not explicitly specified in the Spark Connect API.

This simplifies basic SDK use cases on the default operator installation, where manual specification of a service account on the API becomes cumbersome for end users.

*Note: This is a temporary workaround. A `TODO` comment has been added to the code to ensure this fallback logic is cleanly removed once issue #617 is fully resolved.*

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Relates to #617 (Temporary workaround)

**Checklist:**

- [x] Ran `make verify` locally to ensure code quality, formatting compliance, and no linting errors.
- [x] Ran `make test-python` locally to ensure unit tests pass.
- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing _(Not applicable for this internal fallback logic)_.