### PR TITLE
fix(hub): update type ignore comments for ty syntax

### DIFF
--- a/kubeflow/hub/api/model_registry_client.py
+++ b/kubeflow/hub/api/model_registry_client.py
@@ -91,7 +91,7 @@ class ModelRegistryClient:
         self._registry = ModelRegistry(
             server_address=base_url,
             port=port,
-            author=author,  # type: ignore[arg-type]
+            author=author,  # ty: ignore[invalid-argument-type]
             is_secure=is_secure,
             user_token=user_token,
             custom_ca=custom_ca,
@@ -147,8 +147,8 @@ class ModelRegistryClient:
         return self._registry.register_model(
             name=name,
             uri=uri,
-            model_format_name=model_format_name,  # type: ignore[arg-type]
-            model_format_version=model_format_version,  # type: ignore[arg-type]
+            model_format_name=model_format_name,  # ty: ignore[invalid-argument-type]
+            model_format_version=model_format_version,  # ty: ignore[invalid-argument-type]
             version=version,
             author=author,
             owner=owner,

--- a/kubeflow/hub/storage_test.py
+++ b/kubeflow/hub/storage_test.py
@@ -52,16 +52,16 @@ def test_upload_artifact_delegates_to_oci(monkeypatch):
 def test_upload_artifact_raises_type_error_for_unknown_upload_params():
     """Test upload_artifact rejects unsupported upload parameter types."""
     with pytest.raises(TypeError, match="upload_params must be"):
-        upload_artifact("/tmp/model", upload_params=object())  # type: ignore[arg-type]
+        upload_artifact("/tmp/model", upload_params=object())  # ty: ignore[invalid-argument-type]
 
 
 def test_s3_upload_params_requires_bucket_name():
     """Test S3UploadParams validates required fields."""
     with pytest.raises(ValidationError):
-        S3UploadParams(s3_prefix="prefix")  # type: ignore[call-arg]
+        S3UploadParams(s3_prefix="prefix")  # ty: ignore[missing-argument]
 
 
 def test_oci_upload_params_requires_base_image_and_oci_ref():
     """Test OCIUploadParams validates required fields."""
     with pytest.raises(ValidationError):
-        OCIUploadParams()  # type: ignore[call-arg]
+        OCIUploadParams()  # ty: ignore[missing-argument]


### PR DESCRIPTION
**What this PR does / why we need it**:

Update type ignore comments from mypy-style (type: ignore[arg-type])
to ty-style (ty: ignore[invalid-argument-type]). This ensures consistency
with the project's type checking toolchain.

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
