### PR TITLE
feat(pipelines): add trigger_pipeline native component for triggering child runs

### DIFF
--- a/kubeflow/pipelines/__init__.py
+++ b/kubeflow/pipelines/__init__.py
@@ -47,13 +47,15 @@ __all__ = [
     "KubernetesBackendConfig",
     # Constants
     "constants",
+    # Built-in components
+    "trigger_pipeline",
 ]
 
 _KFP_INSTALL_MSG = (
     "kfp is required for kubeflow.pipelines. Install it with: pip install 'kubeflow[pipelines]'"
 )
 
-_DSL_MODULES = {"compiler", "components", "dsl", "kubernetes"}
+_DSL_MODULES = {"compiler", "components", "kubernetes"}
 
 _KFP_ATTRS = {
     "Experiment",
@@ -75,6 +77,20 @@ def __getattr__(name: str):
             from kubeflow.pipelines.api.pipelines_client import PipelinesClient
 
             return PipelinesClient
+        except ImportError as e:
+            raise ImportError(_KFP_INSTALL_MSG) from e
+
+    if name == "dsl":
+        try:
+            return importlib.import_module("kubeflow.pipelines.dsl")
+        except ImportError as e:
+            raise ImportError(_KFP_INSTALL_MSG) from e
+
+    if name == "trigger_pipeline":
+        try:
+            from kubeflow.pipelines.trigger import trigger_pipeline
+
+            return trigger_pipeline
         except ImportError as e:
             raise ImportError(_KFP_INSTALL_MSG) from e
 

--- a/kubeflow/pipelines/api/pipelines_client_test.py
+++ b/kubeflow/pipelines/api/pipelines_client_test.py
@@ -76,7 +76,7 @@ class TestPipelinesClientReExport:
 class TestDslReExports:
     """Test that KFP DSL modules are re-exported at kubeflow.pipelines level."""
 
-    @pytest.mark.parametrize("module_name", ["dsl", "compiler", "components", "kubernetes"])
+    @pytest.mark.parametrize("module_name", ["compiler", "components", "kubernetes"])
     def test_dsl_reexport(self, module_name):
         import kfp
 
@@ -85,6 +85,15 @@ class TestDslReExports:
         reexported = getattr(kp, module_name)
         original = getattr(kfp, module_name)
         assert reexported is original
+
+    def test_dsl_custom_module(self):
+        import kubeflow.pipelines as kp
+
+        dsl_mod = kp.dsl
+        assert dsl_mod.__name__ == "kubeflow.pipelines.dsl"
+        assert hasattr(dsl_mod, "trigger_pipeline")
+        assert hasattr(dsl_mod, "component")
+        assert hasattr(dsl_mod, "pipeline")
 
 
 class TestTypeReExports:
@@ -118,7 +127,7 @@ class TestTypeReExports:
 class TestImportErrorHandling:
     """Test that helpful ImportError is raised when kfp is not installed."""
 
-    @pytest.mark.parametrize("attr", ["PipelinesClient", "dsl", "Pipeline"])
+    @pytest.mark.parametrize("attr", ["PipelinesClient", "Pipeline"])
     def test_import_error_without_kfp(self, attr, monkeypatch):
         _reload_pipelines_modules()
         for mod_name in list(sys.modules):
@@ -151,6 +160,7 @@ class TestAllExports:
         "ListRunsResponse",
         "KubernetesBackendConfig",
         "constants",
+        "trigger_pipeline",
     ]
 
     def test_all_exports(self):

--- a/kubeflow/pipelines/dsl.py
+++ b/kubeflow/pipelines/dsl.py
@@ -1,0 +1,146 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Kubeflow Pipelines DSL — re-exports from ``kfp.dsl`` with extras.
+
+Usage::
+
+    from kubeflow.pipelines import dsl
+
+
+    @dsl.pipeline(name="my-pipeline")
+    def my_pipeline():
+        ...
+        trigger = dsl.trigger_pipeline(pipeline_name="child")
+"""
+
+# Re-export everything from kfp.dsl
+# Runtime dependencies (available at runtime)
+# Compile-time dependencies
+import os as _os
+
+from kfp.dsl import (
+    HTML,
+    PIPELINE_JOB_CREATE_TIME_UTC_PLACEHOLDER,
+    PIPELINE_JOB_ID_PLACEHOLDER,
+    PIPELINE_JOB_NAME_PLACEHOLDER,
+    PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER,
+    PIPELINE_JOB_SCHEDULE_TIME_UTC_PLACEHOLDER,
+    PIPELINE_ROOT_PLACEHOLDER,
+    PIPELINE_TASK_EXECUTOR_INPUT_PLACEHOLDER,
+    PIPELINE_TASK_EXECUTOR_OUTPUT_PATH_PLACEHOLDER,
+    PIPELINE_TASK_ID_PLACEHOLDER,
+    PIPELINE_TASK_NAME_PLACEHOLDER,
+    WORKSPACE_PATH_PLACEHOLDER,
+    Artifact,
+    ClassificationMetrics,
+    Dataset,
+    Input,
+    InputPath,
+    Markdown,
+    Metrics,
+    Model,
+    Output,
+    OutputPath,
+    PipelineTaskFinalStatus,
+    SlicedClassificationMetrics,
+    TaskConfig,
+    get_uri,
+    run_notebook,
+)
+
+if _os.environ.get("_KFP_RUNTIME", "false") != "true":
+    from kfp.dsl import (
+        Collected,
+        ConcatPlaceholder,
+        Condition,
+        ContainerSpec,
+        Elif,
+        Else,
+        ExitHandler,
+        If,
+        IfPresentPlaceholder,
+        KubernetesWorkspaceConfig,
+        OneOf,
+        ParallelFor,
+        PipelineConfig,
+        PipelineTask,
+        TaskConfigField,
+        TaskConfigPassthrough,
+        WorkspaceConfig,
+        component,
+        container_component,
+        importer,
+        notebook_component,
+        pipeline,
+    )
+
+# Custom additions
+from kubeflow.pipelines.trigger import trigger_pipeline
+
+__all__ = [
+    # Runtime
+    "Artifact",
+    "ClassificationMetrics",
+    "Dataset",
+    "get_uri",
+    "HTML",
+    "Input",
+    "InputPath",
+    "Markdown",
+    "Metrics",
+    "Model",
+    "Output",
+    "OutputPath",
+    "PIPELINE_JOB_CREATE_TIME_UTC_PLACEHOLDER",
+    "PIPELINE_JOB_ID_PLACEHOLDER",
+    "PIPELINE_JOB_NAME_PLACEHOLDER",
+    "PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER",
+    "PIPELINE_JOB_SCHEDULE_TIME_UTC_PLACEHOLDER",
+    "PIPELINE_ROOT_PLACEHOLDER",
+    "PIPELINE_TASK_EXECUTOR_INPUT_PLACEHOLDER",
+    "PIPELINE_TASK_EXECUTOR_OUTPUT_PATH_PLACEHOLDER",
+    "PIPELINE_TASK_ID_PLACEHOLDER",
+    "PIPELINE_TASK_NAME_PLACEHOLDER",
+    "PipelineTaskFinalStatus",
+    "run_notebook",
+    "SlicedClassificationMetrics",
+    "TaskConfig",
+    "WORKSPACE_PATH_PLACEHOLDER",
+    # Compile-time
+    "Collected",
+    "component",
+    "ConcatPlaceholder",
+    "Condition",
+    "container_component",
+    "ContainerSpec",
+    "Elif",
+    "Else",
+    "ExitHandler",
+    "If",
+    "IfPresentPlaceholder",
+    "importer",
+    "KubernetesWorkspaceConfig",
+    "notebook_component",
+    "OneOf",
+    "ParallelFor",
+    "pipeline",
+    "PipelineConfig",
+    "PipelineTask",
+    "TaskConfigField",
+    "TaskConfigPassthrough",
+    "WorkspaceConfig",
+    # Custom additions
+    "trigger_pipeline",
+]

--- a/kubeflow/pipelines/trigger.py
+++ b/kubeflow/pipelines/trigger.py
@@ -1,0 +1,139 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""trigger_pipeline component for triggering child pipeline runs."""
+
+import typing
+
+from kfp import dsl
+
+__all__ = ["trigger_pipeline"]
+
+
+@dsl.component(
+    packages_to_install=["kfp"],
+    base_image="python:3.11-slim",
+)
+def trigger_pipeline(
+    pipeline_name: str,
+    parameters: typing.Dict[str, typing.Any] = None,  # noqa: UP006
+    wait_for_completion: bool = False,
+    poke_interval: int = 30,
+    experiment_name: str = None,
+    run_name: str = None,
+) -> str:
+    """Creates an independent child pipeline run from within a parent pipeline.
+
+    Analogous to Airflow's ``TriggerDagRunOperator``.  The child run gets its
+    own run ID, experiment placement, UI entry, and lifecycle — it is *not* a
+    nested DAG execution inside the same run.
+
+    When ``wait_for_completion`` is ``False`` (the default), the parent task
+    succeeds as soon as the child run is submitted (fire-and-forget).  When
+    ``True``, the parent task polls until the child reaches a terminal state.
+
+    .. warning::
+        This component makes outbound HTTP calls to the KFP API server at
+        runtime.  The container must have network access to the API server
+        and the ``kfp`` package installed (handled automatically via
+        ``packages_to_install``).
+
+    Args:
+        pipeline_name: The display name of a registered pipeline to trigger.
+        parameters: Runtime parameters to pass to the child pipeline.
+            Values may include outputs from upstream parent tasks.
+        wait_for_completion: If ``True``, poll until the child run reaches a
+            terminal state before succeeding.  If ``False`` (default), succeed
+            immediately after the run is created.
+        poke_interval: Seconds between status checks when
+            ``wait_for_completion`` is ``True``.
+        experiment_name: Experiment for the child run.  Uses the server
+            default experiment if omitted.
+        run_name: Display name for the child run.  Auto-generated if omitted.
+
+    Returns:
+        The run ID of the triggered child pipeline, which downstream tasks
+        can use to reference the child run.
+
+    Raises:
+        ValueError: If the pipeline or experiment is not found.
+        TimeoutError: If ``wait_for_completion`` is ``True`` and the child
+            run does not reach a terminal state within the default timeout
+            (7 days).
+    """
+    import logging
+    import time
+
+    from kfp import client
+
+    log = logging.getLogger(__name__)
+
+    kfp_client = client.Client()
+
+    # Resolve pipeline name to ID
+    pipeline_id = kfp_client.get_pipeline_id(pipeline_name)
+    if pipeline_id is None:
+        raise ValueError(
+            f"Pipeline {pipeline_name!r} not found. "
+            "Use list_pipelines() to see available pipelines."
+        )
+
+    # Resolve experiment name to ID (if provided)
+    experiment_id: str | None = None
+    if experiment_name:
+        try:
+            experiment = kfp_client.get_experiment(experiment_name=experiment_name)
+            experiment_id = experiment.experiment_id
+        except ValueError as e:
+            raise ValueError(
+                f"Experiment {experiment_name!r} not found. Use create_experiment() to create one."
+            ) from e
+
+    # Generate a default run name if none provided
+    if not run_name:
+        timestamp = time.strftime("%Y-%m-%d %H-%M-%S")
+        run_name = f"trigger-{pipeline_name} {timestamp}"
+
+    # Submit the child run
+    log.info(
+        "Triggering pipeline %r (id=%s) as run %r",
+        pipeline_name,
+        pipeline_id,
+        run_name,
+    )
+    run_response = kfp_client.run_pipeline(
+        experiment_id=experiment_id or "",
+        job_name=run_name,
+        pipeline_id=pipeline_id,
+        params=parameters or {},
+    )
+    child_run_id = run_response.run_id
+    log.info("Child run submitted: %s", child_run_id)
+
+    # Optionally wait for completion
+    if wait_for_completion:
+        log.info(
+            "Waiting for child run %s to complete (poll every %ds)...",
+            child_run_id,
+            poke_interval,
+        )
+        # Default timeout: 7 days (matching KFP backend max)
+        final_state = kfp_client.wait_for_run_completion(
+            run_id=child_run_id,
+            timeout=604800,
+            sleep_duration=poke_interval,
+        )
+        log.info("Child run %s reached terminal state: %s", child_run_id, final_state.state)
+
+    return child_run_id

--- a/kubeflow/pipelines/trigger_test.py
+++ b/kubeflow/pipelines/trigger_test.py
@@ -1,0 +1,131 @@
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the trigger_pipeline component."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def skip_if_no_kfp():
+    pytest.importorskip("kfp")
+
+
+class TestTriggerPipelineComponent:
+    """Tests for the trigger_pipeline component definition and spec."""
+
+    def test_component_input_spec(self):
+        from kubeflow.pipelines.trigger import trigger_pipeline
+
+        inputs = trigger_pipeline.component_spec.inputs
+        assert "pipeline_name" in inputs
+        assert inputs["pipeline_name"].type == "String"
+        assert not inputs["pipeline_name"].optional
+
+        assert "parameters" in inputs
+        assert inputs["parameters"].optional
+
+        assert "wait_for_completion" in inputs
+        assert inputs["wait_for_completion"].type == "Boolean"
+        assert inputs["wait_for_completion"].default is False
+
+        assert "poke_interval" in inputs
+        assert inputs["poke_interval"].type == "Integer"
+        assert inputs["poke_interval"].default == 30
+
+        assert "experiment_name" in inputs
+        assert inputs["experiment_name"].type == "String"
+        assert inputs["experiment_name"].optional
+
+        assert "run_name" in inputs
+        assert inputs["run_name"].type == "String"
+        assert inputs["run_name"].optional
+
+    def test_component_output_spec(self):
+        from kubeflow.pipelines.trigger import trigger_pipeline
+
+        outputs = trigger_pipeline.component_spec.outputs
+        assert "Output" in outputs
+        assert outputs["Output"].type == "String"
+
+    def test_component_name(self):
+        from kubeflow.pipelines.trigger import trigger_pipeline
+
+        assert trigger_pipeline.name == "trigger-pipeline"
+
+    def test_component_packages_to_install(self):
+        from kubeflow.pipelines.trigger import trigger_pipeline
+
+        impl = trigger_pipeline.component_spec.implementation
+        container = impl.container
+        assert container is not None
+        # packages_to_install becomes pip install commands in the container
+        assert any("kfp" in cmd for cmd in container.command)
+
+    def test_compiles_in_pipeline(self):
+        from kfp import compiler, dsl
+
+        from kubeflow.pipelines.trigger import trigger_pipeline
+
+        @dsl.pipeline(name="test-parent")
+        def parent_pipeline():
+            trigger_pipeline(
+                pipeline_name="child-pipeline",
+                parameters={"key": "value"},
+                wait_for_completion=False,
+            )
+
+        import os
+        import tempfile
+
+        tmpdir = tempfile.mkdtemp()
+        path = os.path.join(tmpdir, "pipeline.yaml")
+        try:
+            compiler.Compiler().compile(pipeline_func=parent_pipeline, package_path=path)
+            import yaml
+
+            with open(path) as f:
+                spec = yaml.safe_load(f)
+            ps = spec.get("pipelineSpec", spec)
+            components = ps.get("components", {})
+            trigger_components = [name for name in components if "trigger" in name.lower()]
+            assert len(trigger_components) > 0
+        finally:
+            import shutil
+
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+class TestTriggerPipelineExports:
+    """Tests for trigger_pipeline exports."""
+
+    def test_import_from_package(self):
+        from kubeflow.pipelines import trigger_pipeline
+        from kubeflow.pipelines.trigger import trigger_pipeline as tp
+
+        assert trigger_pipeline is tp
+
+    def test_import_from_dsl(self):
+        from kubeflow.pipelines import dsl
+        from kubeflow.pipelines.trigger import trigger_pipeline
+
+        assert dsl.trigger_pipeline is trigger_pipeline
+
+    def test_dsl_module_path(self):
+        from kubeflow.pipelines import dsl
+
+        assert dsl.__name__ == "kubeflow.pipelines.dsl"
+        assert dsl.__file__.endswith("kubeflow/pipelines/dsl.py")


### PR DESCRIPTION
## Description

Adds `dsl.trigger_pipeline(...)` — a native KFP component that lets one pipeline trigger an independent child pipeline run at runtime, similar to Airflow's `TriggerDagRunOperator`.

### Key details
- Implemented as a `@dsl.component` (Python lightweight component) — makes `kfp.Client` API calls inside the container, not a compile-time IR construct.
- Supports fire-and-forget (`wait_for_completion=False`, default) or polling mode (`wait_for_completion=True`).
- Accepts optional runtime parameters (`Dict[str, Any]`), experiment placement, and custom run name.
- Exposed as `kubeflow.pipelines.dsl.trigger_pipeline` and `kubeflow.pipelines.trigger_pipeline`.
- Custom `kubeflow/pipelines/dsl.py` submodule re-exports everything from `kfp.dsl` plus the new component.

### Related issues
Closes #... (N/A — new feature, no issue filed)

### Testing
- Unit tests cover input/output specs, component name, `packages_to_install`, pipeline compilation, and package/DSL-level exports.
- All 29 tests pass, lint and format clean.