### PR TITLE
feat(spark): add context manager support to TrainerClient and SparkClient

### DIFF
--- a/kubeflow/spark/api/spark_client.py
+++ b/kubeflow/spark/api/spark_client.py
@@ -55,6 +55,26 @@ class SparkClient:
         else:
             raise ValueError(f"Invalid backend config: {type(backend_config)}")
 
+    def close(self) -> None:
+        """Release resources owned by the client."""
+        close = getattr(self.backend, "close", None)
+        if callable(close):
+            close()
+
+    def __enter__(self) -> "SparkClient":
+        """Enter the runtime context."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type,
+        exc_value,
+        exc_tb,
+    ) -> bool:
+        """Exit the runtime context."""
+        self.close()
+        return False
+
     # ------------------------------------------------------------------
     # Spark Connect sessions
     # ------------------------------------------------------------------

--- a/kubeflow/spark/api/spark_client_test.py
+++ b/kubeflow/spark/api/spark_client_test.py
@@ -171,3 +171,15 @@ def test_submit_job_success(job):
             num_executors=None,
             resources_per_executor=None,
         )
+
+
+def test_context_manager():
+    """Test SparkClient context manager support."""
+    with (
+        patch.object(SparkClient, "close") as mock_close,
+        patch("kubeflow.spark.api.spark_client.KubernetesBackend"),
+        SparkClient() as client,
+    ):
+        assert isinstance(client, SparkClient)
+
+    mock_close.assert_called_once()

--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -63,6 +63,21 @@ class TrainerClient:
         else:
             raise ValueError(f"Invalid backend config '{backend_config}'")
 
+    def close(self) -> None:
+        """Release resources owned by the client."""
+        close = getattr(self.backend, "close", None)
+        if callable(close):
+            close()
+
+    def __enter__(self) -> "TrainerClient":
+        """Enter the runtime context."""
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb) -> bool:
+        """Exit the runtime context."""
+        self.close()
+        return False
+
     def list_runtimes(self) -> list[types.Runtime]:
         """List of the available runtimes, preferring namespaced over cluster-scoped for duplicates.
 

--- a/kubeflow/trainer/api/trainer_client_test.py
+++ b/kubeflow/trainer/api/trainer_client_test.py
@@ -70,3 +70,17 @@ def test_backend_selection(test_case):
         client = TrainerClient(backend_config=test_case["backend_config"])
         backend_name = client.backend.__class__.__name__
         assert backend_name == test_case["expected_backend"]
+
+
+def test_context_manager():
+    """Test TrainerClient context manager support."""
+    with (
+        patch.object(TrainerClient, "close") as mock_close,
+        patch("kubernetes.config.load_kube_config"),
+        patch("kubernetes.client.CustomObjectsApi"),
+        patch("kubernetes.client.CoreV1Api"),
+        TrainerClient() as client,
+    ):
+        assert isinstance(client, TrainerClient)
+
+    mock_close.assert_called_once()


### PR DESCRIPTION
This PR adds context manager support (`__enter__` / `__exit__`) to both `TrainerClient` and `SparkClient`.

### Changes
- Add `__enter__()` to return the client instance.
- Add `__exit__()` to invoke `close()` when exiting the context.
- Add a `close()` lifecycle hook that delegates cleanup to the backend if it exposes a `close()` method.
- Add unit tests verifying that:
  - the clients can be used with a `with` statement.
  - `close()` is invoked when exiting the context manager.

This enables a more Pythonic API and provides a consistent client lifecycle pattern for future resource management.

Fixes #669

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
