### PR TITLE
feat: [KEP-107] Support `options` in `submit_job()` for SparkApplication jobs

### DIFF
--- a/examples/spark/batch_job_options.py
+++ b/examples/spark/batch_job_options.py
@@ -168,11 +168,31 @@ def example_verify_options():
     ):
         raise RuntimeError("Expected driver toleration to be applied.")
 
+    executor = spec.get("executor", {})
+
+    executor_node_selector = executor.get("nodeSelector", {})
+
+    if executor_node_selector.get("kubernetes.io/os") != "linux":
+        raise RuntimeError("Expected executor nodeSelector to be applied.")
+
+    executor_tolerations = executor.get("tolerations", [])
+
+    if not any(
+        t.get("key") == "dedicated"
+        and t.get("operator") == "Equal"
+        and t.get("value") == "spark"
+        and t.get("effect") == "NoSchedule"
+        for t in executor_tolerations
+    ):
+        raise RuntimeError("Expected executor toleration to be applied.")
+
     print("✓ Name verified.")
     print("✓ Labels verified.")
     print("✓ Annotations verified.")
-    print("✓ NodeSelector verified.")
-    print("✓ Toleration verified.")
+    print("✓ Driver NodeSelector verified.")
+    print("✓ Driver Toleration verified.")
+    print("✓ Executor NodeSelector verified.")
+    print("✓ Executor Toleration verified.")
 
     print("\nOptions verification complete.\n")
 
@@ -212,8 +232,8 @@ def example_delete_job():
 
 
 def main():
-    """Run the batch job option examples."""
-    print("E2E: Starting batch_job_option.py", flush=True)
+    """Run the batch job options examples."""
+    print("E2E: Starting batch_job_options.py", flush=True)
     print()
     print("=" * 70)
     print("KUBEFLOW SPARKCLIENT - BATCH JOB OPTIONS")

--- a/examples/spark/batch_job_options.py
+++ b/examples/spark/batch_job_options.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+
+from kubeflow.common.types import KubernetesBackendConfig
+from kubeflow.spark import (
+    Annotations,
+    DriverOption,
+    ExecutorOption,
+    FileJob,
+    Labels,
+    Name,
+    NodeSelector,
+    SparkClient,
+    SparkJobStatus,
+    Toleration,
+)
+
+REMOTE_JOB = "https://raw.githubusercontent.com/kubeflow/sdk/main/examples/spark/spark_job.py"
+
+JOB_NAME: str | None = None
+
+
+def _backend_config(namespace_default: str = "default"):
+    """Backend config; uses SPARK_TEST_NAMESPACE in CI."""
+    return KubernetesBackendConfig(
+        namespace=os.environ.get("SPARK_TEST_NAMESPACE", namespace_default)
+    )
+
+
+def _client() -> SparkClient:
+    """Create SparkClient."""
+    return SparkClient(backend_config=_backend_config())
+
+
+def example_submit_and_wait():
+    """Submit a Spark batch job and wait for completion."""
+    global JOB_NAME
+
+    print("=" * 70)
+    print("SUBMIT SPARK BATCH JOB")
+    print("=" * 70)
+
+    client = _client()
+
+    print("\nSubmitting Spark job...")
+
+    JOB_NAME = client.submit_job(
+        job=FileJob(
+            file_source=REMOTE_JOB,
+            args=["10"],
+        ),
+        options=[
+            Name("batch-job-options-demo"),
+            Labels(
+                {
+                    "app": "spark",
+                    "team": "ml",
+                }
+            ),
+            Annotations(
+                {
+                    "owner": "kubeflow",
+                    "environment": "dev",
+                }
+            ),
+            NodeSelector(
+                {
+                    "kubernetes.io/os": "linux",
+                }
+            ),
+            Toleration(
+                key="dedicated",
+                operator="Equal",
+                value="spark",
+                effect="NoSchedule",
+            ),
+            DriverOption(
+                image="spark:4.0.1",
+                resources={
+                    "cpu": "2",
+                    "memory": "1Gi",
+                },
+                java_options="-XX:+UseG1GC",
+                service_account="spark-operator-spark",
+            ),
+            ExecutorOption(
+                num_instances=2,
+                resources_per_executor={
+                    "cpu": "1",
+                    "memory": "512Mi",
+                },
+                java_options="-XX:+UseG1GC",
+            ),
+        ],
+    )
+
+    print(f"Job submitted successfully: {JOB_NAME}")
+
+    print("\nWaiting for job to complete...")
+
+    job = client.wait_for_job_status(
+        JOB_NAME,
+        status={SparkJobStatus.COMPLETED},
+        timeout=300,
+    )
+
+    print("Job completed successfully.")
+    print(f"Status: {job.status}")
+    print(f"Driver Pod: {job.driver_pod_name}")
+    print(f"Namespace: {job.namespace}")
+    print("\nSubmit and wait example complete.\n")
+
+
+def example_get_job():
+    """Get information about a Spark batch job."""
+    print("=" * 70)
+    print("GET SPARK BATCH JOB")
+    print("=" * 70)
+
+    if JOB_NAME is None:
+        raise RuntimeError("No job has been submitted.")
+
+    client = _client()
+
+    print(f"\nRetrieving job: {JOB_NAME}")
+
+    job = client.get_job(JOB_NAME)
+
+    if job.status != SparkJobStatus.COMPLETED:
+        raise RuntimeError(f"Expected COMPLETED status, got {job.status}.")
+
+    if not job.driver_pod_name:
+        raise RuntimeError("Expected driver pod name to be populated.")
+
+    print("Job retrieved successfully.")
+    print(f"Name: {job.name}")
+    print(f"Namespace: {job.namespace}")
+    print(f"Status: {job.status}")
+    print(f"Driver Pod: {job.driver_pod_name}")
+    print(f"Executors: {job.num_executors}")
+
+    print("\nGet job example complete.\n")
+
+
+def example_list_jobs():
+    """List Spark batch jobs."""
+    print("=" * 70)
+    print("LIST SPARK BATCH JOBS")
+    print("=" * 70)
+
+    if JOB_NAME is None:
+        raise RuntimeError("No job has been submitted.")
+
+    client = _client()
+
+    print("\nListing Spark jobs...")
+
+    jobs = client.list_jobs()
+
+    print(f"Found {len(jobs)} Spark job(s).\n")
+
+    job_found = False
+
+    for job in jobs:
+        print(f"- {job.name} | Status: {job.status} | Namespace: {job.namespace}")
+
+        if job.name == JOB_NAME:
+            job_found = True
+
+    if not job_found:
+        raise RuntimeError(f"Submitted job '{JOB_NAME}' not found in job list.")
+
+    print("\nSubmitted job found in job list.")
+
+    print("\nListing completed Spark jobs...")
+
+    completed_jobs = client.list_jobs(
+        status={SparkJobStatus.COMPLETED},
+    )
+
+    print(f"Found {len(completed_jobs)} completed Spark job(s).\n")
+
+    completed_job_found = False
+
+    for job in completed_jobs:
+        if job.status != SparkJobStatus.COMPLETED:
+            raise RuntimeError(f"Expected COMPLETED status, got {job.status}.")
+
+        print(f"- {job.name} | Status: {job.status} | Namespace: {job.namespace}")
+
+        if job.name == JOB_NAME:
+            completed_job_found = True
+
+    if not completed_job_found:
+        raise RuntimeError(f"Submitted completed job '{JOB_NAME}' not found in filtered job list.")
+
+    print("\nCompleted job filter verified.")
+    print("\nList jobs example complete.\n")
+
+
+def example_get_job_logs():
+    """Get logs from a Spark batch job."""
+    print("=" * 70)
+    print("GET SPARK BATCH JOB LOGS")
+    print("=" * 70)
+
+    if JOB_NAME is None:
+        raise RuntimeError("No job has been submitted.")
+
+    client = _client()
+
+    print(f"\nRetrieving logs for: {JOB_NAME}")
+
+    print("\nDriver logs (first 20 lines):")
+    print("-" * 70)
+
+    line_count = 0
+    for line in client.get_job_logs(JOB_NAME):
+        print(line.rstrip())
+        line_count += 1
+
+        if line_count >= 20:
+            print("...")
+            break
+
+    print("-" * 70)
+    print(f"Displayed {line_count} log lines.")
+
+    print("\nGet job logs example complete.\n")
+
+
+def example_delete_job():
+    """Delete a Spark batch job."""
+    print("=" * 70)
+    print("DELETE SPARK BATCH JOB")
+    print("=" * 70)
+
+    global JOB_NAME
+
+    if JOB_NAME is None:
+        raise RuntimeError("No job has been submitted.")
+
+    client = _client()
+
+    print(f"\nDeleting job: {JOB_NAME}")
+
+    client.delete_job(JOB_NAME)
+
+    print("Job deleted.")
+
+    try:
+        client.get_job(JOB_NAME)
+    except RuntimeError as e:
+        if "Spark job not found" not in str(e):
+            raise
+    else:
+        raise RuntimeError("Job still exists after deletion.")
+
+    print("Verified job has been deleted.")
+
+    JOB_NAME = None
+
+    print("\nDelete job example complete.\n")
+
+
+def main():
+    """Run all batch job lifecycle examples."""
+    print("E2E: Starting batch_job_lifecycle.py", flush=True)
+    print()
+    print("=" * 70)
+    print("KUBEFLOW SPARKCLIENT - BATCH JOB LIFECYCLE")
+    print("=" * 70)
+
+    try:
+        example_submit_and_wait()
+        example_get_job()
+        example_list_jobs()
+        example_get_job_logs()
+        example_delete_job()
+
+        print("=" * 70)
+        print("BATCH JOB LIFECYCLE COMPLETE!")
+        print("=" * 70)
+
+    except Exception as e:
+            print(f"\nError: {e}")
+            raise SystemExit(1) from e
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/spark/batch_job_options.py
+++ b/examples/spark/batch_job_options.py
@@ -15,12 +15,11 @@
 
 
 import os
+import uuid
 
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark import (
     Annotations,
-    DriverOption,
-    ExecutorOption,
     FileJob,
     Labels,
     Name,
@@ -65,7 +64,7 @@ def example_submit_and_wait():
             args=["10"],
         ),
         options=[
-            Name("batch-job-options-demo"),
+            Name(f"batch-job-options-{uuid.uuid4().hex[:8]}"),
             Labels(
                 {
                     "app": "spark",
@@ -89,23 +88,6 @@ def example_submit_and_wait():
                 value="spark",
                 effect="NoSchedule",
             ),
-            DriverOption(
-                image="spark:4.0.1",
-                resources={
-                    "cpu": "2",
-                    "memory": "1Gi",
-                },
-                java_options="-XX:+UseG1GC",
-                service_account="spark-operator-spark",
-            ),
-            ExecutorOption(
-                num_instances=2,
-                resources_per_executor={
-                    "cpu": "1",
-                    "memory": "512Mi",
-                },
-                java_options="-XX:+UseG1GC",
-            ),
         ],
     )
 
@@ -126,41 +108,10 @@ def example_submit_and_wait():
     print("\nSubmit and wait example complete.\n")
 
 
-def example_get_job():
-    """Get information about a Spark batch job."""
+def example_verify_options():
+    """Verify that Spark options were applied to the SparkApplication."""
     print("=" * 70)
-    print("GET SPARK BATCH JOB")
-    print("=" * 70)
-
-    if JOB_NAME is None:
-        raise RuntimeError("No job has been submitted.")
-
-    client = _client()
-
-    print(f"\nRetrieving job: {JOB_NAME}")
-
-    job = client.get_job(JOB_NAME)
-
-    if job.status != SparkJobStatus.COMPLETED:
-        raise RuntimeError(f"Expected COMPLETED status, got {job.status}.")
-
-    if not job.driver_pod_name:
-        raise RuntimeError("Expected driver pod name to be populated.")
-
-    print("Job retrieved successfully.")
-    print(f"Name: {job.name}")
-    print(f"Namespace: {job.namespace}")
-    print(f"Status: {job.status}")
-    print(f"Driver Pod: {job.driver_pod_name}")
-    print(f"Executors: {job.num_executors}")
-
-    print("\nGet job example complete.\n")
-
-
-def example_list_jobs():
-    """List Spark batch jobs."""
-    print("=" * 70)
-    print("LIST SPARK BATCH JOBS")
+    print("VERIFY SPARK BATCH JOB OPTIONS")
     print("=" * 70)
 
     if JOB_NAME is None:
@@ -168,80 +119,62 @@ def example_list_jobs():
 
     client = _client()
 
-    print("\nListing Spark jobs...")
-
-    jobs = client.list_jobs()
-
-    print(f"Found {len(jobs)} Spark job(s).\n")
-
-    job_found = False
-
-    for job in jobs:
-        print(f"- {job.name} | Status: {job.status} | Namespace: {job.namespace}")
-
-        if job.name == JOB_NAME:
-            job_found = True
-
-    if not job_found:
-        raise RuntimeError(f"Submitted job '{JOB_NAME}' not found in job list.")
-
-    print("\nSubmitted job found in job list.")
-
-    print("\nListing completed Spark jobs...")
-
-    completed_jobs = client.list_jobs(
-        status={SparkJobStatus.COMPLETED},
+    response = client.backend.custom_api.get_namespaced_custom_object(
+        group="sparkoperator.k8s.io",
+        version="v1beta2",
+        namespace=client.backend.namespace,
+        plural="sparkapplications",
+        name=JOB_NAME,
     )
 
-    print(f"Found {len(completed_jobs)} completed Spark job(s).\n")
+    metadata = response["metadata"]
+    spec = response["spec"]
 
-    completed_job_found = False
+    resource_name = metadata.get("name")
 
-    for job in completed_jobs:
-        if job.status != SparkJobStatus.COMPLETED:
-            raise RuntimeError(f"Expected COMPLETED status, got {job.status}.")
+    if resource_name != JOB_NAME:
+        raise RuntimeError(f"Expected resource name '{JOB_NAME}', got '{resource_name}'.")
 
-        print(f"- {job.name} | Status: {job.status} | Namespace: {job.namespace}")
+    labels = metadata.get("labels", {})
+    annotations = metadata.get("annotations", {})
 
-        if job.name == JOB_NAME:
-            completed_job_found = True
+    if labels.get("app") != "spark":
+        raise RuntimeError("Expected label app=spark.")
 
-    if not completed_job_found:
-        raise RuntimeError(f"Submitted completed job '{JOB_NAME}' not found in filtered job list.")
+    if labels.get("team") != "ml":
+        raise RuntimeError("Expected label team=ml.")
 
-    print("\nCompleted job filter verified.")
-    print("\nList jobs example complete.\n")
+    if annotations.get("owner") != "kubeflow":
+        raise RuntimeError("Expected annotation owner=kubeflow.")
 
+    if annotations.get("environment") != "dev":
+        raise RuntimeError("Expected annotation environment=dev.")
 
-def example_get_job_logs():
-    """Get logs from a Spark batch job."""
-    print("=" * 70)
-    print("GET SPARK BATCH JOB LOGS")
-    print("=" * 70)
+    driver = spec.get("driver", {})
 
-    if JOB_NAME is None:
-        raise RuntimeError("No job has been submitted.")
+    node_selector = driver.get("nodeSelector", {})
 
-    client = _client()
+    if node_selector.get("kubernetes.io/os") != "linux":
+        raise RuntimeError("Expected driver nodeSelector to be applied.")
 
-    print(f"\nRetrieving logs for: {JOB_NAME}")
+    tolerations = driver.get("tolerations", [])
 
-    print("\nDriver logs (first 20 lines):")
-    print("-" * 70)
+    if not any(
+        t.get("key") == "dedicated"
+        and t.get("operator") == "Equal"
+        and t.get("value") == "spark"
+        and t.get("effect") == "NoSchedule"
+        for t in tolerations
+    ):
+        raise RuntimeError("Expected driver toleration to be applied.")
 
-    line_count = 0
-    for line in client.get_job_logs(JOB_NAME):
-        print(line.rstrip())
-        line_count += 1
+    print("✓ Name verified.")
+    print("✓ Labels verified.")
+    print("✓ Annotations verified.")
+    print("✓ NodeSelector verified.")
+    print("✓ Toleration verified.")
 
-        if line_count >= 20:
-            print("...")
-            break
-
-    print("-" * 70)
-    print(f"Displayed {line_count} log lines.")
-
-    print("\nGet job logs example complete.\n")
+    print("\nOptions verification complete.\n")
 
 
 def example_delete_job():
@@ -279,27 +212,25 @@ def example_delete_job():
 
 
 def main():
-    """Run all batch job lifecycle examples."""
-    print("E2E: Starting batch_job_lifecycle.py", flush=True)
+    """Run the batch job option examples."""
+    print("E2E: Starting batch_job_option.py", flush=True)
     print()
     print("=" * 70)
-    print("KUBEFLOW SPARKCLIENT - BATCH JOB LIFECYCLE")
+    print("KUBEFLOW SPARKCLIENT - BATCH JOB OPTIONS")
     print("=" * 70)
 
     try:
         example_submit_and_wait()
-        example_get_job()
-        example_list_jobs()
-        example_get_job_logs()
+        example_verify_options()
         example_delete_job()
 
         print("=" * 70)
-        print("BATCH JOB LIFECYCLE COMPLETE!")
+        print("BATCH JOB OPTIONS COMPLETE!")
         print("=" * 70)
 
     except Exception as e:
-            print(f"\nError: {e}")
-            raise SystemExit(1) from e
+        print(f"\nError: {e}")
+        raise SystemExit(1) from e
 
 
 if __name__ == "__main__":

--- a/kubeflow/spark/__init__.py
+++ b/kubeflow/spark/__init__.py
@@ -18,6 +18,8 @@ from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.api.spark_client import SparkClient
 from kubeflow.spark.types.options import (
     Annotations,
+    DriverOption,
+    ExecutorOption,
     Labels,
     Name,
     NodeSelector,
@@ -54,6 +56,8 @@ __all__ = [
     "NodeSelector",
     "PodTemplateOverride",
     "Toleration",
+    "DriverOption",
+    "ExecutorOption",
     # Configuration
     "KubernetesBackendConfig",
 ]

--- a/kubeflow/spark/__init__.py
+++ b/kubeflow/spark/__init__.py
@@ -18,8 +18,6 @@ from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.api.spark_client import SparkClient
 from kubeflow.spark.types.options import (
     Annotations,
-    DriverOption,
-    ExecutorOption,
     Labels,
     Name,
     NodeSelector,
@@ -56,8 +54,6 @@ __all__ = [
     "NodeSelector",
     "PodTemplateOverride",
     "Toleration",
-    "DriverOption",
-    "ExecutorOption",
     # Configuration
     "KubernetesBackendConfig",
 ]

--- a/kubeflow/spark/api/spark_client.py
+++ b/kubeflow/spark/api/spark_client.py
@@ -218,13 +218,11 @@ class SparkClient:
         if spark_conf is not None:
             raise NotImplementedError("spark_conf support is not yet implemented.")
 
-        if options is not None:
-            raise NotImplementedError("options are not supported in Phase 1.")
-
         return self.backend.submit_job(
             job=job,
             num_executors=num_executors,
             resources_per_executor=resources_per_executor,
+            options=options,
         ).name
 
     def get_job(self, name: str) -> SparkJob:

--- a/kubeflow/spark/api/spark_client_test.py
+++ b/kubeflow/spark/api/spark_client_test.py
@@ -21,6 +21,7 @@ import pytest
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.api.spark_client import SparkClient
 from kubeflow.spark.test.common import FAILED, SUCCESS, TestCase
+from kubeflow.spark.types.options import Labels
 from kubeflow.spark.types.types import (
     FileJob,
     FuncJob,
@@ -104,13 +105,6 @@ def test_create_and_connect(test_case: TestCase):
             None,
             NotImplementedError,
         ),
-        (
-            FileJob(file_source="s3://bucket/job.py"),
-            None,
-            [object()],
-            None,
-            NotImplementedError,
-        ),
     ],
 )
 def test_submit_job_validation(
@@ -139,17 +133,23 @@ def test_submit_job_validation(
 
 
 @pytest.mark.parametrize(
-    "job",
+    "job,options",
     [
-        FileJob(
-            file_source="s3://bucket/job.py",
+        (
+            FileJob(file_source="s3://bucket/job.py"),
+            None,
         ),
-        FuncJob(
-            func=lambda: None,
+        (
+            FileJob(file_source="s3://bucket/job.py"),
+            [Labels({"team": "ml"})],
+        ),
+        (
+            FuncJob(func=lambda: None),
+            None,
         ),
     ],
 )
-def test_submit_job_success(job):
+def test_submit_job_success(job, options):
     """Test successful submit_job."""
 
     with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as mock_backend:
@@ -162,12 +162,10 @@ def test_submit_job_success(job):
 
         client = SparkClient()
 
-        name = client.submit_job(job=job)
+        name = client.submit_job(job=job, options=options)
 
         assert name == "spark-job-123"
 
         backend.submit_job.assert_called_once_with(
-            job=job,
-            num_executors=None,
-            resources_per_executor=None,
+            job=job, num_executors=None, resources_per_executor=None, options=options
         )

--- a/kubeflow/spark/api/spark_client_test.py
+++ b/kubeflow/spark/api/spark_client_test.py
@@ -20,8 +20,8 @@ import pytest
 
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.api.spark_client import SparkClient
+from kubeflow.spark.options import Labels
 from kubeflow.spark.test.common import FAILED, SUCCESS, TestCase
-from kubeflow.spark.types.options import Labels
 from kubeflow.spark.types.types import (
     FileJob,
     FuncJob,

--- a/kubeflow/spark/backends/base.py
+++ b/kubeflow/spark/backends/base.py
@@ -149,6 +149,7 @@ class RuntimeBackend(abc.ABC):
         job: FileJob | FuncJob,
         num_executors: int | None = None,
         resources_per_executor: dict[str, str] | None = None,
+        options: list | None = None,
     ) -> SparkJob:
         """Submit a Spark batch job.
 

--- a/kubeflow/spark/backends/base.py
+++ b/kubeflow/spark/backends/base.py
@@ -157,6 +157,7 @@ class RuntimeBackend(abc.ABC):
             job: Spark application to execute.
             num_executors: Number of executor instances.
             resources_per_executor: Resource requirements for each executor.
+             options: List of additional Spark configuration options.
 
         Returns:
             Submitted Spark job information.

--- a/kubeflow/spark/backends/base.py
+++ b/kubeflow/spark/backends/base.py
@@ -157,7 +157,7 @@ class RuntimeBackend(abc.ABC):
             job: Spark application to execute.
             num_executors: Number of executor instances.
             resources_per_executor: Resource requirements for each executor.
-             options: List of additional Spark configuration options.
+            options: List of configuration options. Use the Name option for a custom job name.
 
         Returns:
             Submitted Spark job information.

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -156,7 +156,7 @@ class KubernetesBackend(RuntimeBackend):
             spark_conf=spark_conf,
             driver=driver,
             executor=executor,
-            options=options,  # Use filtered list
+            options=options,
             backend=self,  # Pass backend for option validation
         )
 
@@ -920,11 +920,6 @@ class KubernetesBackend(RuntimeBackend):
 
         job_name = generate_job_name()
 
-        logger.info(
-            "Submitting SparkApplication '%s'",
-            job_name,
-        )
-
         if isinstance(job, FileJob):
             spark_application = get_spark_application_cr_from_file_job(
                 name=job_name,
@@ -948,6 +943,14 @@ class KubernetesBackend(RuntimeBackend):
                 options=options,
                 backend=self,
             )
+
+        # The Name option may override the auto-generated name.
+        job_name = spark_application.metadata.name
+
+        logger.info(
+            "Submitting SparkApplication '%s'",
+            job_name,
+        )
 
         try:
             thread = self.custom_api.create_namespaced_custom_object(

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -40,6 +40,7 @@ from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.backends.base import RuntimeBackend
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.utils import (
+    extract_name_option,
     build_service_url,
     build_spark_connect_cr,
     generate_job_name,
@@ -50,7 +51,6 @@ from kubeflow.spark.backends.kubernetes.utils import (
     get_spark_connect_info_from_cr,
     read_pod_logs,
 )
-from kubeflow.spark.types.options import Name
 from kubeflow.spark.types.types import (
     Driver,
     Executor,
@@ -119,35 +119,6 @@ class KubernetesBackend(RuntimeBackend):
     # Spark Connect sessions
     # ------------------------------------------------------------------
 
-    def _extract_name_option(self, options: list | None) -> tuple[str, list]:
-        """Extract Name option from options list, or generate name if absent.
-
-        Args:
-            options: List of option objects (Labels, Annotations, etc.).
-
-        Returns:
-            Tuple of (session_name, filtered_options):
-            - session_name: Name from Name option, or auto-generated name
-            - filtered_options: Options list with Name option removed
-        """
-        if not options:
-            return generate_session_name(), []
-
-        name_from_option = None
-        filtered_options = []
-
-        for option in options:
-            if isinstance(option, Name):
-                name_from_option = option.name
-                # Don't add Name option to filtered list
-            else:
-                filtered_options.append(option)
-
-        # Use Name option if provided, otherwise auto-generate
-        session_name = name_from_option if name_from_option else generate_session_name()
-
-        return session_name, filtered_options
-
     def _create_session(
         self,
         num_executors: int | None = None,
@@ -177,7 +148,10 @@ class KubernetesBackend(RuntimeBackend):
                 If the SparkConnect resource cannot be created.
         """
         # Extract Name option if present, or auto-generate
-        name, filtered_options = self._extract_name_option(options)
+        name, filtered_options = extract_name_option(
+            options,
+            generate_session_name(),
+        )
 
         spark_connect = build_spark_connect_cr(
             name=name,
@@ -917,6 +891,7 @@ class KubernetesBackend(RuntimeBackend):
         job: FileJob | FuncJob,
         num_executors: int | None = None,
         resources_per_executor: dict[str, str] | None = None,
+        options: list | None = None,
     ) -> SparkJob:
         """Submit a SparkApplication for batch execution.
 
@@ -945,7 +920,10 @@ class KubernetesBackend(RuntimeBackend):
         """
         self._validate_job(job)
 
-        job_name = generate_job_name()
+        job_name, filtered_options = extract_name_option(
+            options,
+            generate_job_name(),
+        )
 
         logger.info(
             "Submitting SparkApplication '%s'",

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -42,7 +42,6 @@ from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.utils import (
     build_service_url,
     build_spark_connect_cr,
-    extract_name_option,
     generate_job_name,
     generate_session_name,
     get_spark_application_cr_from_file_job,
@@ -147,11 +146,7 @@ class KubernetesBackend(RuntimeBackend):
             RuntimeError:
                 If the SparkConnect resource cannot be created.
         """
-        # Extract Name option if present, or auto-generate
-        name, filtered_options = extract_name_option(
-            options,
-            generate_session_name(),
-        )
+        name = generate_session_name()
 
         spark_connect = build_spark_connect_cr(
             name=name,
@@ -161,7 +156,7 @@ class KubernetesBackend(RuntimeBackend):
             spark_conf=spark_conf,
             driver=driver,
             executor=executor,
-            options=filtered_options,  # Use filtered list
+            options=options,  # Use filtered list
             backend=self,  # Pass backend for option validation
         )
 
@@ -923,10 +918,7 @@ class KubernetesBackend(RuntimeBackend):
         """
         self._validate_job(job)
 
-        job_name, filtered_options = extract_name_option(
-            options,
-            generate_job_name(),
-        )
+        job_name = generate_job_name()
 
         logger.info(
             "Submitting SparkApplication '%s'",
@@ -941,7 +933,7 @@ class KubernetesBackend(RuntimeBackend):
                 arguments=job.args,
                 num_executors=num_executors,
                 resources_per_executor=resources_per_executor,
-                options=filtered_options,
+                options=options,
                 backend=self,
             )
 
@@ -953,7 +945,7 @@ class KubernetesBackend(RuntimeBackend):
                 func_args=job.func_args,
                 num_executors=num_executors,
                 resources_per_executor=resources_per_executor,
-                options=filtered_options,
+                options=options,
                 backend=self,
             )
 

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -40,9 +40,9 @@ from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.backends.base import RuntimeBackend
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.utils import (
-    extract_name_option,
     build_service_url,
     build_spark_connect_cr,
+    extract_name_option,
     generate_job_name,
     generate_session_name,
     get_spark_application_cr_from_file_job,
@@ -905,6 +905,9 @@ class KubernetesBackend(RuntimeBackend):
             resources_per_executor:
                 Resource requirements per executor.
 
+            options:
+                List of additional Spark configuration options.
+
         Returns:
             SparkJob information object.
 
@@ -938,6 +941,8 @@ class KubernetesBackend(RuntimeBackend):
                 arguments=job.args,
                 num_executors=num_executors,
                 resources_per_executor=resources_per_executor,
+                options=filtered_options,
+                backend=self,
             )
 
         else:
@@ -948,6 +953,8 @@ class KubernetesBackend(RuntimeBackend):
                 func_args=job.func_args,
                 num_executors=num_executors,
                 resources_per_executor=resources_per_executor,
+                options=filtered_options,
+                backend=self,
             )
 
         try:

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -1279,6 +1279,19 @@ def test_validate_job(kubernetes_backend, test_case):
                 "use_mock_command": True,
             },
         ),
+        TestCase(
+            name="valid remote file submission with options",
+            expected_status=SUCCESS,
+            config={
+                "job": FileJob(
+                    file_source="s3://bucket/job.py",
+                ),
+                "options": [
+                    Name("custom-job"),
+                    Labels({"team": "ml"}),
+                ],
+            },
+        ),
     ],
 )
 def test_submit_job(kubernetes_backend, test_case):
@@ -1301,12 +1314,16 @@ def test_submit_job(kubernetes_backend, test_case):
 
                 job = kubernetes_backend.submit_job(
                     job=test_case.config["job"],
+                    options=test_case.config.get("options"),
                 )
 
                 mock_build.assert_called_once()
 
                 assert mock_build.call_args.kwargs["func"] == test_case.config["job"].func
                 assert mock_build.call_args.kwargs["func_args"] == test_case.config["job"].func_args
+                if test_case.config.get("options"):
+                    assert mock_build.call_args.kwargs["options"] == test_case.config["options"]
+                    assert mock_build.call_args.kwargs["backend"] is kubernetes_backend
 
         else:
             job = kubernetes_backend.submit_job(

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -28,8 +28,6 @@ from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
 from kubeflow.spark.backends.kubernetes.utils import (
-    extract_name_option,
-    generate_session_name,
     validate_spark_connect_url,
 )
 from kubeflow.spark.test.common import (
@@ -862,59 +860,6 @@ def test_create_and_connect(kubernetes_backend, test_case):
             assert mock_create.call_args.kwargs.get("options") == options
 
         assert test_case.expected_status == SUCCESS
-
-    except Exception as e:
-        assert type(e) is test_case.expected_error
-    print("test execution complete")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        TestCase(
-            name="valid flow with name option provided",
-            expected_status=SUCCESS,
-            config={"options": [Name("test-name"), Labels({"app": "spark"})]},
-            expected_output={"name": "test-name", "remaining_count": 1, "remaining_type": Labels},
-        ),
-        TestCase(
-            name="valid flow with no name option auto generates",
-            expected_status=SUCCESS,
-            config={"options": [Labels({"app": "spark"})]},
-            expected_output={
-                "name_prefix": "spark-connect-",
-                "remaining_count": 1,
-                "remaining_type": Labels,
-            },
-        ),
-        TestCase(
-            name="valid flow with none options auto generates",
-            expected_status=SUCCESS,
-            config={"options": None},
-            expected_output={"name_prefix": "spark-connect-", "remaining_count": 0},
-        ),
-        TestCase(
-            name="valid flow with empty options auto generates",
-            expected_status=SUCCESS,
-            config={"options": []},
-            expected_output={"name_prefix": "spark-connect-", "remaining_count": 0},
-        ),
-    ],
-)
-def test_extract_name_option(kubernetes_backend, test_case):
-    """Test extract_name_option for name extraction and auto-generation."""
-    print("Executing test:", test_case.name)
-    try:
-        name, filtered = extract_name_option(test_case.config["options"], generate_session_name())
-
-        assert test_case.expected_status == SUCCESS
-        if "name" in test_case.expected_output:
-            assert name == test_case.expected_output["name"]
-        else:
-            assert name.startswith(test_case.expected_output["name_prefix"])
-        assert len(filtered) == test_case.expected_output["remaining_count"]
-        if "remaining_type" in test_case.expected_output:
-            assert isinstance(filtered[0], test_case.expected_output["remaining_type"])
 
     except Exception as e:
         assert type(e) is test_case.expected_error

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -1273,10 +1273,15 @@ def test_submit_job(kubernetes_backend, test_case):
         else:
             job = kubernetes_backend.submit_job(
                 job=test_case.config["job"],
+                options=test_case.config.get("options"),
             )
 
         assert test_case.expected_status == SUCCESS
-        assert job.name.startswith("spark-job-")
+
+        if test_case.config.get("options"):
+            assert job.name == "custom-job"
+        else:
+            assert job.name.startswith("spark-job-")
 
     except Exception as e:
         assert type(e) is test_case.expected_error

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -30,6 +30,7 @@ from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
 from kubeflow.spark.backends.kubernetes.utils import (
     validate_spark_connect_url,
 )
+from kubeflow.spark.options import Labels, Name
 from kubeflow.spark.test.common import (
     DEFAULT_NAMESPACE,
     FAILED,
@@ -41,7 +42,6 @@ from kubeflow.spark.test.common import (
     TIMEOUT,
     TestCase,
 )
-from kubeflow.spark.types.options import Labels, Name
 from kubeflow.spark.types.types import (
     FileJob,
     FuncJob,

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -28,6 +28,8 @@ from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
 from kubeflow.spark.backends.kubernetes.utils import (
+    extract_name_option,
+    generate_session_name,
     validate_spark_connect_url,
 )
 from kubeflow.spark.test.common import (
@@ -900,10 +902,10 @@ def test_create_and_connect(kubernetes_backend, test_case):
     ],
 )
 def test_extract_name_option(kubernetes_backend, test_case):
-    """Test KubernetesBackend._extract_name_option for name extraction and auto-generation."""
+    """Test extract_name_option for name extraction and auto-generation."""
     print("Executing test:", test_case.name)
     try:
-        name, filtered = kubernetes_backend._extract_name_option(test_case.config["options"])
+        name, filtered = extract_name_option(test_case.config["options"], generate_session_name())
 
         assert test_case.expected_status == SUCCESS
         if "name" in test_case.expected_output:

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -308,6 +308,13 @@ def apply_options(
 
         backend:
             Backend used for option validation.
+
+        Raises:
+            ValueError:
+                If options are provided without a backend instance.
+
+            TypeError:
+                If an option is not callable.
     """
     if not options:
         return
@@ -316,8 +323,13 @@ def apply_options(
         raise ValueError("A backend instance is required to apply Spark options.")
 
     for option in options:
-        if callable(option):
-            option(resource, backend)
+        if not callable(option):
+            raise TypeError(
+                f"Invalid Spark option: {option!r}. Options must be callable, "
+                "for example: Name, Labels, Annotations, NodeSelector or Toleration."
+            )
+
+        option(resource, backend)
 
 
 # ----------------------------------------------------------------------

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -30,6 +30,7 @@ from kubeflow_spark_api import models
 from kubernetes import client
 
 from kubeflow.common import constants as common_constants
+from kubeflow.spark.types.options import Name
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.types.types import (
     Driver,
@@ -291,6 +292,34 @@ def _validate_cpu_value(cpu: str | int | None) -> int:
 
     return cores
 
+def extract_name_option(
+    options: list | None,
+    default_name: str,
+) -> tuple[str, list]:
+    """Extract the Name option from the options list.
+
+    Args:
+        options: List of option objects (Labels, Annotations, etc.).
+        default_name: Default resource name to use when no Name option is provided.
+
+    Returns:
+        Tuple of (resource_name, filtered_options):
+        - resource_name: Name from the Name option, or the provided default name.
+        - filtered_options: Options list with the Name option removed.
+    """
+    if not options:
+        return default_name, []
+
+    name = default_name
+    filtered_options = []
+
+    for option in options:
+        if isinstance(option, Name):
+            name = option.name
+        else:
+            filtered_options.append(option)
+
+    return name, filtered_options
 
 # ----------------------------------------------------------------------
 # Spark Connect session utility functions

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -30,8 +30,8 @@ from kubeflow_spark_api import models
 from kubernetes import client
 
 from kubeflow.common import constants as common_constants
-from kubeflow.spark.types.options import Name
 from kubeflow.spark.backends.kubernetes import constants
+from kubeflow.spark.types.options import Name
 from kubeflow.spark.types.types import (
     Driver,
     Executor,
@@ -292,6 +292,7 @@ def _validate_cpu_value(cpu: str | int | None) -> int:
 
     return cores
 
+
 def extract_name_option(
     options: list | None,
     default_name: str,
@@ -320,6 +321,32 @@ def extract_name_option(
             filtered_options.append(option)
 
     return name, filtered_options
+
+
+def apply_options(
+    resource: models.SparkV1alpha1SparkConnect | models.SparkV1beta2SparkApplication,
+    options: list | None,
+    backend: Any | None = None,
+) -> None:
+    """Apply configuration options to a Spark resource.
+
+    Args:
+        resource:
+            Spark resource to configure.
+
+        options:
+            List of configuration options.
+
+        backend:
+            Backend used for option validation.
+    """
+    if not options or backend is None:
+        return
+
+    for option in options:
+        if callable(option):
+            option(resource, backend)
+
 
 # ----------------------------------------------------------------------
 # Spark Connect session utility functions
@@ -531,10 +558,11 @@ def build_spark_connect_cr(
     )
 
     # Apply options - extensibility without API changes (callable pattern)
-    if options and backend is not None:
-        for option in options:
-            if callable(option):
-                option(spark_connect, backend)
+    apply_options(
+        spark_connect,
+        options,
+        backend,
+    )
 
     return spark_connect
 
@@ -734,6 +762,8 @@ def get_spark_application_cr_from_file_job(
     arguments: list[str] | None = None,
     num_executors: int | None = None,
     resources_per_executor: dict[str, str] | None = None,
+    options: list | None = None,
+    backend: Any | None = None,
 ) -> models.SparkV1beta2SparkApplication:
     """Build a SparkApplication custom resource for a file-based Spark job.
 
@@ -744,6 +774,7 @@ def get_spark_application_cr_from_file_job(
         arguments: Command-line arguments passed to the Spark application.
         num_executors: Number of executor instances.
         resources_per_executor: Resource requirements for each executor.
+        options: List of configuration options.
 
     Returns:
         SparkApplication custom resource model.
@@ -752,7 +783,7 @@ def get_spark_application_cr_from_file_job(
         ValueError:
             If the executor resource configuration is invalid.
     """
-    return models.SparkV1beta2SparkApplication(
+    spark_application = models.SparkV1beta2SparkApplication(
         api_version=f"{constants.SPARK_APPLICATION_GROUP}/{constants.SPARK_APPLICATION_VERSION}",
         kind=constants.SPARK_APPLICATION_KIND,
         metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
@@ -774,6 +805,14 @@ def get_spark_application_cr_from_file_job(
         ),
     )
 
+    apply_options(
+        spark_application,
+        options,
+        backend,
+    )
+
+    return spark_application
+
 
 def get_spark_application_cr_from_func_job(
     name: str,
@@ -782,6 +821,8 @@ def get_spark_application_cr_from_func_job(
     func_args: dict[str, Any] | None = None,
     num_executors: int | None = None,
     resources_per_executor: dict[str, str] | None = None,
+    options: list | None = None,
+    backend: Any | None = None,
 ) -> models.SparkV1beta2SparkApplication:
     """Build a SparkApplication custom resource for a function-based Spark job.
 
@@ -792,6 +833,7 @@ def get_spark_application_cr_from_func_job(
         func_args: Keyword arguments passed to the function.
         num_executors: Number of executor instances.
         resources_per_executor: Resource requirements for each executor.
+        options: List of configuration options.
 
     Returns:
         SparkApplication custom resource model.
@@ -845,6 +887,12 @@ def get_spark_application_cr_from_func_job(
             mount_path=constants.FUNC_JOB_SCRIPT_DIR,
         ),
     ]
+
+    apply_options(
+        spark_application,
+        options,
+        backend,
+    )
 
     return spark_application
 

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -31,7 +31,6 @@ from kubernetes import client
 
 from kubeflow.common import constants as common_constants
 from kubeflow.spark.backends.kubernetes import constants
-from kubeflow.spark.types.options import Name
 from kubeflow.spark.types.types import (
     Driver,
     Executor,
@@ -293,36 +292,6 @@ def _validate_cpu_value(cpu: str | int | None) -> int:
     return cores
 
 
-def extract_name_option(
-    options: list | None,
-    default_name: str,
-) -> tuple[str, list]:
-    """Extract the Name option from the options list.
-
-    Args:
-        options: List of option objects (Labels, Annotations, etc.).
-        default_name: Default resource name to use when no Name option is provided.
-
-    Returns:
-        Tuple of (resource_name, filtered_options):
-        - resource_name: Name from the Name option, or the provided default name.
-        - filtered_options: Options list with the Name option removed.
-    """
-    if not options:
-        return default_name, []
-
-    name = default_name
-    filtered_options = []
-
-    for option in options:
-        if isinstance(option, Name):
-            name = option.name
-        else:
-            filtered_options.append(option)
-
-    return name, filtered_options
-
-
 def apply_options(
     resource: models.SparkV1alpha1SparkConnect | models.SparkV1beta2SparkApplication,
     options: list | None,
@@ -340,8 +309,11 @@ def apply_options(
         backend:
             Backend used for option validation.
     """
-    if not options or backend is None:
+    if not options:
         return
+
+    if backend is None:
+        raise ValueError("A backend instance is required to apply Spark options.")
 
     for option in options:
         if callable(option):
@@ -775,6 +747,7 @@ def get_spark_application_cr_from_file_job(
         num_executors: Number of executor instances.
         resources_per_executor: Resource requirements for each executor.
         options: List of configuration options.
+        backend: Backend instance used for option validation.
 
     Returns:
         SparkApplication custom resource model.
@@ -834,6 +807,7 @@ def get_spark_application_cr_from_func_job(
         num_executors: Number of executor instances.
         resources_per_executor: Resource requirements for each executor.
         options: List of configuration options.
+        backend: Backend instance used for option validation.
 
     Returns:
         SparkApplication custom resource model.

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -44,8 +44,8 @@ from kubeflow.spark.backends.kubernetes.utils import (
     read_pod_logs,
     validate_spark_connect_url,
 )
+from kubeflow.spark.options import Labels
 from kubeflow.spark.test.common import FAILED, SUCCESS, TestCase
-from kubeflow.spark.types.options import Labels
 from kubeflow.spark.types.types import (
     Driver,
     Executor,

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -99,13 +99,6 @@ def mock_k8s_backend():
 
 
 @pytest.fixture
-def mock_non_k8s_backend():
-    """Create a mock non-Kubernetes backend."""
-    backend = Mock()
-    return backend
-
-
-@pytest.fixture
 def spark_connect_resource(minimal_spec):
     """Creates a minimal SparkConnect resource."""
     return models.SparkV1alpha1SparkConnect(
@@ -243,6 +236,28 @@ def test_generate_session_name(test_case: TestCase) -> None:
             },
         ),
         TestCase(
+            name="missing backend",
+            expected_status=FAILED,
+            expected_error=ValueError,
+            expected_output="backend instance is required",
+            config={
+                "options": [
+                    Labels({"team": "ml"}),
+                ],
+                "backend": None,
+            },
+        ),
+        TestCase(
+            name="non callable option",
+            expected_status=FAILED,
+            expected_error=TypeError,
+            expected_output="Options must be callable",
+            config={
+                "options": ["not-a-callable"],
+                "backend": "k8s",
+            },
+        ),
+        TestCase(
             name="empty options",
             expected_status=SUCCESS,
             config={
@@ -260,10 +275,26 @@ def test_apply_options(
 
     print("Executing test:", test_case.name)
 
+    backend = mock_k8s_backend if test_case.config.get("backend", "k8s") == "k8s" else None
+
+    if test_case.expected_status == FAILED:
+        with pytest.raises(
+            test_case.expected_error,
+            match=test_case.expected_output,
+        ):
+            apply_options(
+                spark_connect_resource,
+                test_case.config["options"],
+                backend,
+            )
+
+        print("test execution complete")
+        return
+
     apply_options(
         spark_connect_resource,
         test_case.config["options"],
-        mock_k8s_backend,
+        backend,
     )
 
     assert test_case.expected_status == SUCCESS
@@ -271,7 +302,8 @@ def test_apply_options(
     if test_case.name == "apply label option":
         assert spark_connect_resource.metadata.labels["team"] == "ml"
 
-    print("test execution complete")
+
+print("test execution complete")
 
 
 @pytest.mark.parametrize(
@@ -1395,7 +1427,7 @@ def test_get_spark_application_cr_from_file_job(test_case: TestCase, mock_k8s_ba
                 "name": "test-job",
                 "namespace": "default",
                 "func": sample_function,
-                "func_args": [1, 2],
+                "func_args": {"a": 1, "b": 2},
                 "num_executors": 3,
                 "resources_per_executor": {
                     "cpu": "2",

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -31,7 +31,6 @@ from kubeflow.spark.backends.kubernetes.utils import (
     apply_options,
     build_service_url,
     build_spark_connect_cr,
-    extract_name_option,
     generate_job_name,
     generate_session_name,
     get_command_using_spark_func,
@@ -46,7 +45,7 @@ from kubeflow.spark.backends.kubernetes.utils import (
     validate_spark_connect_url,
 )
 from kubeflow.spark.test.common import FAILED, SUCCESS, TestCase
-from kubeflow.spark.types.options import Labels, Name
+from kubeflow.spark.types.options import Labels
 from kubeflow.spark.types.types import (
     Driver,
     Executor,
@@ -222,76 +221,6 @@ def test_generate_session_name(test_case: TestCase) -> None:
         assert len(names) == test_case.expected_output
 
     print("test execution complete")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        TestCase(
-            name="name option provided",
-            expected_status=SUCCESS,
-            config={
-                "options": [
-                    Name("custom-name"),
-                    Labels({"app": "spark"}),
-                ],
-                "default_name": "generated-name",
-            },
-            expected_output={
-                "name": "custom-name",
-                "remaining_count": 1,
-            },
-        ),
-        TestCase(
-            name="no name option",
-            expected_status=SUCCESS,
-            config={
-                "options": [
-                    Labels({"app": "spark"}),
-                ],
-                "default_name": "generated-name",
-            },
-            expected_output={
-                "name": "generated-name",
-                "remaining_count": 1,
-            },
-        ),
-        TestCase(
-            name="none options",
-            expected_status=SUCCESS,
-            config={
-                "options": None,
-                "default_name": "generated-name",
-            },
-            expected_output={
-                "name": "generated-name",
-                "remaining_count": 0,
-            },
-        ),
-        TestCase(
-            name="empty options",
-            expected_status=SUCCESS,
-            config={
-                "options": [],
-                "default_name": "generated-name",
-            },
-            expected_output={
-                "name": "generated-name",
-                "remaining_count": 0,
-            },
-        ),
-    ],
-)
-def test_extract_name_option(test_case: TestCase) -> None:
-    """Tests extract_name_option."""
-
-    name, filtered = extract_name_option(
-        test_case.config["options"],
-        test_case.config["default_name"],
-    )
-
-    assert name == test_case.expected_output["name"]
-    assert len(filtered) == test_case.expected_output["remaining_count"]
 
 
 @pytest.mark.parametrize(

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -22,11 +22,13 @@ from kubeflow_spark_api import models
 import pytest
 
 from kubeflow.spark.backends.kubernetes import constants
+from kubeflow.spark.types.options import Labels, Name
 from kubeflow.spark.backends.kubernetes.utils import (
     _memory_kubernetes_to_spark,
     _resolve_driver_resources,
     _resolve_executor_resources,
     _validate_cpu_value,
+    extract_name_option,
     build_service_url,
     build_spark_connect_cr,
     generate_job_name,
@@ -192,6 +194,74 @@ def test_generate_session_name(test_case: TestCase) -> None:
 
     print("test execution complete")
 
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="name option provided",
+            expected_status=SUCCESS,
+            config={
+                "options": [
+                    Name("custom-name"),
+                    Labels({"app": "spark"}),
+                ],
+                "default_name": "generated-name",
+            },
+            expected_output={
+                "name": "custom-name",
+                "remaining_count": 1,
+            },
+        ),
+        TestCase(
+            name="no name option",
+            expected_status=SUCCESS,
+            config={
+                "options": [
+                    Labels({"app": "spark"}),
+                ],
+                "default_name": "generated-name",
+            },
+            expected_output={
+                "name": "generated-name",
+                "remaining_count": 1,
+            },
+        ),
+        TestCase(
+            name="none options",
+            expected_status=SUCCESS,
+            config={
+                "options": None,
+                "default_name": "generated-name",
+            },
+            expected_output={
+                "name": "generated-name",
+                "remaining_count": 0,
+            },
+        ),
+        TestCase(
+            name="empty options",
+            expected_status=SUCCESS,
+            config={
+                "options": [],
+                "default_name": "generated-name",
+            },
+            expected_output={
+                "name": "generated-name",
+                "remaining_count": 0,
+            },
+        ),
+    ],
+)
+def test_extract_name_option(test_case: TestCase) -> None:
+    """Tests extract_name_option."""
+
+    name, filtered = extract_name_option(
+        test_case.config["options"],
+        test_case.config["default_name"],
+    )
+
+    assert name == test_case.expected_output["name"]
+    assert len(filtered) == test_case.expected_output["remaining_count"]
 
 @pytest.mark.parametrize(
     "test_case",

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -22,15 +22,16 @@ from kubeflow_spark_api import models
 import pytest
 
 from kubeflow.spark.backends.kubernetes import constants
-from kubeflow.spark.types.options import Labels, Name
+from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
 from kubeflow.spark.backends.kubernetes.utils import (
     _memory_kubernetes_to_spark,
     _resolve_driver_resources,
     _resolve_executor_resources,
     _validate_cpu_value,
-    extract_name_option,
+    apply_options,
     build_service_url,
     build_spark_connect_cr,
+    extract_name_option,
     generate_job_name,
     generate_session_name,
     get_command_using_spark_func,
@@ -45,6 +46,7 @@ from kubeflow.spark.backends.kubernetes.utils import (
     validate_spark_connect_url,
 )
 from kubeflow.spark.test.common import FAILED, SUCCESS, TestCase
+from kubeflow.spark.types.options import Labels, Name
 from kubeflow.spark.types.types import (
     Driver,
     Executor,
@@ -86,6 +88,33 @@ def spark_application_spec():
             memory="2g",
             instances=5,
         ),
+    )
+
+
+@pytest.fixture
+def mock_k8s_backend():
+    """Create a mock KubernetesBackend."""
+    backend = Mock(spec=KubernetesBackend)
+    backend.__class__ = KubernetesBackend
+    return backend
+
+
+@pytest.fixture
+def mock_non_k8s_backend():
+    """Create a mock non-Kubernetes backend."""
+    backend = Mock()
+    return backend
+
+
+@pytest.fixture
+def spark_connect_resource(minimal_spec):
+    """Creates a minimal SparkConnect resource."""
+    return models.SparkV1alpha1SparkConnect(
+        metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+            name="test-session",
+            namespace="default",
+        ),
+        spec=minimal_spec,
     )
 
 
@@ -194,6 +223,7 @@ def test_generate_session_name(test_case: TestCase) -> None:
 
     print("test execution complete")
 
+
 @pytest.mark.parametrize(
     "test_case",
     [
@@ -262,6 +292,58 @@ def test_extract_name_option(test_case: TestCase) -> None:
 
     assert name == test_case.expected_output["name"]
     assert len(filtered) == test_case.expected_output["remaining_count"]
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="apply label option",
+            expected_status=SUCCESS,
+            config={
+                "options": [
+                    Labels({"team": "ml"}),
+                ],
+            },
+        ),
+        TestCase(
+            name="none options",
+            expected_status=SUCCESS,
+            config={
+                "options": None,
+            },
+        ),
+        TestCase(
+            name="empty options",
+            expected_status=SUCCESS,
+            config={
+                "options": [],
+            },
+        ),
+    ],
+)
+def test_apply_options(
+    test_case: TestCase,
+    spark_connect_resource,
+    mock_k8s_backend,
+) -> None:
+    """Tests apply_options."""
+
+    print("Executing test:", test_case.name)
+
+    apply_options(
+        spark_connect_resource,
+        test_case.config["options"],
+        mock_k8s_backend,
+    )
+
+    assert test_case.expected_status == SUCCESS
+
+    if test_case.name == "apply label option":
+        assert spark_connect_resource.metadata.labels["team"] == "ml"
+
+    print("test execution complete")
+
 
 @pytest.mark.parametrize(
     "test_case",
@@ -487,6 +569,15 @@ def test_build_service_url(test_case: TestCase) -> None:
             },
         ),
         TestCase(
+            name="spark connect cr with options",
+            expected_status=SUCCESS,
+            config={
+                "options": [
+                    Labels({"team": "ml"}),
+                ],
+            },
+        ),
+        TestCase(
             name="kep107 level3 advanced mode",
             expected_status=SUCCESS,
             config={
@@ -508,14 +599,19 @@ def test_build_service_url(test_case: TestCase) -> None:
         ),
     ],
 )
-def test_build_spark_connect_cr(test_case: TestCase) -> None:
+def test_build_spark_connect_cr(test_case: TestCase, mock_k8s_backend) -> None:
     """Tests build_spark_connect_cr."""
     print("Executing test:", test_case.name)
+
+    config = dict(test_case.config)
+
+    if "options" in config:
+        config["backend"] = mock_k8s_backend
 
     spark_connect = build_spark_connect_cr(
         name="test-session",
         namespace="default",
-        **test_case.config,
+        **config,
     )
 
     assert test_case.expected_status == SUCCESS
@@ -594,6 +690,9 @@ def test_build_spark_connect_cr(test_case: TestCase) -> None:
         assert spark_connect.spec.executor.instances == 20
         assert spark_connect.spec.executor.cores == 8
         assert spark_connect.spec.executor.memory == "32g"
+
+    elif test_case.name == "spark connect cr with options":
+        assert spark_connect.metadata.labels["team"] == "ml"
 
     print("test execution complete")
 
@@ -1281,9 +1380,27 @@ def test_get_spark_job_executor_spec(test_case: TestCase) -> None:
                 },
             },
         ),
+        TestCase(
+            name="build spark application with options",
+            expected_status=SUCCESS,
+            config={
+                "name": "test-job",
+                "namespace": "default",
+                "main_file": "s3://bucket/job.py",
+                "arguments": ["--date", "2026-06-30"],
+                "num_executors": 3,
+                "resources_per_executor": {
+                    "cpu": "2",
+                    "memory": "4Gi",
+                },
+                "options": [
+                    Labels({"team": "ml"}),
+                ],
+            },
+        ),
     ],
 )
-def test_get_spark_application_cr_from_file_job(test_case: TestCase) -> None:
+def test_get_spark_application_cr_from_file_job(test_case: TestCase, mock_k8s_backend) -> None:
     """Tests build_spark_application_cr."""
 
     print("Executing test:", test_case.name)
@@ -1295,6 +1412,8 @@ def test_get_spark_application_cr_from_file_job(test_case: TestCase) -> None:
         arguments=test_case.config["arguments"],
         num_executors=test_case.config["num_executors"],
         resources_per_executor=test_case.config["resources_per_executor"],
+        options=test_case.config.get("options"),
+        backend=mock_k8s_backend,
     )
 
     assert test_case.expected_status == SUCCESS
@@ -1316,6 +1435,8 @@ def test_get_spark_application_cr_from_file_job(test_case: TestCase) -> None:
     assert app.spec.executor.memory == _memory_kubernetes_to_spark(
         "4Gi",
     )
+    if test_case.name == "build spark application with options":
+        assert app.metadata.labels["team"] == "ml"
 
     print("test execution complete")
 
@@ -1338,10 +1459,29 @@ def test_get_spark_application_cr_from_file_job(test_case: TestCase) -> None:
                 },
             },
         ),
+        TestCase(
+            name="build spark application from function with options",
+            expected_status=SUCCESS,
+            config={
+                "name": "test-job",
+                "namespace": "default",
+                "func": sample_function,
+                "func_args": [1, 2],
+                "num_executors": 3,
+                "resources_per_executor": {
+                    "cpu": "2",
+                    "memory": "4Gi",
+                },
+                "options": [
+                    Labels({"team": "ml"}),
+                ],
+            },
+        ),
     ],
 )
 def test_get_spark_application_cr_from_func_job(
     test_case: TestCase,
+    mock_k8s_backend,
 ) -> None:
     """Tests get_spark_application_cr_from_func_job."""
 
@@ -1354,6 +1494,8 @@ def test_get_spark_application_cr_from_func_job(
         func_args=test_case.config["func_args"],
         num_executors=test_case.config["num_executors"],
         resources_per_executor=test_case.config["resources_per_executor"],
+        options=test_case.config.get("options"),
+        backend=mock_k8s_backend,
     )
 
     assert test_case.expected_status == SUCCESS
@@ -1378,6 +1520,9 @@ def test_get_spark_application_cr_from_func_job(
     assert app.spec.executor.instances == 3
     assert app.spec.executor.cores == 2
     assert app.spec.executor.memory == "4g"
+
+    if test_case.name == "build spark application from function with options":
+        assert app.metadata.labels["team"] == "ml"
 
     print("test execution complete")
 

--- a/kubeflow/spark/options/__init__.py
+++ b/kubeflow/spark/options/__init__.py
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Public API for the Kubeflow Spark client and types. Import from kubeflow.spark."""
+"""Spark configuration options."""
 
-from kubeflow.common.types import KubernetesBackendConfig
-from kubeflow.spark.api.spark_client import SparkClient
-from kubeflow.spark.options import (
+from kubeflow.spark.options.kubernetes import (
     Annotations,
     Labels,
     Name,
@@ -24,36 +22,12 @@ from kubeflow.spark.options import (
     PodTemplateOverride,
     Toleration,
 )
-from kubeflow.spark.types.types import (
-    Driver,
-    Executor,
-    FileJob,
-    FuncJob,
-    SparkConnectInfo,
-    SparkConnectState,
-    SparkJob,
-    SparkJobStatus,
-)
 
 __all__ = [
-    # Core API
-    "SparkClient",
-    # Types
-    "Driver",
-    "Executor",
-    "FileJob",
-    "FuncJob",
-    "SparkConnectInfo",
-    "SparkConnectState",
-    "SparkJob",
-    "SparkJobStatus",
-    # Options (KEP-107 extensibility pattern - callable pattern like trainer SDK)
     "Annotations",
     "Labels",
     "Name",
     "NodeSelector",
     "PodTemplateOverride",
     "Toleration",
-    # Configuration
-    "KubernetesBackendConfig",
 ]

--- a/kubeflow/spark/options/kubernetes.py
+++ b/kubeflow/spark/options/kubernetes.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The Kubeflow Authors.
+# Copyright The Kubeflow Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kubeflow/spark/options/kubernetes_test.py
+++ b/kubeflow/spark/options/kubernetes_test.py
@@ -21,8 +21,7 @@ import pytest
 
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
-from kubeflow.spark.test.common import FAILED, SUCCESS, TestCase
-from kubeflow.spark.types.options import (
+from kubeflow.spark.options import (
     Annotations,
     Labels,
     Name,
@@ -30,6 +29,7 @@ from kubeflow.spark.types.options import (
     PodTemplateOverride,
     Toleration,
 )
+from kubeflow.spark.test.common import FAILED, SUCCESS, TestCase
 
 
 @pytest.fixture

--- a/kubeflow/spark/types/options.py
+++ b/kubeflow/spark/types/options.py
@@ -21,86 +21,13 @@ This follows the same callable pattern as kubeflow.trainer.options for SDK consi
 """
 
 from dataclasses import dataclass
-import math
-import re
 from typing import Any
 
 from kubeflow_spark_api import models
 
 from kubeflow.spark.backends.base import RuntimeBackend
-from kubeflow.spark.backends.kubernetes.constants import (
-    DEFAULT_DRIVER_CPU,
-    DEFAULT_DRIVER_MEMORY,
-    DEFAULT_EXECUTOR_CPU,
-    DEFAULT_EXECUTOR_MEMORY,
-    DEFAULT_NUM_EXECUTORS,
-)
-from kubeflow.spark.types.types import Driver as BaseDriver, Executor as BaseExecutor
 
 SparkResource = models.SparkV1alpha1SparkConnect | models.SparkV1beta2SparkApplication
-
-
-# NOTE:
-# This helper intentionally mirrors the Kubernetes backend implementation.
-# It is duplicated here to avoid a circular import between the options module
-# and backend utilities.
-def _convert_kubernetes_memory_to_spark(memory: str) -> str:
-    """Convert Kubernetes-style memory values to Spark-compatible memory values.
-
-    Spark accepts integer memory values with JVM suffixes (k, m, g, t, p).
-    Kubernetes quantities may contain fractional values (for example, ``1.5Gi``),
-    so fractional values are converted to an equivalent MiB value.
-
-    Args:
-        memory: Memory value using Kubernetes or Spark notation.
-
-    Returns:
-        Memory value formatted using Spark-compatible units. If the input format
-        is not recognized, the original value is returned.
-    """
-    if not memory or not memory[-1].isalpha():
-        return memory
-
-    match = re.match(
-        r"^(\d+(?:\.\d+)?)\s*([KMGTPE]i?|[kmgtp]b?)$",
-        memory,
-        re.IGNORECASE,
-    )
-    if not match:
-        return memory
-
-    coefficient, suffix = match.group(1), (match.group(2) or "").lower()
-
-    exponent_by_suffix = {
-        "ki": 10,
-        "k": 10,
-        "kb": 10,
-        "mi": 20,
-        "m": 20,
-        "mb": 20,
-        "gi": 30,
-        "g": 30,
-        "gb": 30,
-        "ti": 40,
-        "t": 40,
-        "tb": 40,
-        "pi": 50,
-        "p": 50,
-        "pb": 50,
-        "ei": 60,
-    }
-
-    if suffix not in exponent_by_suffix:
-        return memory
-
-    exponent = exponent_by_suffix[suffix]
-
-    spark_suffix = {10: "k", 20: "m", 30: "g", 40: "t", 50: "p"}.get(exponent)
-    if "." not in coefficient and spark_suffix is not None:
-        return coefficient + spark_suffix
-
-    total_bytes = math.ceil(float(coefficient) * (2**exponent))
-    return f"{math.ceil(total_bytes / (2**20))}m"
 
 
 @dataclass
@@ -355,7 +282,7 @@ class NodeSelector:
 
                 role_spec.template.spec.node_selector.update(self.selectors)
 
-        else:
+        elif isinstance(resource, models.SparkV1beta2SparkApplication):
             role_specs = [
                 resource.spec.driver,
                 resource.spec.executor,
@@ -366,6 +293,8 @@ class NodeSelector:
                     role_spec.node_selector = {}
 
                 role_spec.node_selector.update(self.selectors)
+        else:
+            raise TypeError(f"Unsupported Spark resource type: {type(resource).__name__}")
 
 
 @dataclass
@@ -446,7 +375,7 @@ class Toleration:
 
                 role_spec.template.spec.tolerations.append(toleration)
 
-        else:
+        elif isinstance(resource, models.SparkV1beta2SparkApplication):
             role_specs = [
                 resource.spec.driver,
                 resource.spec.executor,
@@ -457,14 +386,19 @@ class Toleration:
                     role_spec.tolerations = []
 
                 role_spec.tolerations.append(toleration)
+        else:
+            raise TypeError(f"Unsupported Spark resource type: {type(resource).__name__}")
 
 
 @dataclass
 class Name:
     """Set a custom name for the Spark resource.
 
-    This option sets the session name which becomes the Kubernetes resource name.
-    If not provided, a name will be auto-generated with format: spark-connect-{uuid}
+    This option sets the Kubernetes resource name.
+
+    If not provided, a name is automatically generated:
+    - Spark Connect sessions: `spark-connect-{uuid}`
+    - Spark batch jobs: `spark-job-{uuid}`
 
     The session name must follow DNS-1123 subdomain rules:
     - Lowercase alphanumeric characters, '-', or '.'
@@ -490,19 +424,12 @@ class Name:
         # Auto-generated name
         spark = client.connect()  # Creates "spark-connect-a1b2c3d4"
         ```
-
-    Note:
-        This option is extracted early in the backend flow before CRD building,
-        unlike other options which modify the CRD after it's built.
     """
 
     name: str
 
     def __call__(self, resource: SparkResource, backend: RuntimeBackend) -> None:
         """Apply custom name to the Spark resource metadata.
-
-        Note: This method exists for interface consistency but is not typically
-        called, as the name is extracted earlier in the backend flow.
 
         Args:
             resource: Spark resource to modify.
@@ -520,118 +447,3 @@ class Name:
             )
 
         resource.metadata.name = self.name
-
-
-@dataclass
-class DriverOption(BaseDriver):
-    """Configure the SparkApplication driver.
-
-    This option customizes the driver configuration for Spark batch jobs.
-
-    Supported backends:
-        - Kubernetes
-
-    Args:
-        image: Custom container image for the driver.
-        resources: Resource requirements as a dictionary.
-        java_options: JVM options for the driver.
-        service_account: Kubernetes service account for the driver.
-    """
-
-    def __call__(
-        self,
-        resource: SparkResource,
-        backend: RuntimeBackend,
-    ) -> None:
-        """Apply driver configuration to a SparkApplication.
-
-        Args:
-            resource: Spark resource to modify.
-            backend: Backend instance for validation.
-
-        Raises:
-            ValueError: If backend does not support driver configuration.
-        """
-        from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
-
-        if not isinstance(backend, KubernetesBackend):
-            raise ValueError(
-                f"Driver option is not compatible with {type(backend).__name__}. "
-                f"Supported backends: KubernetesBackend"
-            )
-
-        if not isinstance(resource, models.SparkV1beta2SparkApplication):
-            return
-
-        resources = self.resources or {}
-
-        cores = int(resources.get("cpu", DEFAULT_DRIVER_CPU))
-        memory = _convert_kubernetes_memory_to_spark(resources.get("memory", DEFAULT_DRIVER_MEMORY))
-
-        resource.spec.driver.cores = cores
-        resource.spec.driver.memory = memory
-
-        if self.service_account is not None:
-            resource.spec.driver.service_account = self.service_account
-
-        if self.java_options is not None:
-            resource.spec.driver.java_options = self.java_options
-
-        if self.image is not None:
-            resource.spec.image = self.image
-
-
-@dataclass
-class ExecutorOption(BaseExecutor):
-    """Configure the SparkApplication executors.
-
-    This option customizes the executor configuration for Spark batch jobs.
-
-    Supported backends:
-        - Kubernetes
-
-    Args:
-        num_instances: Number of executor instances.
-        resources_per_executor: Resource requirements for each executor.
-        java_options: JVM options for executors.
-    """
-
-    def __call__(
-        self,
-        resource: SparkResource,
-        backend: RuntimeBackend,
-    ) -> None:
-        """Apply executor configuration to a SparkApplication.
-
-        Args:
-            resource: Spark resource to modify.
-            backend: Backend instance for validation.
-
-        Raises:
-            ValueError: If backend does not support executor configuration.
-        """
-        from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
-
-        if not isinstance(backend, KubernetesBackend):
-            raise ValueError(
-                f"Executor option is not compatible with {type(backend).__name__}. "
-                f"Supported backends: KubernetesBackend"
-            )
-
-        if not isinstance(resource, models.SparkV1beta2SparkApplication):
-            return
-
-        resources = self.resources_per_executor or {}
-
-        instances = self.num_instances if self.num_instances is not None else DEFAULT_NUM_EXECUTORS
-        cores = int(resources.get("cpu", DEFAULT_EXECUTOR_CPU))
-        memory = _convert_kubernetes_memory_to_spark(
-            resources.get("memory", DEFAULT_EXECUTOR_MEMORY)
-        )
-
-        resource.spec.executor.instances = instances
-        resource.spec.executor.cores = cores
-        resource.spec.executor.memory = memory
-
-        if self.java_options is not None:
-            resource.spec.executor.java_options = self.java_options

--- a/kubeflow/spark/types/options.py
+++ b/kubeflow/spark/types/options.py
@@ -21,11 +21,86 @@ This follows the same callable pattern as kubeflow.trainer.options for SDK consi
 """
 
 from dataclasses import dataclass
+import math
+import re
 from typing import Any
 
 from kubeflow_spark_api import models
 
 from kubeflow.spark.backends.base import RuntimeBackend
+from kubeflow.spark.backends.kubernetes.constants import (
+    DEFAULT_DRIVER_CPU,
+    DEFAULT_DRIVER_MEMORY,
+    DEFAULT_EXECUTOR_CPU,
+    DEFAULT_EXECUTOR_MEMORY,
+    DEFAULT_NUM_EXECUTORS,
+)
+from kubeflow.spark.types.types import Driver as BaseDriver, Executor as BaseExecutor
+
+SparkResource = models.SparkV1alpha1SparkConnect | models.SparkV1beta2SparkApplication
+
+
+# NOTE:
+# This helper intentionally mirrors the Kubernetes backend implementation.
+# It is duplicated here to avoid a circular import between the options module
+# and backend utilities.
+def _convert_kubernetes_memory_to_spark(memory: str) -> str:
+    """Convert Kubernetes-style memory values to Spark-compatible memory values.
+
+    Spark accepts integer memory values with JVM suffixes (k, m, g, t, p).
+    Kubernetes quantities may contain fractional values (for example, ``1.5Gi``),
+    so fractional values are converted to an equivalent MiB value.
+
+    Args:
+        memory: Memory value using Kubernetes or Spark notation.
+
+    Returns:
+        Memory value formatted using Spark-compatible units. If the input format
+        is not recognized, the original value is returned.
+    """
+    if not memory or not memory[-1].isalpha():
+        return memory
+
+    match = re.match(
+        r"^(\d+(?:\.\d+)?)\s*([KMGTPE]i?|[kmgtp]b?)$",
+        memory,
+        re.IGNORECASE,
+    )
+    if not match:
+        return memory
+
+    coefficient, suffix = match.group(1), (match.group(2) or "").lower()
+
+    exponent_by_suffix = {
+        "ki": 10,
+        "k": 10,
+        "kb": 10,
+        "mi": 20,
+        "m": 20,
+        "mb": 20,
+        "gi": 30,
+        "g": 30,
+        "gb": 30,
+        "ti": 40,
+        "t": 40,
+        "tb": 40,
+        "pi": 50,
+        "p": 50,
+        "pb": 50,
+        "ei": 60,
+    }
+
+    if suffix not in exponent_by_suffix:
+        return memory
+
+    exponent = exponent_by_suffix[suffix]
+
+    spark_suffix = {10: "k", 20: "m", 30: "g", 40: "t", 50: "p"}.get(exponent)
+    if "." not in coefficient and spark_suffix is not None:
+        return coefficient + spark_suffix
+
+    total_bytes = math.ceil(float(coefficient) * (2**exponent))
+    return f"{math.ceil(total_bytes / (2**20))}m"
 
 
 @dataclass
@@ -48,13 +123,11 @@ class Labels:
 
     labels: dict[str, str]
 
-    def __call__(
-        self, spark_connect: models.SparkV1alpha1SparkConnect, backend: RuntimeBackend
-    ) -> None:
-        """Apply labels to the SparkConnect model.
+    def __call__(self, resource: SparkResource, backend: RuntimeBackend) -> None:
+        """Apply labels to the Spark resource.
 
         Args:
-            spark_connect: SparkConnect model to modify.
+            resource: Spark resource to modify.
             backend: Backend instance for validation.
 
         Raises:
@@ -68,9 +141,9 @@ class Labels:
                 f"Supported backends: KubernetesBackend"
             )
 
-        if spark_connect.metadata.labels is None:
-            spark_connect.metadata.labels = {}
-        spark_connect.metadata.labels.update(self.labels)
+        if resource.metadata.labels is None:
+            resource.metadata.labels = {}
+        resource.metadata.labels.update(self.labels)
 
 
 @dataclass
@@ -98,13 +171,11 @@ class Annotations:
 
     annotations: dict[str, str]
 
-    def __call__(
-        self, spark_connect: models.SparkV1alpha1SparkConnect, backend: RuntimeBackend
-    ) -> None:
-        """Apply annotations to the SparkConnect model.
+    def __call__(self, resource: SparkResource, backend: RuntimeBackend) -> None:
+        """Apply annotations to the Spark resource.
 
         Args:
-            spark_connect: SparkConnect model to modify.
+            resource: Spark resource to modify.
             backend: Backend instance for validation.
 
         Raises:
@@ -118,9 +189,9 @@ class Annotations:
                 f"Supported backends: KubernetesBackend"
             )
 
-        if spark_connect.metadata.annotations is None:
-            spark_connect.metadata.annotations = {}
-        spark_connect.metadata.annotations.update(self.annotations)
+        if resource.metadata.annotations is None:
+            resource.metadata.annotations = {}
+        resource.metadata.annotations.update(self.annotations)
 
 
 @dataclass
@@ -145,10 +216,10 @@ class PodTemplateOverride:
                     "spec": {
                         "securityContext": {
                             "runAsUser": 1000,
-                            "fsGroup": 1000
+                            "fsGroup": 1000,
                         }
                     }
-                }
+                },
             )
         ]
         spark = client.connect(..., options=options)
@@ -162,29 +233,35 @@ class PodTemplateOverride:
     template: dict[str, Any]
 
     def __call__(
-        self, spark_connect: models.SparkV1alpha1SparkConnect, backend: RuntimeBackend
+        self,
+        resource: SparkResource,
+        backend: RuntimeBackend,
     ) -> None:
         """Apply pod template override to the SparkConnect model.
 
         Args:
-            spark_connect: SparkConnect model to modify.
+            resource: Spark resource to modify.
             backend: Backend instance for validation.
 
         Raises:
-            ValueError: If backend does not support pod template overrides or invalid role.
+            ValueError: If backend does not support pod template overrides,
+                the resource is not SparkConnect, or the role is invalid.
         """
         from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
 
         if not isinstance(backend, KubernetesBackend):
             raise ValueError(
-                f"PodTemplateOverride option is not compatible with {type(backend).__name__}. "
-                f"Supported backends: KubernetesBackend"
+                f"PodTemplateOverride option is not compatible with "
+                f"{type(backend).__name__}. Supported backends: KubernetesBackend"
             )
 
+        if not isinstance(resource, models.SparkV1alpha1SparkConnect):
+            raise ValueError("PodTemplateOverride is currently supported only for SparkConnect.")
+
         if self.role == "driver":
-            role_spec = spark_connect.spec.server
+            role_spec = resource.spec.server
         elif self.role == "executor":
-            role_spec = spark_connect.spec.executor
+            role_spec = resource.spec.executor
         else:
             raise ValueError(f"Invalid role '{self.role}'. Must be 'driver' or 'executor'.")
 
@@ -241,13 +318,11 @@ class NodeSelector:
 
     selectors: dict[str, str]
 
-    def __call__(
-        self, spark_connect: models.SparkV1alpha1SparkConnect, backend: RuntimeBackend
-    ) -> None:
-        """Apply node selector constraints to the SparkConnect model.
+    def __call__(self, resource: SparkResource, backend: RuntimeBackend) -> None:
+        """Apply node selector constraints to the Spark resource.
 
         Args:
-            spark_connect: SparkConnect model to modify.
+            resource: Spark resource to modify.
             backend: Backend instance for validation.
 
         Raises:
@@ -262,15 +337,35 @@ class NodeSelector:
             )
 
         # Apply to both server and executor
-        for role_spec in [spark_connect.spec.server, spark_connect.spec.executor]:
-            if role_spec.template is None:
-                role_spec.template = models.IoK8sApiCoreV1PodTemplateSpec()
-            if role_spec.template.spec is None:
-                # PodSpec requires containers field (can be empty list)
-                role_spec.template.spec = models.IoK8sApiCoreV1PodSpec(containers=[])
-            if role_spec.template.spec.node_selector is None:
-                role_spec.template.spec.node_selector = {}
-            role_spec.template.spec.node_selector.update(self.selectors)
+        if isinstance(resource, models.SparkV1alpha1SparkConnect):
+            role_specs = [
+                resource.spec.server,
+                resource.spec.executor,
+            ]
+
+            for role_spec in role_specs:
+                if role_spec.template is None:
+                    role_spec.template = models.IoK8sApiCoreV1PodTemplateSpec()
+
+                if role_spec.template.spec is None:
+                    role_spec.template.spec = models.IoK8sApiCoreV1PodSpec(containers=[])
+
+                if role_spec.template.spec.node_selector is None:
+                    role_spec.template.spec.node_selector = {}
+
+                role_spec.template.spec.node_selector.update(self.selectors)
+
+        else:
+            role_specs = [
+                resource.spec.driver,
+                resource.spec.executor,
+            ]
+
+            for role_spec in role_specs:
+                if role_spec.node_selector is None:
+                    role_spec.node_selector = {}
+
+                role_spec.node_selector.update(self.selectors)
 
 
 @dataclass
@@ -306,13 +401,11 @@ class Toleration:
     value: str = ""
     effect: str = "NoSchedule"
 
-    def __call__(
-        self, spark_connect: models.SparkV1alpha1SparkConnect, backend: RuntimeBackend
-    ) -> None:
-        """Apply toleration to the SparkConnect model.
+    def __call__(self, resource: SparkResource, backend: RuntimeBackend) -> None:
+        """Apply toleration to the Spark resource.
 
         Args:
-            spark_connect: SparkConnect model to modify.
+            resource: Spark resource to modify.
             backend: Backend instance for validation.
 
         Raises:
@@ -335,20 +428,40 @@ class Toleration:
         )
 
         # Apply to both server and executor
-        for role_spec in [spark_connect.spec.server, spark_connect.spec.executor]:
-            if role_spec.template is None:
-                role_spec.template = models.IoK8sApiCoreV1PodTemplateSpec()
-            if role_spec.template.spec is None:
-                # PodSpec requires containers field (can be empty list)
-                role_spec.template.spec = models.IoK8sApiCoreV1PodSpec(containers=[])
-            if role_spec.template.spec.tolerations is None:
-                role_spec.template.spec.tolerations = []
-            role_spec.template.spec.tolerations.append(toleration)
+        if isinstance(resource, models.SparkV1alpha1SparkConnect):
+            role_specs = [
+                resource.spec.server,
+                resource.spec.executor,
+            ]
+
+            for role_spec in role_specs:
+                if role_spec.template is None:
+                    role_spec.template = models.IoK8sApiCoreV1PodTemplateSpec()
+
+                if role_spec.template.spec is None:
+                    role_spec.template.spec = models.IoK8sApiCoreV1PodSpec(containers=[])
+
+                if role_spec.template.spec.tolerations is None:
+                    role_spec.template.spec.tolerations = []
+
+                role_spec.template.spec.tolerations.append(toleration)
+
+        else:
+            role_specs = [
+                resource.spec.driver,
+                resource.spec.executor,
+            ]
+
+            for role_spec in role_specs:
+                if role_spec.tolerations is None:
+                    role_spec.tolerations = []
+
+                role_spec.tolerations.append(toleration)
 
 
 @dataclass
 class Name:
-    """Set a custom name for the SparkConnect session.
+    """Set a custom name for the Spark resource.
 
     This option sets the session name which becomes the Kubernetes resource name.
     If not provided, a name will be auto-generated with format: spark-connect-{uuid}
@@ -385,16 +498,14 @@ class Name:
 
     name: str
 
-    def __call__(
-        self, spark_connect: models.SparkV1alpha1SparkConnect, backend: RuntimeBackend
-    ) -> None:
-        """Apply custom name to SparkConnect metadata.
+    def __call__(self, resource: SparkResource, backend: RuntimeBackend) -> None:
+        """Apply custom name to the Spark resource metadata.
 
         Note: This method exists for interface consistency but is not typically
         called, as the name is extracted earlier in the backend flow.
 
         Args:
-            spark_connect: SparkConnect model to modify.
+            resource: Spark resource to modify.
             backend: Backend instance for validation.
 
         Raises:
@@ -408,4 +519,119 @@ class Name:
                 f"Supported backends: KubernetesBackend"
             )
 
-        spark_connect.metadata.name = self.name
+        resource.metadata.name = self.name
+
+
+@dataclass
+class DriverOption(BaseDriver):
+    """Configure the SparkApplication driver.
+
+    This option customizes the driver configuration for Spark batch jobs.
+
+    Supported backends:
+        - Kubernetes
+
+    Args:
+        image: Custom container image for the driver.
+        resources: Resource requirements as a dictionary.
+        java_options: JVM options for the driver.
+        service_account: Kubernetes service account for the driver.
+    """
+
+    def __call__(
+        self,
+        resource: SparkResource,
+        backend: RuntimeBackend,
+    ) -> None:
+        """Apply driver configuration to a SparkApplication.
+
+        Args:
+            resource: Spark resource to modify.
+            backend: Backend instance for validation.
+
+        Raises:
+            ValueError: If backend does not support driver configuration.
+        """
+        from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"Driver option is not compatible with {type(backend).__name__}. "
+                f"Supported backends: KubernetesBackend"
+            )
+
+        if not isinstance(resource, models.SparkV1beta2SparkApplication):
+            return
+
+        resources = self.resources or {}
+
+        cores = int(resources.get("cpu", DEFAULT_DRIVER_CPU))
+        memory = _convert_kubernetes_memory_to_spark(resources.get("memory", DEFAULT_DRIVER_MEMORY))
+
+        resource.spec.driver.cores = cores
+        resource.spec.driver.memory = memory
+
+        if self.service_account is not None:
+            resource.spec.driver.service_account = self.service_account
+
+        if self.java_options is not None:
+            resource.spec.driver.java_options = self.java_options
+
+        if self.image is not None:
+            resource.spec.image = self.image
+
+
+@dataclass
+class ExecutorOption(BaseExecutor):
+    """Configure the SparkApplication executors.
+
+    This option customizes the executor configuration for Spark batch jobs.
+
+    Supported backends:
+        - Kubernetes
+
+    Args:
+        num_instances: Number of executor instances.
+        resources_per_executor: Resource requirements for each executor.
+        java_options: JVM options for executors.
+    """
+
+    def __call__(
+        self,
+        resource: SparkResource,
+        backend: RuntimeBackend,
+    ) -> None:
+        """Apply executor configuration to a SparkApplication.
+
+        Args:
+            resource: Spark resource to modify.
+            backend: Backend instance for validation.
+
+        Raises:
+            ValueError: If backend does not support executor configuration.
+        """
+        from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
+
+        if not isinstance(backend, KubernetesBackend):
+            raise ValueError(
+                f"Executor option is not compatible with {type(backend).__name__}. "
+                f"Supported backends: KubernetesBackend"
+            )
+
+        if not isinstance(resource, models.SparkV1beta2SparkApplication):
+            return
+
+        resources = self.resources_per_executor or {}
+
+        instances = self.num_instances if self.num_instances is not None else DEFAULT_NUM_EXECUTORS
+        cores = int(resources.get("cpu", DEFAULT_EXECUTOR_CPU))
+        memory = _convert_kubernetes_memory_to_spark(
+            resources.get("memory", DEFAULT_EXECUTOR_MEMORY)
+        )
+
+        resource.spec.executor.instances = instances
+        resource.spec.executor.cores = cores
+        resource.spec.executor.memory = memory
+
+        if self.java_options is not None:
+            resource.spec.executor.java_options = self.java_options

--- a/kubeflow/spark/types/options.py
+++ b/kubeflow/spark/types/options.py
@@ -123,13 +123,20 @@ class Annotations:
 
 @dataclass
 class PodTemplateOverride:
-    """Override pod template specifications for driver or executors.
+    """Override pod template specifications for Spark Connect driver or executors.
 
     Provides full control over Kubernetes pod specifications for advanced use cases
     like custom volumes, init containers, sidecars, or security contexts.
 
+    Supported resources:
+        - Spark Connect
+
     Supported backends:
         - Kubernetes
+
+    Note:
+        PodTemplateOverride is currently supported only for Spark Connect.
+        It is not supported for Spark batch jobs submitted with ``submit_job()``.
 
     Args:
         role: Target role ("driver" or "executor").
@@ -254,6 +261,8 @@ class NodeSelector:
 
         Raises:
             ValueError: If backend does not support node selectors.
+
+            TypeError: If the resource is not a supported Spark resource.
         """
         from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
 
@@ -339,6 +348,8 @@ class Toleration:
 
         Raises:
             ValueError: If backend does not support tolerations.
+
+            TypeError: If the resource is not a supported Spark resource.
         """
         from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
 

--- a/kubeflow/spark/types/options_test.py
+++ b/kubeflow/spark/types/options_test.py
@@ -352,12 +352,28 @@ def test_node_selector_applies_to_both_roles(
                 "node_selector": {
                     "node-type": "spark",
                 },
+                "resource": "connect",
+                "backend": "non-k8s",
+            },
+        ),
+        TestCase(
+            name="unsupported resource type",
+            expected_status=FAILED,
+            expected_error=TypeError,
+            expected_output="Unsupported Spark resource type",
+            config={
+                "node_selector": {
+                    "node-type": "spark",
+                },
+                "resource": "unsupported",
+                "backend": "k8s",
             },
         ),
     ],
 )
 def test_node_selector_incompatible_backend(
     test_case: TestCase,
+    mock_k8s_backend,
     mock_non_k8s_backend,
     spark_connect_model,
     spark_application_model,
@@ -368,12 +384,20 @@ def test_node_selector_incompatible_backend(
 
     option = NodeSelector(test_case.config["node_selector"])
 
-    for resource in [spark_connect_model, spark_application_model]:
-        with pytest.raises(
-            test_case.expected_error,
-            match=test_case.expected_output,
-        ):
-            option(resource, mock_non_k8s_backend)
+    backend = mock_k8s_backend if test_case.config["backend"] == "k8s" else mock_non_k8s_backend
+
+    if test_case.config["resource"] == "connect":
+        resource = spark_connect_model
+    elif test_case.config["resource"] == "application":
+        resource = spark_application_model
+    else:
+        resource = object()
+
+    with pytest.raises(
+        test_case.expected_error,
+        match=test_case.expected_output,
+    ):
+        option(resource, backend)
 
     print("test execution complete")
 
@@ -495,12 +519,27 @@ def test_toleration_without_value(
             config={
                 "key": "test",
                 "operator": "Exists",
+                "resource": "connect",
+                "backend": "non-k8s",
+            },
+        ),
+        TestCase(
+            name="unsupported resource type",
+            expected_status=FAILED,
+            expected_error=TypeError,
+            expected_output="Unsupported Spark resource type",
+            config={
+                "key": "test",
+                "operator": "Exists",
+                "resource": "unsupported",
+                "backend": "k8s",
             },
         ),
     ],
 )
 def test_toleration_incompatible_backend(
     test_case: TestCase,
+    mock_k8s_backend,
     mock_non_k8s_backend,
     spark_connect_model,
     spark_application_model,
@@ -514,12 +553,20 @@ def test_toleration_incompatible_backend(
         operator=test_case.config["operator"],
     )
 
-    for resource in [spark_connect_model, spark_application_model]:
-        with pytest.raises(
-            test_case.expected_error,
-            match=test_case.expected_output,
-        ):
-            option(resource, mock_non_k8s_backend)
+    backend = mock_k8s_backend if test_case.config["backend"] == "k8s" else mock_non_k8s_backend
+
+    if test_case.config["resource"] == "connect":
+        resource = spark_connect_model
+    elif test_case.config["resource"] == "application":
+        resource = spark_application_model
+    else:
+        resource = object()
+
+    with pytest.raises(
+        test_case.expected_error,
+        match=test_case.expected_output,
+    ):
+        option(resource, backend)
 
     print("test execution complete")
 
@@ -601,6 +648,18 @@ def test_pod_template_override(
             config={
                 "role": "invalid",
                 "template": {"spec": {}},
+                "resource": "connect",
+            },
+        ),
+        TestCase(
+            name="spark application not supported",
+            expected_status=FAILED,
+            expected_error=ValueError,
+            expected_output="currently supported only for SparkConnect",
+            config={
+                "role": "driver",
+                "template": {"spec": {}},
+                "resource": "application",
             },
         ),
     ],
@@ -620,11 +679,17 @@ def test_pod_template_invalid_role(
         template=test_case.config["template"],
     )
 
+    resource = (
+        spark_connect_model
+        if test_case.config["resource"] == "connect"
+        else spark_application_model
+    )
+
     with pytest.raises(
         test_case.expected_error,
         match=test_case.expected_output,
     ):
-        option(spark_connect_model, mock_k8s_backend)
+        option(resource, mock_k8s_backend)
 
     print("test execution complete")
 

--- a/kubeflow/spark/types/options_test.py
+++ b/kubeflow/spark/types/options_test.py
@@ -21,17 +21,15 @@ import pytest
 
 from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
+from kubeflow.spark.test.common import FAILED, SUCCESS, TestCase
 from kubeflow.spark.types.options import (
     Annotations,
-    DriverOption,
-    ExecutorOption,
     Labels,
     Name,
     NodeSelector,
     PodTemplateOverride,
     Toleration,
 )
-from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
 
 
 @pytest.fixture
@@ -761,162 +759,5 @@ def test_name_option_incompatible_backend(
             match=test_case.expected_output,
         ):
             option(resource, mock_non_k8s_backend)
-
-    print("test execution complete")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        TestCase(
-            name="apply driver option",
-            expected_status=SUCCESS,
-            config={
-                "image": "spark:test",
-                "resources": {
-                    "cpu": "2",
-                    "memory": "1Gi",
-                },
-                "java_options": "-XX:+UseG1GC",
-                "service_account": "spark-driver",
-            },
-        ),
-    ],
-)
-def test_driver_option_apply(
-    test_case: TestCase,
-    mock_k8s_backend,
-    spark_application_model,
-):
-    """Test DriverOption."""
-
-    print("Executing test:", test_case.name)
-
-    option = DriverOption(
-        image=test_case.config["image"],
-        resources=test_case.config["resources"],
-        java_options=test_case.config["java_options"],
-        service_account=test_case.config["service_account"],
-    )
-
-    option(spark_application_model, mock_k8s_backend)
-
-    assert spark_application_model.spec.image == test_case.config["image"]
-    assert spark_application_model.spec.driver.cores == 2
-    assert spark_application_model.spec.driver.memory == "1g"
-    assert spark_application_model.spec.driver.java_options == test_case.config["java_options"]
-    assert (
-        spark_application_model.spec.driver.service_account == test_case.config["service_account"]
-    )
-
-    assert test_case.expected_status == SUCCESS
-
-    print("test execution complete")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        TestCase(
-            name="incompatible backend",
-            expected_status=FAILED,
-            expected_error=ValueError,
-            expected_output="not compatible",
-            config={},
-        ),
-    ],
-)
-def test_driver_option_incompatible_backend(
-    test_case: TestCase,
-    mock_non_k8s_backend,
-    spark_application_model,
-):
-    """Test DriverOption with incompatible backend."""
-
-    print("Executing test:", test_case.name)
-
-    option = DriverOption()
-
-    with pytest.raises(
-        test_case.expected_error,
-        match=test_case.expected_output,
-    ):
-        option(spark_application_model, mock_non_k8s_backend)
-
-    print("test execution complete")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        TestCase(
-            name="apply executor option",
-            expected_status=SUCCESS,
-            config={
-                "num_instances": 3,
-                "resources_per_executor": {
-                    "cpu": "2",
-                    "memory": "512Mi",
-                },
-                "java_options": "-XX:+UseG1GC",
-            },
-        ),
-    ],
-)
-def test_executor_option_apply(
-    test_case: TestCase,
-    mock_k8s_backend,
-    spark_application_model,
-):
-    """Test ExecutorOption."""
-
-    print("Executing test:", test_case.name)
-
-    option = ExecutorOption(
-        num_instances=test_case.config["num_instances"],
-        resources_per_executor=test_case.config["resources_per_executor"],
-        java_options=test_case.config["java_options"],
-    )
-
-    option(spark_application_model, mock_k8s_backend)
-
-    assert spark_application_model.spec.executor.instances == test_case.config["num_instances"]
-    assert spark_application_model.spec.executor.cores == 2
-    assert spark_application_model.spec.executor.memory == "512m"
-    assert spark_application_model.spec.executor.java_options == test_case.config["java_options"]
-
-    assert test_case.expected_status == SUCCESS
-
-    print("test execution complete")
-
-
-@pytest.mark.parametrize(
-    "test_case",
-    [
-        TestCase(
-            name="incompatible backend",
-            expected_status=FAILED,
-            expected_error=ValueError,
-            expected_output="not compatible",
-            config={},
-        ),
-    ],
-)
-def test_executor_option_incompatible_backend(
-    test_case: TestCase,
-    mock_non_k8s_backend,
-    spark_application_model,
-):
-    """Test ExecutorOption with incompatible backend."""
-
-    print("Executing test:", test_case.name)
-
-    option = ExecutorOption()
-
-    with pytest.raises(
-        test_case.expected_error,
-        match=test_case.expected_output,
-    ):
-        option(spark_application_model, mock_non_k8s_backend)
 
     print("test execution complete")

--- a/kubeflow/spark/types/options_test.py
+++ b/kubeflow/spark/types/options_test.py
@@ -23,12 +23,15 @@ from kubeflow.spark.backends.kubernetes import constants
 from kubeflow.spark.backends.kubernetes.backend import KubernetesBackend
 from kubeflow.spark.types.options import (
     Annotations,
+    DriverOption,
+    ExecutorOption,
     Labels,
     Name,
     NodeSelector,
     PodTemplateOverride,
     Toleration,
 )
+from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
 
 
 @pytest.fixture
@@ -74,205 +77,846 @@ def spark_connect_model():
     )
 
 
-class TestLabels:
-    """Tests for Labels option."""
-
-    def test_labels_apply_to_crd(self, mock_k8s_backend, spark_connect_model):
-        """Labels option adds labels to CRD metadata."""
-        option = Labels({"app": "spark", "team": "data-eng"})
-
-        option(spark_connect_model, mock_k8s_backend)
-
-        assert spark_connect_model.metadata.labels["app"] == "spark"
-        assert spark_connect_model.metadata.labels["team"] == "data-eng"
-
-    def test_labels_merge_with_existing(self, mock_k8s_backend, spark_connect_model):
-        """Labels option merges with existing labels."""
-        spark_connect_model.metadata.labels = {"existing": "label"}
-        option = Labels({"new-label": "value"})
-
-        option(spark_connect_model, mock_k8s_backend)
-
-        assert spark_connect_model.metadata.labels["existing"] == "label"
-        assert spark_connect_model.metadata.labels["new-label"] == "value"
-
-    def test_labels_incompatible_backend(self, mock_non_k8s_backend, spark_connect_model):
-        """Labels option raises error for incompatible backend."""
-        option = Labels({"app": "spark"})
-
-        with pytest.raises(ValueError, match="not compatible"):
-            option(spark_connect_model, mock_non_k8s_backend)
+@pytest.fixture
+def spark_application_model():
+    """Create a minimal SparkApplication model for testing."""
+    return models.SparkV1beta2SparkApplication(
+        api_version=f"{constants.SPARK_APPLICATION_GROUP}/{constants.SPARK_APPLICATION_VERSION}",
+        kind=constants.SPARK_APPLICATION_KIND,
+        metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+            name="test-job",
+            namespace="default",
+        ),
+        spec=models.SparkV1beta2SparkApplicationSpec(
+            spark_version=constants.DEFAULT_SPARK_VERSION,
+            type="Python",
+            mode="cluster",
+            image=constants.DEFAULT_SPARK_IMAGE,
+            mainApplicationFile="local:///opt/spark/examples/pi.py",
+            driver=models.SparkV1beta2DriverSpec(),
+            executor=models.SparkV1beta2ExecutorSpec(),
+        ),
+    )
 
 
-class TestAnnotations:
-    """Tests for Annotations option."""
-
-    def test_annotations_apply_to_crd(self, mock_k8s_backend, spark_connect_model):
-        """Annotations option adds annotations to CRD metadata."""
-        option = Annotations({"description": "ETL pipeline", "owner": "data-team"})
-
-        option(spark_connect_model, mock_k8s_backend)
-
-        assert spark_connect_model.metadata.annotations["description"] == "ETL pipeline"
-        assert spark_connect_model.metadata.annotations["owner"] == "data-team"
-
-    def test_annotations_incompatible_backend(self, mock_non_k8s_backend, spark_connect_model):
-        """Annotations option raises error for incompatible backend."""
-        option = Annotations({"description": "test"})
-
-        with pytest.raises(ValueError, match="not compatible"):
-            option(spark_connect_model, mock_non_k8s_backend)
-
-
-class TestNodeSelector:
-    """Tests for NodeSelector option."""
-
-    def test_node_selector_applies_to_both_roles(self, mock_k8s_backend, spark_connect_model):
-        """NodeSelector option adds selectors to both driver and executor."""
-        option = NodeSelector({"node-type": "spark", "gpu": "true"})
-
-        option(spark_connect_model, mock_k8s_backend)
-
-        # Check server (driver)
-        server_node_selector = spark_connect_model.spec.server.template.spec.node_selector
-        assert server_node_selector["node-type"] == "spark"
-        assert server_node_selector["gpu"] == "true"
-        # Check executor
-        executor_node_selector = spark_connect_model.spec.executor.template.spec.node_selector
-        assert executor_node_selector["node-type"] == "spark"
-        assert executor_node_selector["gpu"] == "true"
-
-    def test_node_selector_incompatible_backend(self, mock_non_k8s_backend, spark_connect_model):
-        """NodeSelector option raises error for incompatible backend."""
-        option = NodeSelector({"node-type": "spark"})
-
-        with pytest.raises(ValueError, match="not compatible"):
-            option(spark_connect_model, mock_non_k8s_backend)
-
-
-class TestToleration:
-    """Tests for Toleration option."""
-
-    def test_toleration_with_value(self, mock_k8s_backend, spark_connect_model):
-        """Toleration option with value."""
-        option = Toleration(
-            key="spark-workload",
-            operator="Equal",
-            value="true",
-            effect="NoSchedule",
-        )
-
-        option(spark_connect_model, mock_k8s_backend)
-
-        tolerations = spark_connect_model.spec.server.template.spec.tolerations
-        assert len(tolerations) == 1
-        assert tolerations[0].key == "spark-workload"
-        assert tolerations[0].operator == "Equal"
-        assert tolerations[0].value == "true"
-        assert tolerations[0].effect == "NoSchedule"
-
-    def test_toleration_without_value(self, mock_k8s_backend, spark_connect_model):
-        """Toleration option without value (operator=Exists)."""
-        option = Toleration(
-            key="dedicated",
-            operator="Exists",
-            effect="NoSchedule",
-        )
-
-        option(spark_connect_model, mock_k8s_backend)
-
-        tolerations = spark_connect_model.spec.server.template.spec.tolerations
-        assert len(tolerations) == 1
-        assert tolerations[0].key == "dedicated"
-        assert tolerations[0].operator == "Exists"
-        assert tolerations[0].value is None  # Value is None when empty
-        assert tolerations[0].effect == "NoSchedule"
-
-    def test_toleration_incompatible_backend(self, mock_non_k8s_backend, spark_connect_model):
-        """Toleration option raises error for incompatible backend."""
-        option = Toleration(key="test", operator="Exists")
-
-        with pytest.raises(ValueError, match="not compatible"):
-            option(spark_connect_model, mock_non_k8s_backend)
-
-
-class TestPodTemplateOverride:
-    """Tests for PodTemplateOverride option."""
-
-    def test_pod_template_driver(self, mock_k8s_backend, spark_connect_model):
-        """PodTemplateOverride applies to driver."""
-        option = PodTemplateOverride(
-            role="driver",
-            template={
-                "spec": {
-                    "securityContext": {
-                        "runAsUser": 1000,
-                        "fsGroup": 1000,
-                    }
-                }
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="apply labels",
+            expected_status=SUCCESS,
+            config={
+                "labels": {
+                    "app": "spark",
+                    "team": "data-eng",
+                },
             },
-        )
+        ),
+    ],
+)
+def test_labels_apply_to_crd(
+    test_case: TestCase,
+    mock_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test Labels option."""
 
-        option(spark_connect_model, mock_k8s_backend)
+    print("Executing test:", test_case.name)
 
-        # Convert to dict to verify merged template
-        crd = spark_connect_model.to_dict()
-        assert crd["spec"]["server"]["template"]["spec"]["securityContext"]["runAsUser"] == 1000
-        assert crd["spec"]["server"]["template"]["spec"]["securityContext"]["fsGroup"] == 1000
+    option = Labels(test_case.config["labels"])
 
-    def test_pod_template_executor(self, mock_k8s_backend, spark_connect_model):
-        """PodTemplateOverride applies to executor."""
-        option = PodTemplateOverride(
-            role="executor",
-            template={
-                "spec": {
-                    "securityContext": {
-                        "runAsUser": 1000,
-                    }
-                }
+    for resource in [spark_connect_model, spark_application_model]:
+        option(resource, mock_k8s_backend)
+
+        for key, value in test_case.config["labels"].items():
+            assert resource.metadata.labels[key] == value
+
+    assert test_case.expected_status == SUCCESS
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="merge labels",
+            expected_status=SUCCESS,
+            config={
+                "existing_labels": {
+                    "existing": "label",
+                },
+                "new_labels": {
+                    "new-label": "value",
+                },
             },
-        )
+        ),
+    ],
+)
+def test_labels_merge_with_existing(
+    test_case: TestCase,
+    mock_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test Labels option merging."""
 
+    print("Executing test:", test_case.name)
+
+    for resource in [spark_connect_model, spark_application_model]:
+        resource.metadata.labels = test_case.config["existing_labels"].copy()
+
+        option = Labels(test_case.config["new_labels"])
+        option(resource, mock_k8s_backend)
+
+        assert resource.metadata.labels["existing"] == "label"
+        assert resource.metadata.labels["new-label"] == "value"
+
+    assert test_case.expected_status == SUCCESS
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="incompatible backend",
+            expected_status=FAILED,
+            expected_error=ValueError,
+            expected_output="not compatible",
+            config={
+                "labels": {
+                    "app": "spark",
+                },
+            },
+        ),
+    ],
+)
+def test_labels_incompatible_backend(
+    test_case: TestCase,
+    mock_non_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test Labels option with incompatible backend."""
+
+    print("Executing test:", test_case.name)
+
+    option = Labels(test_case.config["labels"])
+
+    for resource in [spark_connect_model, spark_application_model]:
+        with pytest.raises(
+            test_case.expected_error,
+            match=test_case.expected_output,
+        ):
+            option(resource, mock_non_k8s_backend)
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="apply annotations",
+            expected_status=SUCCESS,
+            config={
+                "annotations": {
+                    "description": "ETL pipeline",
+                    "owner": "data-team",
+                },
+            },
+        ),
+    ],
+)
+def test_annotations_apply_to_crd(
+    test_case: TestCase,
+    mock_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test Annotations option."""
+
+    print("Executing test:", test_case.name)
+
+    option = Annotations(test_case.config["annotations"])
+
+    for resource in [spark_connect_model, spark_application_model]:
+        option(resource, mock_k8s_backend)
+
+        for key, value in test_case.config["annotations"].items():
+            assert resource.metadata.annotations[key] == value
+
+    assert test_case.expected_status == SUCCESS
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="incompatible backend",
+            expected_status=FAILED,
+            expected_error=ValueError,
+            expected_output="not compatible",
+            config={
+                "annotations": {
+                    "description": "test",
+                },
+            },
+        ),
+    ],
+)
+def test_annotations_incompatible_backend(
+    test_case: TestCase,
+    mock_non_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test Annotations option with incompatible backend."""
+
+    print("Executing test:", test_case.name)
+
+    option = Annotations(test_case.config["annotations"])
+
+    for resource in [spark_connect_model, spark_application_model]:
+        with pytest.raises(
+            test_case.expected_error,
+            match=test_case.expected_output,
+        ):
+            option(resource, mock_non_k8s_backend)
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="apply node selector",
+            expected_status=SUCCESS,
+            config={
+                "node_selector": {
+                    "node-type": "spark",
+                    "gpu": "true",
+                },
+            },
+        ),
+    ],
+)
+def test_node_selector_applies_to_both_roles(
+    test_case: TestCase,
+    mock_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test NodeSelector option."""
+
+    print("Executing test:", test_case.name)
+
+    option = NodeSelector(test_case.config["node_selector"])
+
+    option(spark_connect_model, mock_k8s_backend)
+    option(spark_application_model, mock_k8s_backend)
+
+    connect_server = spark_connect_model.spec.server.template.spec.node_selector
+    connect_executor = spark_connect_model.spec.executor.template.spec.node_selector
+
+    app_driver = spark_application_model.spec.driver.node_selector
+    app_executor = spark_application_model.spec.executor.node_selector
+
+    for node_selector in [
+        connect_server,
+        connect_executor,
+        app_driver,
+        app_executor,
+    ]:
+        for key, value in test_case.config["node_selector"].items():
+            assert node_selector[key] == value
+
+    assert test_case.expected_status == SUCCESS
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="incompatible backend",
+            expected_status=FAILED,
+            expected_error=ValueError,
+            expected_output="not compatible",
+            config={
+                "node_selector": {
+                    "node-type": "spark",
+                },
+            },
+        ),
+    ],
+)
+def test_node_selector_incompatible_backend(
+    test_case: TestCase,
+    mock_non_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test NodeSelector option with incompatible backend."""
+
+    print("Executing test:", test_case.name)
+
+    option = NodeSelector(test_case.config["node_selector"])
+
+    for resource in [spark_connect_model, spark_application_model]:
+        with pytest.raises(
+            test_case.expected_error,
+            match=test_case.expected_output,
+        ):
+            option(resource, mock_non_k8s_backend)
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="toleration with value",
+            expected_status=SUCCESS,
+            config={
+                "key": "spark-workload",
+                "operator": "Equal",
+                "value": "true",
+                "effect": "NoSchedule",
+            },
+        ),
+    ],
+)
+def test_toleration_with_value(
+    test_case: TestCase,
+    mock_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test Toleration option with value."""
+
+    print("Executing test:", test_case.name)
+
+    option = Toleration(
+        key=test_case.config["key"],
+        operator=test_case.config["operator"],
+        value=test_case.config["value"],
+        effect=test_case.config["effect"],
+    )
+
+    option(spark_connect_model, mock_k8s_backend)
+    option(spark_application_model, mock_k8s_backend)
+
+    connect_server_tolerations = spark_connect_model.spec.server.template.spec.tolerations
+    connect_executor_tolerations = spark_connect_model.spec.executor.template.spec.tolerations
+
+    app_driver_tolerations = spark_application_model.spec.driver.tolerations
+    app_executor_tolerations = spark_application_model.spec.executor.tolerations
+
+    for tolerations in [
+        connect_server_tolerations,
+        connect_executor_tolerations,
+        app_driver_tolerations,
+        app_executor_tolerations,
+    ]:
+        assert len(tolerations) == 1
+        assert tolerations[0].key == test_case.config["key"]
+        assert tolerations[0].operator == test_case.config["operator"]
+        assert tolerations[0].value == test_case.config["value"]
+        assert tolerations[0].effect == test_case.config["effect"]
+
+    assert test_case.expected_status == SUCCESS
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="toleration without value",
+            expected_status=SUCCESS,
+            config={
+                "key": "dedicated",
+                "operator": "Exists",
+                "effect": "NoSchedule",
+            },
+        ),
+    ],
+)
+def test_toleration_without_value(
+    test_case: TestCase,
+    mock_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test Toleration option without value."""
+
+    print("Executing test:", test_case.name)
+
+    option = Toleration(
+        key=test_case.config["key"],
+        operator=test_case.config["operator"],
+        effect=test_case.config["effect"],
+    )
+
+    option(spark_connect_model, mock_k8s_backend)
+    option(spark_application_model, mock_k8s_backend)
+
+    connect_tolerations = spark_connect_model.spec.server.template.spec.tolerations
+    app_tolerations = spark_application_model.spec.driver.tolerations
+
+    for tolerations in [connect_tolerations, app_tolerations]:
+        assert len(tolerations) == 1
+        assert tolerations[0].key == test_case.config["key"]
+        assert tolerations[0].operator == test_case.config["operator"]
+        assert tolerations[0].value is None
+        assert tolerations[0].effect == test_case.config["effect"]
+
+    assert test_case.expected_status == SUCCESS
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="incompatible backend",
+            expected_status=FAILED,
+            expected_error=ValueError,
+            expected_output="not compatible",
+            config={
+                "key": "test",
+                "operator": "Exists",
+            },
+        ),
+    ],
+)
+def test_toleration_incompatible_backend(
+    test_case: TestCase,
+    mock_non_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test Toleration option with incompatible backend."""
+
+    print("Executing test:", test_case.name)
+
+    option = Toleration(
+        key=test_case.config["key"],
+        operator=test_case.config["operator"],
+    )
+
+    for resource in [spark_connect_model, spark_application_model]:
+        with pytest.raises(
+            test_case.expected_error,
+            match=test_case.expected_output,
+        ):
+            option(resource, mock_non_k8s_backend)
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="driver pod template",
+            expected_status=SUCCESS,
+            config={
+                "role": "driver",
+                "template": {
+                    "spec": {
+                        "securityContext": {
+                            "runAsUser": 1000,
+                            "fsGroup": 1000,
+                        }
+                    }
+                },
+            },
+        ),
+        TestCase(
+            name="executor pod template",
+            expected_status=SUCCESS,
+            config={
+                "role": "executor",
+                "template": {
+                    "spec": {
+                        "securityContext": {
+                            "runAsUser": 1000,
+                        }
+                    }
+                },
+            },
+        ),
+    ],
+)
+def test_pod_template_override(
+    test_case: TestCase,
+    mock_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test PodTemplateOverride option."""
+
+    print("Executing test:", test_case.name)
+
+    option = PodTemplateOverride(
+        role=test_case.config["role"],
+        template=test_case.config["template"],
+    )
+
+    option(spark_connect_model, mock_k8s_backend)
+
+    connect_crd = spark_connect_model.to_dict()
+
+    if test_case.config["role"] == "driver":
+        security_context = connect_crd["spec"]["server"]["template"]["spec"]["securityContext"]
+    else:
+        security_context = connect_crd["spec"]["executor"]["template"]["spec"]["securityContext"]
+
+    for key, value in test_case.config["template"]["spec"]["securityContext"].items():
+        assert security_context[key] == value
+
+    assert test_case.expected_status == SUCCESS
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="invalid role",
+            expected_status=FAILED,
+            expected_error=ValueError,
+            expected_output="Invalid role",
+            config={
+                "role": "invalid",
+                "template": {"spec": {}},
+            },
+        ),
+    ],
+)
+def test_pod_template_invalid_role(
+    test_case: TestCase,
+    mock_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test PodTemplateOverride option with invalid role."""
+
+    print("Executing test:", test_case.name)
+
+    option = PodTemplateOverride(
+        role=test_case.config["role"],
+        template=test_case.config["template"],
+    )
+
+    with pytest.raises(
+        test_case.expected_error,
+        match=test_case.expected_output,
+    ):
         option(spark_connect_model, mock_k8s_backend)
 
-        # Convert to dict to verify merged template
-        crd = spark_connect_model.to_dict()
-        assert crd["spec"]["executor"]["template"]["spec"]["securityContext"]["runAsUser"] == 1000
-
-    def test_pod_template_invalid_role(self, mock_k8s_backend, spark_connect_model):
-        """PodTemplateOverride raises error for invalid role."""
-        option = PodTemplateOverride(role="invalid", template={"spec": {}})
-
-        with pytest.raises(ValueError, match="Invalid role"):
-            option(spark_connect_model, mock_k8s_backend)
-
-    def test_pod_template_incompatible_backend(self, mock_non_k8s_backend, spark_connect_model):
-        """PodTemplateOverride option raises error for incompatible backend."""
-        option = PodTemplateOverride(role="driver", template={"spec": {}})
-
-        with pytest.raises(ValueError, match="not compatible"):
-            option(spark_connect_model, mock_non_k8s_backend)
+    print("test execution complete")
 
 
-class TestNameOption:
-    """Tests for Name option."""
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="incompatible backend",
+            expected_status=FAILED,
+            expected_error=ValueError,
+            expected_output="not compatible",
+            config={
+                "role": "driver",
+                "template": {"spec": {}},
+            },
+        ),
+    ],
+)
+def test_pod_template_incompatible_backend(
+    test_case: TestCase,
+    mock_non_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test PodTemplateOverride option with incompatible backend."""
 
-    def test_name_option_basic(self):
-        """Create Name option with valid name."""
-        option = Name("my-custom-session")
-        assert option.name == "my-custom-session"
+    print("Executing test:", test_case.name)
 
-    def test_name_option_apply_to_crd(self, mock_k8s_backend, spark_connect_model):
-        """Apply Name option to CRD."""
-        option = Name("new-session-name")
+    option = PodTemplateOverride(
+        role=test_case.config["role"],
+        template=test_case.config["template"],
+    )
 
-        option(spark_connect_model, mock_k8s_backend)
+    for resource in [spark_connect_model, spark_application_model]:
+        with pytest.raises(
+            test_case.expected_error,
+            match=test_case.expected_output,
+        ):
+            option(resource, mock_non_k8s_backend)
 
-        assert spark_connect_model.metadata.name == "new-session-name"
+    print("test execution complete")
 
-    def test_name_option_incompatible_backend(self, mock_non_k8s_backend, spark_connect_model):
-        """Name option raises error for incompatible backend."""
-        option = Name("test-session")
 
-        with pytest.raises(ValueError, match="not compatible"):
-            option(spark_connect_model, mock_non_k8s_backend)
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="basic name option",
+            expected_status=SUCCESS,
+            config={
+                "name": "my-custom-session",
+            },
+        ),
+    ],
+)
+def test_name_option_basic(test_case: TestCase):
+    """Test Name option creation."""
+
+    print("Executing test:", test_case.name)
+
+    option = Name(test_case.config["name"])
+
+    assert option.name == test_case.config["name"]
+    assert test_case.expected_status == SUCCESS
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="apply name",
+            expected_status=SUCCESS,
+            config={
+                "name": "new-session-name",
+            },
+        ),
+    ],
+)
+def test_name_option_apply_to_crd(
+    test_case: TestCase,
+    mock_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test Name option."""
+
+    print("Executing test:", test_case.name)
+
+    option = Name(test_case.config["name"])
+
+    for resource in [spark_connect_model, spark_application_model]:
+        option(resource, mock_k8s_backend)
+        assert resource.metadata.name == test_case.config["name"]
+
+    assert test_case.expected_status == SUCCESS
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="incompatible backend",
+            expected_status=FAILED,
+            expected_error=ValueError,
+            expected_output="not compatible",
+            config={
+                "name": "test-session",
+            },
+        ),
+    ],
+)
+def test_name_option_incompatible_backend(
+    test_case: TestCase,
+    mock_non_k8s_backend,
+    spark_connect_model,
+    spark_application_model,
+):
+    """Test Name option with incompatible backend."""
+
+    print("Executing test:", test_case.name)
+
+    option = Name(test_case.config["name"])
+
+    for resource in [spark_connect_model, spark_application_model]:
+        with pytest.raises(
+            test_case.expected_error,
+            match=test_case.expected_output,
+        ):
+            option(resource, mock_non_k8s_backend)
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="apply driver option",
+            expected_status=SUCCESS,
+            config={
+                "image": "spark:test",
+                "resources": {
+                    "cpu": "2",
+                    "memory": "1Gi",
+                },
+                "java_options": "-XX:+UseG1GC",
+                "service_account": "spark-driver",
+            },
+        ),
+    ],
+)
+def test_driver_option_apply(
+    test_case: TestCase,
+    mock_k8s_backend,
+    spark_application_model,
+):
+    """Test DriverOption."""
+
+    print("Executing test:", test_case.name)
+
+    option = DriverOption(
+        image=test_case.config["image"],
+        resources=test_case.config["resources"],
+        java_options=test_case.config["java_options"],
+        service_account=test_case.config["service_account"],
+    )
+
+    option(spark_application_model, mock_k8s_backend)
+
+    assert spark_application_model.spec.image == test_case.config["image"]
+    assert spark_application_model.spec.driver.cores == 2
+    assert spark_application_model.spec.driver.memory == "1g"
+    assert spark_application_model.spec.driver.java_options == test_case.config["java_options"]
+    assert (
+        spark_application_model.spec.driver.service_account == test_case.config["service_account"]
+    )
+
+    assert test_case.expected_status == SUCCESS
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="incompatible backend",
+            expected_status=FAILED,
+            expected_error=ValueError,
+            expected_output="not compatible",
+            config={},
+        ),
+    ],
+)
+def test_driver_option_incompatible_backend(
+    test_case: TestCase,
+    mock_non_k8s_backend,
+    spark_application_model,
+):
+    """Test DriverOption with incompatible backend."""
+
+    print("Executing test:", test_case.name)
+
+    option = DriverOption()
+
+    with pytest.raises(
+        test_case.expected_error,
+        match=test_case.expected_output,
+    ):
+        option(spark_application_model, mock_non_k8s_backend)
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="apply executor option",
+            expected_status=SUCCESS,
+            config={
+                "num_instances": 3,
+                "resources_per_executor": {
+                    "cpu": "2",
+                    "memory": "512Mi",
+                },
+                "java_options": "-XX:+UseG1GC",
+            },
+        ),
+    ],
+)
+def test_executor_option_apply(
+    test_case: TestCase,
+    mock_k8s_backend,
+    spark_application_model,
+):
+    """Test ExecutorOption."""
+
+    print("Executing test:", test_case.name)
+
+    option = ExecutorOption(
+        num_instances=test_case.config["num_instances"],
+        resources_per_executor=test_case.config["resources_per_executor"],
+        java_options=test_case.config["java_options"],
+    )
+
+    option(spark_application_model, mock_k8s_backend)
+
+    assert spark_application_model.spec.executor.instances == test_case.config["num_instances"]
+    assert spark_application_model.spec.executor.cores == 2
+    assert spark_application_model.spec.executor.memory == "512m"
+    assert spark_application_model.spec.executor.java_options == test_case.config["java_options"]
+
+    assert test_case.expected_status == SUCCESS
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="incompatible backend",
+            expected_status=FAILED,
+            expected_error=ValueError,
+            expected_output="not compatible",
+            config={},
+        ),
+    ],
+)
+def test_executor_option_incompatible_backend(
+    test_case: TestCase,
+    mock_non_k8s_backend,
+    spark_application_model,
+):
+    """Test ExecutorOption with incompatible backend."""
+
+    print("Executing test:", test_case.name)
+
+    option = ExecutorOption()
+
+    with pytest.raises(
+        test_case.expected_error,
+        match=test_case.expected_output,
+    ):
+        option(spark_application_model, mock_non_k8s_backend)
+
+    print("test execution complete")

--- a/test/e2e/spark/test_spark_examples.py
+++ b/test/e2e/spark/test_spark_examples.py
@@ -24,7 +24,7 @@ import pytest
 
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark.backends.kubernetes import KubernetesBackend
-from kubeflow.spark.types.options import Name
+from kubeflow.spark.options import Name
 from kubeflow.spark.types.types import SparkConnectState
 
 from .cluster_watcher import run_watcher_in_thread

--- a/test/e2e/spark/test_spark_examples.py
+++ b/test/e2e/spark/test_spark_examples.py
@@ -245,3 +245,15 @@ class TestSparkExamples:
         stdout = self._run_example("batch_func_job_lifecycle.py", namespace)
 
         assert "FUNCJOB LIFECYCLE COMPLETE!" in stdout
+
+    def test_batch_job_options_example(self):
+        """EX07: Validate batch_job_options.py runs without errors."""
+        namespace = os.environ.get("SPARK_TEST_NAMESPACE", "spark-test")
+
+        if USE_IN_CLUSTER and RUNNER_IMAGE:
+            self._run_example("batch_job_options.py", namespace)
+            return
+
+        stdout = self._run_example("batch_job_options.py", namespace)
+
+        assert "BATCH JOB OPTIONS COMPLETE!" in stdout


### PR DESCRIPTION
## Summary

This PR adds support for configuring SparkApplication jobs through the `options` parameter in `SparkClient.submit_job()`.

The following SparkApplication configurations are now supported through `options`:

- Labels
- Annotations
- NodeSelector
- Toleration
- DriverOption
- ExecutorOption

## Additional Changes

- Added unit tests covering the new functionality.
- Added an end-to-end example demonstrating SparkApplication configuration through `options`.

ref - #520 