### PR TITLE
feat(spark): add DynamicAllocation support for Spark resources

### DIFF
--- a/kubeflow/spark/__init__.py
+++ b/kubeflow/spark/__init__.py
@@ -18,6 +18,7 @@ from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.api.spark_client import SparkClient
 from kubeflow.spark.options import (
     Annotations,
+    DynamicAllocation,
     Labels,
     Name,
     NodeSelector,
@@ -49,6 +50,7 @@ __all__ = [
     "SparkJobStatus",
     # Options (KEP-107 extensibility pattern - callable pattern like trainer SDK)
     "Annotations",
+    "DynamicAllocation",
     "Labels",
     "Name",
     "NodeSelector",

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -16,7 +16,7 @@
 
 from datetime import datetime
 import multiprocessing
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from kubeflow_spark_api import models
 import pytest
@@ -45,7 +45,7 @@ from kubeflow.spark.backends.kubernetes.utils import (
     read_pod_logs,
     validate_spark_connect_url,
 )
-from kubeflow.spark.options import Labels
+from kubeflow.spark.options import DynamicAllocation, Labels
 from kubeflow.spark.test.common import FAILED, SUCCESS, TestCase
 from kubeflow.spark.types.types import (
     Driver,
@@ -727,6 +727,122 @@ def test_build_spark_connect_cr(test_case: TestCase, mock_k8s_backend) -> None:
 
     elif test_case.name == "spark connect cr with options":
         assert spark_connect.metadata.labels["team"] == "ml"
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="dynamic allocation enabled with defaults",
+            expected_status=SUCCESS,
+            config={
+                "options": [DynamicAllocation(enabled=True)],
+            },
+        ),
+        TestCase(
+            name="dynamic allocation disabled",
+            expected_status=SUCCESS,
+            config={
+                "options": [DynamicAllocation(enabled=False)],
+            },
+        ),
+        TestCase(
+            name="dynamic allocation with min/max executors",
+            expected_status=SUCCESS,
+            config={
+                "options": [
+                    DynamicAllocation(
+                        enabled=True,
+                        min_executors=1,
+                        max_executors=20,
+                    )
+                ],
+            },
+        ),
+        TestCase(
+            name="dynamic allocation with all fields",
+            expected_status=SUCCESS,
+            config={
+                "options": [
+                    DynamicAllocation(
+                        enabled=True,
+                        initial_executors=2,
+                        min_executors=1,
+                        max_executors=50,
+                        shuffle_tracking_enabled=True,
+                        shuffle_tracking_timeout=60000,
+                    )
+                ],
+            },
+        ),
+        TestCase(
+            name="dynamic allocation overrides num_executors",
+            expected_status=SUCCESS,
+            config={
+                "num_executors": 5,
+                "options": [DynamicAllocation(enabled=True)],
+            },
+        ),
+        TestCase(
+            name="dynamic allocation disabled preserves num_executors",
+            expected_status=SUCCESS,
+            config={
+                "num_executors": 5,
+                "options": [DynamicAllocation(enabled=False)],
+            },
+        ),
+    ],
+)
+def test_build_spark_connect_cr_dynamic_allocation(test_case: TestCase) -> None:
+    """Tests build_spark_connect_cr with dynamic allocation."""
+    print("Executing test:", test_case.name)
+
+    backend = MagicMock()
+    backend.__class__ = KubernetesBackend
+
+    spark_connect = build_spark_connect_cr(
+        name="test-session",
+        namespace="default",
+        backend=backend,
+        **test_case.config,
+    )
+
+    assert test_case.expected_status == SUCCESS
+
+    if test_case.name == "dynamic allocation enabled with defaults":
+        assert spark_connect.spec.dynamic_allocation is not None
+        assert spark_connect.spec.dynamic_allocation.enabled is True
+        assert spark_connect.spec.executor.instances is None
+
+    elif test_case.name == "dynamic allocation disabled":
+        assert spark_connect.spec.dynamic_allocation is not None
+        assert spark_connect.spec.dynamic_allocation.enabled is False
+        assert spark_connect.spec.executor.instances == constants.DEFAULT_NUM_EXECUTORS
+
+    elif test_case.name == "dynamic allocation with min/max executors":
+        assert spark_connect.spec.dynamic_allocation.enabled is True
+        assert spark_connect.spec.dynamic_allocation.min_executors == 1
+        assert spark_connect.spec.dynamic_allocation.max_executors == 20
+        assert spark_connect.spec.executor.instances is None
+
+    elif test_case.name == "dynamic allocation with all fields":
+        assert spark_connect.spec.dynamic_allocation.enabled is True
+        assert spark_connect.spec.dynamic_allocation.initial_executors == 2
+        assert spark_connect.spec.dynamic_allocation.min_executors == 1
+        assert spark_connect.spec.dynamic_allocation.max_executors == 50
+        assert spark_connect.spec.dynamic_allocation.shuffle_tracking_enabled is True
+        assert spark_connect.spec.dynamic_allocation.shuffle_tracking_timeout == 60000
+        assert spark_connect.spec.executor.instances is None
+
+    elif test_case.name == "dynamic allocation overrides num_executors":
+        assert spark_connect.spec.dynamic_allocation.enabled is True
+        assert spark_connect.spec.executor.instances is None
+
+    elif test_case.name == "dynamic allocation disabled preserves num_executors":
+        assert spark_connect.spec.dynamic_allocation.enabled is False
+        assert spark_connect.spec.executor.instances == 5
 
     print("test execution complete")
 
@@ -1468,6 +1584,23 @@ def test_get_spark_job_executor_spec(test_case: TestCase) -> None:
                 ],
             },
         ),
+        TestCase(
+            name="build spark application with dynamic allocation",
+            expected_status=SUCCESS,
+            config={
+                "name": "test-job",
+                "namespace": "default",
+                "main_file": "s3://bucket/job.py",
+                "num_executors": 3,
+                "options": [
+                    DynamicAllocation(
+                        enabled=True,
+                        min_executors=1,
+                        max_executors=20,
+                    ),
+                ],
+            },
+        ),
     ],
 )
 def test_get_spark_application_cr_from_file_job(test_case: TestCase, mock_k8s_backend) -> None:
@@ -1512,6 +1645,13 @@ def test_get_spark_application_cr_from_file_job(test_case: TestCase, mock_k8s_ba
 
     elif test_case.name == "file job with spark conf":
         assert app.spec.spark_conf == test_case.config["spark_conf"]
+
+    elif test_case.name == "build spark application with dynamic allocation":
+        assert app.spec.dynamic_allocation is not None
+        assert app.spec.dynamic_allocation.enabled is True
+        assert app.spec.dynamic_allocation.min_executors == 1
+        assert app.spec.dynamic_allocation.max_executors == 20
+        assert app.spec.executor.instances is None
 
     print("test execution complete")
 

--- a/kubeflow/spark/options/__init__.py
+++ b/kubeflow/spark/options/__init__.py
@@ -16,6 +16,7 @@
 
 from kubeflow.spark.options.kubernetes import (
     Annotations,
+    DynamicAllocation,
     Labels,
     Name,
     NodeSelector,
@@ -25,6 +26,7 @@ from kubeflow.spark.options.kubernetes import (
 
 __all__ = [
     "Annotations",
+    "DynamicAllocation",
     "Labels",
     "Name",
     "NodeSelector",

--- a/kubeflow/spark/options/kubernetes.py
+++ b/kubeflow/spark/options/kubernetes.py
@@ -402,6 +402,98 @@ class Toleration:
 
 
 @dataclass
+class DynamicAllocation:
+    """Enable dynamic allocation for Spark executors.
+
+    When enabled, Spark dynamically scales the number of executors based on
+    workload demand rather than using a fixed executor count. The fixed executor
+    count (`.spec.executor.instances`) is omitted so the Spark operator manages
+    executor scaling.
+
+    Supported resources:
+        - Spark Connect
+        - Spark Application
+
+    Supported backends:
+        - Kubernetes
+
+    Args:
+        enabled: Whether dynamic allocation is enabled.
+        initial_executors: Initial number of executors to allocate.
+        min_executors: Minimum number of executors to maintain.
+        max_executors: Maximum number of executors to allocate.
+        shuffle_tracking_enabled: Whether to use shuffle tracking for executor
+            liveness instead of requiring a separate shuffle service.
+        shuffle_tracking_timeout: Timeout in milliseconds for shuffle tracking.
+            Executors idle beyond this timeout may be removed.
+
+    Example:
+        options = [
+            DynamicAllocation(
+                enabled=True,
+                min_executors=1,
+                max_executors=20,
+            )
+        ]
+        spark = client.connect(..., options=options)
+    """
+
+    enabled: bool = True
+    initial_executors: int | None = None
+    min_executors: int | None = None
+    max_executors: int | None = None
+    shuffle_tracking_enabled: bool | None = None
+    shuffle_tracking_timeout: int | None = None
+
+    def __call__(self, resource: SparkResource, backend: RuntimeBackend) -> None:
+        """Apply dynamic allocation to the Spark resource.
+
+        Args:
+            resource: Spark resource to modify.
+            backend: Backend instance for validation.
+
+        Raises:
+            ValueError: If backend does not support dynamic allocation.
+
+            TypeError: If the resource is not a supported Spark resource.
+        """
+        from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"DynamicAllocation option is not compatible with {type(backend).__name__}. "
+                f"Supported backends: KubernetesBackend"
+            )
+
+        if isinstance(resource, models.SparkV1alpha1SparkConnect):
+            resource.spec.dynamic_allocation = models.SparkV1alpha1DynamicAllocation(
+                enabled=self.enabled,
+                initial_executors=self.initial_executors,
+                min_executors=self.min_executors,
+                max_executors=self.max_executors,
+                shuffle_tracking_enabled=self.shuffle_tracking_enabled,
+                shuffle_tracking_timeout=self.shuffle_tracking_timeout,
+            )
+            executor_spec = resource.spec.executor
+        elif isinstance(resource, models.SparkV1beta2SparkApplication):
+            resource.spec.dynamic_allocation = models.SparkV1beta2DynamicAllocation(
+                enabled=self.enabled,
+                initial_executors=self.initial_executors,
+                min_executors=self.min_executors,
+                max_executors=self.max_executors,
+                shuffle_tracking_enabled=self.shuffle_tracking_enabled,
+                shuffle_tracking_timeout=self.shuffle_tracking_timeout,
+            )
+            executor_spec = resource.spec.executor
+        else:
+            raise TypeError(f"Unsupported Spark resource type: {type(resource).__name__}")
+
+        # Dynamic allocation manages executor counts, so omit a fixed instance count
+        if self.enabled:
+            executor_spec.instances = None
+
+
+@dataclass
 class Name:
     """Set a custom name for the Spark resource.
 

--- a/kubeflow/spark/options/kubernetes_test.py
+++ b/kubeflow/spark/options/kubernetes_test.py
@@ -23,6 +23,7 @@ from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
 from kubeflow.spark.options import (
     Annotations,
+    DynamicAllocation,
     Labels,
     Name,
     NodeSelector,
@@ -824,5 +825,142 @@ def test_name_option_incompatible_backend(
             match=test_case.expected_output,
         ):
             option(resource, mock_non_k8s_backend)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="dynamic allocation enabled with defaults",
+            expected_status=SUCCESS,
+            config={
+                "enabled": True,
+            },
+        ),
+        TestCase(
+            name="dynamic allocation disabled",
+            expected_status=SUCCESS,
+            config={
+                "enabled": False,
+            },
+        ),
+        TestCase(
+            name="dynamic allocation with all fields",
+            expected_status=SUCCESS,
+            config={
+                "enabled": True,
+                "initial_executors": 2,
+                "min_executors": 1,
+                "max_executors": 50,
+                "shuffle_tracking_enabled": True,
+                "shuffle_tracking_timeout": 60000,
+            },
+        ),
+    ],
+)
+def test_dynamic_allocation_apply(
+    test_case: TestCase,
+    mock_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test DynamicAllocation option for Spark Connect and Spark Application."""
+
+    print("Executing test:", test_case.name)
+
+    option = DynamicAllocation(**test_case.config)
+
+    for resource in [spark_connect_model, spark_application_model]:
+        resource.spec.executor.instances = 2
+
+        option(resource, mock_k8s_backend)
+
+        assert resource.spec.dynamic_allocation is not None
+        assert resource.spec.dynamic_allocation.enabled == test_case.config["enabled"]
+        assert resource.spec.dynamic_allocation.initial_executors == test_case.config.get(
+            "initial_executors"
+        )
+        assert resource.spec.dynamic_allocation.min_executors == test_case.config.get(
+            "min_executors"
+        )
+        assert resource.spec.dynamic_allocation.max_executors == test_case.config.get(
+            "max_executors"
+        )
+        assert resource.spec.dynamic_allocation.shuffle_tracking_enabled == test_case.config.get(
+            "shuffle_tracking_enabled"
+        )
+        assert resource.spec.dynamic_allocation.shuffle_tracking_timeout == test_case.config.get(
+            "shuffle_tracking_timeout"
+        )
+
+        if test_case.config["enabled"]:
+            assert resource.spec.executor.instances is None
+        else:
+            assert resource.spec.executor.instances == 2
+
+    assert test_case.expected_status == SUCCESS
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="dynamic allocation defaults",
+            expected_status=SUCCESS,
+        ),
+    ],
+)
+def test_dynamic_allocation_defaults(test_case: TestCase):
+    """Test DynamicAllocation option defaults."""
+
+    print("Executing test:", test_case.name)
+
+    option = DynamicAllocation()
+
+    assert option.enabled is True
+    assert option.initial_executors is None
+    assert option.min_executors is None
+    assert option.max_executors is None
+    assert option.shuffle_tracking_enabled is None
+    assert option.shuffle_tracking_timeout is None
+
+    assert test_case.expected_status == SUCCESS
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="incompatible backend",
+            expected_status=FAILED,
+            expected_error=ValueError,
+            expected_output="not compatible",
+        ),
+    ],
+)
+def test_dynamic_allocation_incompatible_backend(
+    test_case: TestCase,
+    mock_non_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test DynamicAllocation option with incompatible backend."""
+
+    print("Executing test:", test_case.name)
+
+    option = DynamicAllocation()
+
+    for resource in [spark_connect_model, spark_application_model]:
+        with pytest.raises(
+            test_case.expected_error,
+            match=test_case.expected_output,
+        ):
+            option(resource, mock_non_k8s_backend)
+
+    print("test execution complete")
 
     print("test execution complete")


### PR DESCRIPTION
## Description

Adds a `DynamicAllocation` dataclass to `kubeflow.spark.types` that allows users to configure dynamic executor scaling for SparkConnect sessions.

## Changes

- Add `DynamicAllocation` dataclass with fields: `enabled`, `initial_executors`, `min_executors`, `max_executors`, `shuffle_tracking_enabled`, `shuffle_tracking_timeout`
- Expose `dynamic_allocation` as a first-class parameter on `SparkClient.connect()`
- Thread `dynamic_allocation` through `KubernetesBackend` to `build_spark_connect_cr`
- When `dynamic_allocation.enabled=True`, `executor.instances` is omitted from the CR to let the Spark operator manage executor counts dynamically
- Add unit tests for `DynamicAllocation` creation and CR building

## Usage Example

```python
from kubeflow.spark import SparkClient, DynamicAllocation

client = SparkClient()
session = client.connect(
    dynamic_allocation=DynamicAllocation(
        enabled=True,
        initial_executors=2,
        min_executors=1,
        max_executors=20,
        shuffle_tracking_enabled=True,
    )
)
```

Closes #489
