### PR TITLE
fix(spark): add default service account fallback for Spark Connect

### DIFF
--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -357,7 +357,7 @@ def get_spark_connect_driver_spec(
     """
     cores, memory = _resolve_driver_resources(driver)
 
-    # Fallback to the default service account if not specified.
+    # Fallback to the the spark-operator chart's default service account if not specified.
     # TODO: Remove this temporary workaround once issue #617 lands.
     service_account_name = (
         driver.service_account

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -357,7 +357,7 @@ def get_spark_connect_driver_spec(
     """
     cores, memory = _resolve_driver_resources(driver)
 
-    # Fallback to the the spark-operator chart's default service account if not specified.
+    # Fallback to the spark-operator chart's default service account if not specified.
     # TODO: Remove this temporary workaround once issue #617 lands.
     service_account_name = (
         driver.service_account

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -357,15 +357,19 @@ def get_spark_connect_driver_spec(
     """
     cores, memory = _resolve_driver_resources(driver)
 
-    template = None
-
-    if driver and driver.service_account:
-        template = models.IoK8sApiCoreV1PodTemplateSpec(
-            spec=models.IoK8sApiCoreV1PodSpec(
-                containers=[],
-                service_account_name=driver.service_account,
-            )
+    # Fallback to the default service account if not specified.
+    # TODO: Remove this temporary workaround once issue #617 lands.
+    service_account_name = (
+        driver.service_account
+        if driver and driver.service_account
+        else constants.DEFAULT_SERVICE_ACCOUNT
+    )
+    template = models.IoK8sApiCoreV1PodTemplateSpec(
+        spec=models.IoK8sApiCoreV1PodSpec(
+            containers=[],
+            service_account_name=service_account_name,
         )
+    )
 
     return models.SparkV1alpha1ServerSpec(
         cores=cores,

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -315,6 +315,17 @@ def test_build_service_url(test_case: TestCase) -> None:
             },
         ),
         TestCase(
+            name="driver with service account and default resources",
+            config={
+                "driver": Driver(service_account="custom-spark-sa"),
+                "expected_cores": constants.DEFAULT_DRIVER_CPU,
+                "expected_memory": _memory_kubernetes_to_spark(
+                    constants.DEFAULT_DRIVER_MEMORY,
+                ),
+                "expected_service_account": "custom-spark-sa",
+            },
+        ),
+        TestCase(
             name="driver with resources and service account",
             config={
                 "driver": Driver(

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -36,6 +36,7 @@ from kubeflow.spark.backends.kubernetes.utils import (
     get_spark_application_cr_from_file_job,
     get_spark_application_cr_from_func_job,
     get_spark_application_info_from_cr,
+    get_spark_connect_driver_spec,
     get_spark_connect_info_from_cr,
     get_spark_job_driver_spec,
     get_spark_job_executor_spec,
@@ -286,6 +287,54 @@ def test_build_service_url(test_case: TestCase) -> None:
         assert test_case.expected_output in url
 
     print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="default driver configuration",
+            config={
+                "driver": None,
+                "expected_cores": constants.DEFAULT_DRIVER_CPU,
+                "expected_memory": _memory_kubernetes_to_spark(
+                    constants.DEFAULT_DRIVER_MEMORY,
+                ),
+                "expected_service_account": constants.DEFAULT_SERVICE_ACCOUNT,
+            },
+        ),
+        TestCase(
+            name="driver without service account",
+            config={
+                "driver": Driver(),
+                "expected_cores": constants.DEFAULT_DRIVER_CPU,
+                "expected_memory": _memory_kubernetes_to_spark(
+                    constants.DEFAULT_DRIVER_MEMORY,
+                ),
+                "expected_service_account": constants.DEFAULT_SERVICE_ACCOUNT,
+            },
+        ),
+        TestCase(
+            name="driver with resources and service account",
+            config={
+                "driver": Driver(
+                    resources={"cpu": "2", "memory": "4Gi"},
+                    service_account="custom-spark-sa",
+                ),
+                "expected_cores": 2,
+                "expected_memory": "4g",
+                "expected_service_account": "custom-spark-sa",
+            },
+        ),
+    ],
+)
+def test_get_spark_connect_driver_spec(test_case: TestCase) -> None:
+    """Tests get_spark_connect_driver_spec."""
+    spec = get_spark_connect_driver_spec(test_case.config["driver"])
+
+    assert spec.cores == test_case.config["expected_cores"]
+    assert spec.memory == test_case.config["expected_memory"]
+    assert spec.template.spec.service_account_name == test_case.config["expected_service_account"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This change introduces a fallback to the `spark-operator-spark` default service account when `driver.service_account` is not explicitly specified in the Spark Connect API.

This simplifies basic SDK use cases on the default operator installation, where manual specification of a service account on the API becomes cumbersome for end users.

*Note: This is a temporary workaround and is meant to be removed once #617 lands.*

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #668

**Checklist:**

- [x] Ran `make verify` locally to ensure code quality, formatting compliance, and no linting errors.
- [x] Ran `make test-python` locally to ensure unit tests pass.
- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing _(Not applicable for this internal fallback logic)_.