### PR TITLE
feat(trainer): add tail_lines support to get_job_logs

### DIFF
--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -236,15 +236,16 @@ class TrainerClient:
         self,
         name: str,
         step: str = constants.NODE + "-0",
-        follow: bool | None = False,
+        follow: bool = False,
+        tail_lines: int | None = None,
     ) -> Iterator[str]:
         """Get logs from a specific step of a TrainJob.
 
         Args:
             name: Name of the TrainJob.
-            step: Step of the TrainJob to collect logs from, like "dataset-initializer"
-                or "node-0". Defaults to "node-0".
-            follow: Whether to stream logs in realtime as they are produced. Defaults to False.
+            step: Step of the TrainJob to collect logs from, like dataset-initializer or node-0.
+            follow: Whether to stream logs in realtime as they are produced.
+            tail_lines: Number of lines from the end of the logs to return. If None, returns all available logs.
 
         Returns:
             Iterator of log lines.
@@ -259,7 +260,7 @@ class TrainerClient:
             >>> for logline in client.get_job_logs(name="s8d44aa4fb6d", follow=True):
             ...     print(logline)
         """
-        return self.backend.get_job_logs(name=name, follow=follow, step=step)
+        return self.backend.get_job_logs(name=name, follow=follow, tail_lines=tail_lines, step=step)
 
     def get_job_events(self, name: str) -> list[types.Event]:
         """Get events for a TrainJob.

--- a/kubeflow/trainer/backends/base.py
+++ b/kubeflow/trainer/backends/base.py
@@ -63,6 +63,7 @@ class RuntimeBackend(abc.ABC):
         self,
         name: str,
         follow: bool = False,
+        tail_lines: int | None = None,
         step: str = constants.NODE + "-0",
     ) -> Iterator[str]:
         raise NotImplementedError()

--- a/kubeflow/trainer/backends/container/adapters/base.py
+++ b/kubeflow/trainer/backends/container/adapters/base.py
@@ -98,7 +98,12 @@ class BaseContainerClientAdapter(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def container_logs(self, container_id: str, follow: bool) -> Iterator[str]:
+    def container_logs(
+        self,
+        container_id: str,
+        follow: bool,
+        tail_lines: int | None = None,
+    ) -> Iterator[str]:
         """Stream logs from a container."""
         raise NotImplementedError()
 

--- a/kubeflow/trainer/backends/container/adapters/docker.py
+++ b/kubeflow/trainer/backends/container/adapters/docker.py
@@ -106,10 +106,19 @@ class DockerClientAdapter(BaseContainerClientAdapter):
         """Get Docker container by ID."""
         return self.client.containers.get(container_id)
 
-    def container_logs(self, container_id: str, follow: bool) -> Iterator[str]:
+    def container_logs(
+        self,
+        container_id: str,
+        follow: bool,
+        tail_lines: int | None = None,
+    ) -> Iterator[str]:
         """Stream logs from Docker container."""
         container = self.get_container(container_id)
-        logs = container.logs(stream=bool(follow), follow=bool(follow))
+        logs = container.logs(
+            stream=bool(follow),
+            follow=bool(follow),
+            tail="all" if tail_lines is None else tail_lines,
+        )
         if follow:
             for chunk in logs:
                 if isinstance(chunk, bytes):

--- a/kubeflow/trainer/backends/container/adapters/podman.py
+++ b/kubeflow/trainer/backends/container/adapters/podman.py
@@ -112,10 +112,19 @@ class PodmanClientAdapter(BaseContainerClientAdapter):
         """Get Podman container by ID."""
         return self.client.containers.get(container_id)
 
-    def container_logs(self, container_id: str, follow: bool) -> Iterator[str]:
+    def container_logs(
+        self,
+        container_id: str,
+        follow: bool,
+        tail_lines: int | None = None,
+    ) -> Iterator[str]:
         """Stream logs from Podman container."""
         container = self.get_container(container_id)
-        logs = container.logs(stream=bool(follow), follow=bool(follow))
+        logs = container.logs(
+            stream=bool(follow),
+            follow=bool(follow),
+            tail="all" if tail_lines is None else tail_lines,
+        )
         if follow:
             for chunk in logs:
                 if isinstance(chunk, bytes):

--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -778,6 +778,7 @@ class ContainerBackend(RuntimeBackend):
         self,
         name: str,
         follow: bool = False,
+        tail_lines: int | None = None,
         step: str = constants.NODE + "-0",
     ) -> Iterator[str]:
         """Get logs for a training job by querying container runtime."""
@@ -798,7 +799,11 @@ class ContainerBackend(RuntimeBackend):
                 continue
 
             try:
-                yield from self._adapter.container_logs(container["id"], follow)
+                yield from self._adapter.container_logs(
+                    container["id"],
+                    follow,
+                    tail_lines,
+                )
             except Exception as e:
                 logger.warning(f"Failed to get logs for {container['name']}: {e}")
                 yield f"Error getting logs: {e}\n"

--- a/kubeflow/trainer/backends/container/backend_test.py
+++ b/kubeflow/trainer/backends/container/backend_test.py
@@ -98,7 +98,12 @@ class MockContainerAdapter(BaseContainerClientAdapter):
                 return Mock(id=container_id, status=container["status"])
         return None
 
-    def container_logs(self, container_id: str, follow: bool) -> Iterator[str]:
+    def container_logs(
+        self,
+        container_id: str,
+        follow: bool,
+        tail_lines: int | None = None,
+    ) -> Iterator[str]:
         if follow:
             yield f"Log line 1 from {container_id}\n"
             yield f"Log line 2 from {container_id}\n"

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -449,6 +449,7 @@ class KubernetesBackend(RuntimeBackend):
         self,
         name: str,
         follow: bool = False,
+        tail_lines: int | None = None,
         step: str = constants.NODE + "-0",
     ) -> Iterator[str]:
         """Get the TrainJob logs"""
@@ -464,7 +465,10 @@ class KubernetesBackend(RuntimeBackend):
         # Remove the number for the node step.
         container_name = re.sub(r"-\d+$", "", step)
         yield from self._read_pod_logs(
-            pod_name=pod_name, container_name=container_name, follow=follow
+            pod_name=pod_name,
+            container_name=container_name,
+            follow=follow,
+            tail_lines=tail_lines,
         )
 
     def wait_for_job_status(
@@ -626,7 +630,13 @@ class KubernetesBackend(RuntimeBackend):
             ),
         )
 
-    def _read_pod_logs(self, pod_name: str, container_name: str, follow: bool) -> Iterator[str]:
+    def _read_pod_logs(
+        self,
+        pod_name: str,
+        container_name: str,
+        follow: bool,
+        tail_lines: int | None = None,
+    ) -> Iterator[str]:
         """Read logs from a pod container."""
         try:
             if follow:
@@ -636,6 +646,7 @@ class KubernetesBackend(RuntimeBackend):
                     namespace=self.namespace,
                     container=container_name,
                     follow=True,
+                    tail_lines=tail_lines,
                 )
 
                 # Stream logs incrementally.
@@ -645,6 +656,7 @@ class KubernetesBackend(RuntimeBackend):
                     name=pod_name,
                     namespace=self.namespace,
                     container=container_name,
+                    tail_lines=tail_lines,
                 )
 
                 yield from logs.splitlines()

--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -194,6 +194,7 @@ class LocalProcessBackend(RuntimeBackend):
         self,
         name: str,
         follow: bool = False,
+        tail_lines: int | None = None,
         step: str = constants.NODE + "-0",
     ) -> Iterator[str]:
         _job = [j for j in self.__local_jobs if j.name == name]
@@ -207,7 +208,10 @@ class LocalProcessBackend(RuntimeBackend):
                 continue
             # Flatten the generator and pass through flags so it behaves as expected
             # (adjust args if stream_logs has different signature)
-            yield from _step.job.logs(follow=follow)
+            yield from _step.job.logs(
+                follow=follow,
+                tail_lines=tail_lines,
+            )
 
     def get_job_events(self, name: str) -> list[types.Event]:
         raise NotImplementedError()

--- a/kubeflow/trainer/backends/localprocess/job.py
+++ b/kubeflow/trainer/backends/localprocess/job.py
@@ -149,9 +149,14 @@ class LocalJob(threading.Thread):
     def returncode(self):
         return self._returncode
 
-    def logs(self, follow=False) -> list[str]:
+    def logs(
+        self,
+        follow=False,
+        tail_lines: int | None = None,
+    ) -> list[str]:
         if not follow:
-            return self._stdout.splitlines()
+            lines = self._stdout.splitlines()
+            return lines if tail_lines is None else lines[-tail_lines:]
 
         try:
             for chunk in self.stream_logs():
@@ -159,7 +164,8 @@ class LocalJob(threading.Thread):
         except StopIteration:
             pass
 
-        return self._stdout.splitlines()
+        lines = self._stdout.splitlines()
+        return lines if tail_lines is None else lines[-tail_lines:]
 
     def stream_logs(self):
         """Generator that yields new output lines as they come in."""


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `tail_lines` support to `TrainerClient.get_job_logs()` and propagates it through all Trainer backends.

### Changes
- Add `tail_lines: int | None = None` to `TrainerClient.get_job_logs()`.
- Propagate the new parameter through the `RuntimeBackend` interface.
- Support `tail_lines` in the Kubernetes backend by forwarding it to the Kubernetes Pod Logs API.
- Support `tail_lines` in the Container backend and Docker/Podman adapters.
- Support `tail_lines` in the LocalProcess backend and `LocalJob.logs()`.
- Preserve existing behavior when `tail_lines` is not specified.

**Which issue(s) this PR fixes**:

Fixes #682

**Checklist:**

- [ ] Docs included if any changes are user facing