### PR TITLE
fix(spark): treat Spark Operator retry states as non-terminal

### DIFF
--- a/docs/source/spark/index.rst
+++ b/docs/source/spark/index.rst
@@ -78,6 +78,27 @@ Key Concepts
 
 **Spark Operator**: A Kubernetes controller that manages the lifecycle of Spark applications.
 
+Batch Job States
+----------------
+
+``SparkJob.status`` summarizes Spark Operator states for batch jobs:
+
+- ``CREATED``: The application is new or submitted.
+- ``RUNNING``: The application is running or succeeding.
+- ``RETRYING``: The operator is handling a submission or run failure that may be retried.
+- ``SUSPENDED``: The application is suspending, suspended, or resuming.
+- ``COMPLETED``: The application completed successfully.
+- ``FAILED``: The application reached the terminal operator ``FAILED`` state.
+- ``UNKNOWN``: The operator reported ``UNKNOWN`` or a state the SDK does not recognize.
+
+Only ``COMPLETED`` and ``FAILED`` are terminal Spark Operator states.
+``wait_for_job_status()`` continues polling through retry, suspension, and unknown states. It
+raises if the operator reaches ``FAILED`` unless ``FAILED`` is one of the requested target
+statuses.
+
+Use ``SparkJob.operator_state`` to inspect the exact Spark Operator state and
+``SparkJob.error_message`` to inspect the operator-provided error message when available.
+
 Common Patterns
 ---------------
 

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -1156,9 +1156,14 @@ class KubernetesBackend(RuntimeBackend):
 
         Raises:
             ValueError: If polling_interval is negative.
-            RuntimeError: If the SparkApplication reaches the FAILED state before reaching
-                one of the target statuses.
+            RuntimeError: If the SparkApplication reaches the terminal FAILED state before
+                reaching one of the target statuses.
             TimeoutError: If the target status is not reached within the timeout.
+
+        Note:
+            Only the terminal FAILED state aborts polling. Non-terminal states such as
+            RETRYING (the operator restart cycle) and UNKNOWN are polled through, so a job
+            that recovers via a retry is waited on until it reaches a target status.
         """
         if timeout <= 0:
             raise ValueError("timeout must be positive.")
@@ -1183,7 +1188,8 @@ class KubernetesBackend(RuntimeBackend):
                 return job
             if job.status == SparkJobStatus.FAILED and SparkJobStatus.FAILED not in status:
                 raise RuntimeError(
-                    f"Spark job reached failed state: {self.namespace}/{name}(status={job.status})"
+                    f"Spark job reached failed state: {self.namespace}/{name} "
+                    f"(status={job.status}, state={job.state}, error={job.error_message})"
                 )
 
             now = time.monotonic()

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -88,6 +88,7 @@ def get_spark_application(
     name: str,
     namespace: str = DEFAULT_NAMESPACE,
     state: str | None = "SUBMITTED",
+    error_message: str | None = None,
 ) -> models.SparkV1beta2SparkApplication:
     """Create a mock SparkApplication model for testing."""
     return models.SparkV1beta2SparkApplication(
@@ -117,6 +118,7 @@ def get_spark_application(
             models.SparkV1beta2SparkApplicationStatus(
                 application_state=models.SparkV1beta2ApplicationState(
                     state=state,
+                    error_message=error_message,
                 ),
                 driver_info=models.SparkV1beta2DriverInfo(
                     pod_name=f"{name}-driver",
@@ -1357,7 +1359,7 @@ def test_submit_job(kubernetes_backend, test_case):
                 "job_name": "spark-job-suspending",
                 "state": "SUSPENDING",
             },
-            expected_output=SparkJobStatus.RUNNING,
+            expected_output=SparkJobStatus.SUSPENDED,
         ),
         TestCase(
             name="suspended job",
@@ -1366,7 +1368,7 @@ def test_submit_job(kubernetes_backend, test_case):
                 "job_name": "spark-job-suspended",
                 "state": "SUSPENDED",
             },
-            expected_output=SparkJobStatus.RUNNING,
+            expected_output=SparkJobStatus.SUSPENDED,
         ),
         TestCase(
             name="resuming job",
@@ -1402,7 +1404,7 @@ def test_submit_job(kubernetes_backend, test_case):
                 "job_name": "spark-job-submission-failed",
                 "state": "SUBMISSION_FAILED",
             },
-            expected_output=SparkJobStatus.FAILED,
+            expected_output=SparkJobStatus.RETRYING,
         ),
         TestCase(
             name="failing job",
@@ -1411,7 +1413,7 @@ def test_submit_job(kubernetes_backend, test_case):
                 "job_name": "spark-job-failing",
                 "state": "FAILING",
             },
-            expected_output=SparkJobStatus.FAILED,
+            expected_output=SparkJobStatus.RETRYING,
         ),
         TestCase(
             name="pending rerun job",
@@ -1420,7 +1422,7 @@ def test_submit_job(kubernetes_backend, test_case):
                 "job_name": "spark-job-pending-rerun",
                 "state": "PENDING_RERUN",
             },
-            expected_output=SparkJobStatus.FAILED,
+            expected_output=SparkJobStatus.RETRYING,
         ),
         TestCase(
             name="invalidating job",
@@ -1429,7 +1431,7 @@ def test_submit_job(kubernetes_backend, test_case):
                 "job_name": "spark-job-invalidating",
                 "state": "INVALIDATING",
             },
-            expected_output=SparkJobStatus.FAILED,
+            expected_output=SparkJobStatus.RETRYING,
         ),
         TestCase(
             name="unknown state job",
@@ -1438,7 +1440,7 @@ def test_submit_job(kubernetes_backend, test_case):
                 "job_name": "spark-job-unknown",
                 "state": "UNKNOWN",
             },
-            expected_output=SparkJobStatus.FAILED,
+            expected_output=SparkJobStatus.UNKNOWN,
         ),
         TestCase(
             name="job not found",
@@ -1799,6 +1801,69 @@ def test_wait_for_job_status(kubernetes_backend, test_case):
                     kubernetes_backend.wait_for_job_status(**kwargs)
 
     print("test execution complete")
+
+
+def test_get_job_exposes_operator_state_and_error(kubernetes_backend):
+    """get_job surfaces the raw operator state and error message for diagnostics."""
+    with patch(
+        "kubeflow.spark.backends.kubernetes.backend.models.SparkV1beta2SparkApplication.from_dict"
+    ) as mock_from_dict:
+        mock_from_dict.return_value = get_spark_application(
+            name="spark-job-retrying",
+            state="PENDING_RERUN",
+            error_message="driver pod failed; retrying",
+        )
+
+        job = kubernetes_backend.get_job("spark-job-retrying")
+
+    assert job.status == SparkJobStatus.RETRYING
+    assert job.state == "PENDING_RERUN"
+    assert job.error_message == "driver pod failed; retrying"
+
+
+def test_wait_for_job_status_polls_through_retry(kubernetes_backend):
+    """A job that transitions through a retry cycle is waited on, not failed early."""
+    retrying = Mock(status=SparkJobStatus.RETRYING, state="PENDING_RERUN", error_message=None)
+    completed = Mock(status=SparkJobStatus.COMPLETED, state="COMPLETED", error_message=None)
+
+    with (
+        patch.object(
+            kubernetes_backend,
+            "get_job",
+            side_effect=[retrying, retrying, completed],
+        ),
+        patch("kubeflow.spark.backends.kubernetes.backend.time.sleep"),
+    ):
+        job = kubernetes_backend.wait_for_job_status(
+            name="spark-job-retry",
+            status={SparkJobStatus.COMPLETED},
+            timeout=10,
+            polling_interval=1,
+        )
+
+    assert job.status == SparkJobStatus.COMPLETED
+
+
+def test_wait_for_job_status_failure_includes_diagnostics(kubernetes_backend):
+    """A terminal failure raises with the raw operator state and error message."""
+    failed = Mock(
+        status=SparkJobStatus.FAILED,
+        state="FAILED",
+        error_message="driver container exited with code 1",
+    )
+
+    with patch.object(kubernetes_backend, "get_job", return_value=failed):
+        with pytest.raises(RuntimeError) as exc_info:
+            kubernetes_backend.wait_for_job_status(
+                name="spark-job-failed",
+                status={SparkJobStatus.COMPLETED},
+                timeout=1,
+                polling_interval=1,
+            )
+
+    message = str(exc_info.value)
+    assert "FAILED" in message
+    assert "driver container exited with code 1" in message
 
 
 @pytest.mark.parametrize(

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -838,15 +838,17 @@ def get_spark_application_info_from_cr(
     creation_timestamp = cr.metadata.creation_timestamp
     num_executors = None
     driver_pod_name = None
+    state = None
+    error_message = None
 
     if cr.spec and cr.spec.executor:
         num_executors = cr.spec.executor.instances
 
     if cr.status:
         if cr.status.application_state:
-            status = SparkJobStatus.from_operator_state(
-                cr.status.application_state.state,
-            )
+            state = cr.status.application_state.state
+            error_message = cr.status.application_state.error_message
+            status = SparkJobStatus.from_operator_state(state)
 
         if cr.status.driver_info:
             driver_pod_name = cr.status.driver_info.pod_name
@@ -858,4 +860,6 @@ def get_spark_application_info_from_cr(
         creation_timestamp=creation_timestamp,
         num_executors=num_executors,
         driver_pod_name=driver_pod_name,
+        state=state,
+        error_message=error_message,
     )

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -1344,7 +1344,7 @@ def test_get_spark_application_cr_from_func_job(
             expected_status=SUCCESS,
             config={
                 "spark_state": "SUSPENDING",
-                "job_status": SparkJobStatus.RUNNING,
+                "job_status": SparkJobStatus.SUSPENDED,
             },
         ),
         TestCase(
@@ -1352,7 +1352,7 @@ def test_get_spark_application_cr_from_func_job(
             expected_status=SUCCESS,
             config={
                 "spark_state": "SUSPENDED",
-                "job_status": SparkJobStatus.RUNNING,
+                "job_status": SparkJobStatus.SUSPENDED,
             },
         ),
         TestCase(
@@ -1384,7 +1384,7 @@ def test_get_spark_application_cr_from_func_job(
             expected_status=SUCCESS,
             config={
                 "spark_state": "SUBMISSION_FAILED",
-                "job_status": SparkJobStatus.FAILED,
+                "job_status": SparkJobStatus.RETRYING,
             },
         ),
         TestCase(
@@ -1392,7 +1392,7 @@ def test_get_spark_application_cr_from_func_job(
             expected_status=SUCCESS,
             config={
                 "spark_state": "FAILING",
-                "job_status": SparkJobStatus.FAILED,
+                "job_status": SparkJobStatus.RETRYING,
             },
         ),
         TestCase(
@@ -1400,7 +1400,7 @@ def test_get_spark_application_cr_from_func_job(
             expected_status=SUCCESS,
             config={
                 "spark_state": "PENDING_RERUN",
-                "job_status": SparkJobStatus.FAILED,
+                "job_status": SparkJobStatus.RETRYING,
             },
         ),
         TestCase(
@@ -1408,7 +1408,15 @@ def test_get_spark_application_cr_from_func_job(
             expected_status=SUCCESS,
             config={
                 "spark_state": "INVALIDATING",
-                "job_status": SparkJobStatus.FAILED,
+                "job_status": SparkJobStatus.RETRYING,
+            },
+        ),
+        TestCase(
+            name="unknown status",
+            expected_status=SUCCESS,
+            config={
+                "spark_state": "UNKNOWN",
+                "job_status": SparkJobStatus.UNKNOWN,
             },
         ),
         TestCase(
@@ -1538,8 +1546,34 @@ def test_get_spark_application_info_from_cr(
         assert job.name == "test-job"
         assert job.namespace == "default"
         assert job.status == test_case.config["job_status"]
+        assert job.state == test_case.config["spark_state"]
         assert job.driver_pod_name == "test-driver"
         assert job.creation_timestamp == creation_timestamp
         assert job.num_executors == 5
 
     print("test execution complete")
+
+
+def test_get_spark_application_info_from_cr_exposes_error_message(
+    spark_application_spec,
+) -> None:
+    """The raw operator state and error message are surfaced on SparkJob."""
+    spark_app = models.SparkV1beta2SparkApplication(
+        metadata=models.IoK8sApimachineryPkgApisMetaV1ObjectMeta(
+            name="test-job",
+            namespace="default",
+        ),
+        spec=spark_application_spec,
+        status=models.SparkV1beta2SparkApplicationStatus(
+            application_state=models.SparkV1beta2ApplicationState(
+                state="FAILING",
+                error_message="driver pod failed; retrying",
+            ),
+        ),
+    )
+
+    job = get_spark_application_info_from_cr(spark_app)
+
+    assert job.status == SparkJobStatus.RETRYING
+    assert job.state == "FAILING"
+    assert job.error_message == "driver pod failed; retrying"

--- a/kubeflow/spark/types/types.py
+++ b/kubeflow/spark/types/types.py
@@ -118,10 +118,21 @@ class Executor:
 
 
 class SparkJobStatus(str, Enum):
-    """State of a Spark batch job."""
+    """State of a Spark batch job.
+
+    Only ``COMPLETED`` and ``FAILED`` are terminal. The remaining values are
+    non-terminal: a job may still progress out of them. In particular,
+    ``RETRYING`` covers the Spark Operator retry cycle (for example
+    ``SUBMISSION_FAILED`` -> ``PENDING_RERUN`` -> ``SUBMITTED`` -> ``RUNNING``),
+    so callers must not treat it as a failure. Use :attr:`SparkJob.state` and
+    :attr:`SparkJob.error_message` for the raw operator state and error details.
+    """
 
     CREATED = "Created"
     RUNNING = "Running"
+    SUSPENDED = "Suspended"
+    RETRYING = "Retrying"
+    UNKNOWN = "Unknown"
     COMPLETED = "Completed"
     FAILED = "Failed"
 
@@ -139,16 +150,17 @@ class SparkJobStatus(str, Enum):
             Corresponding SparkJobStatus.
 
         Note:
-            Unknown SparkApplication states default to FAILED so newly
-            introduced operator states are handled conservatively.
+            Unrecognized SparkApplication states default to UNKNOWN (a
+            non-terminal state) so that a newly introduced operator state is
+            not mistaken for a terminal failure and does not abort polling.
         """
         normalized_state = (raw_state or "").upper()
 
         status = _SDK_STATE_BY_OPERATOR_STATE.get(normalized_state)
 
         if status is None:
-            logger.warning("Unknown SparkApplication state '%s'. Defaulting to FAILED.", raw_state)
-            return cls.FAILED
+            logger.warning("Unknown SparkApplication state '%s'. Defaulting to UNKNOWN.", raw_state)
+            return cls.UNKNOWN
 
         return status
 
@@ -163,19 +175,24 @@ _SDK_STATE_BY_OPERATOR_STATE: dict[str, SparkJobStatus] = {
         SparkJobStatus.RUNNING: (
             "RUNNING",
             "SUCCEEDING",
-            "SUSPENDING",
-            "SUSPENDED",
             "RESUMING",
         ),
-        SparkJobStatus.COMPLETED: ("COMPLETED",),
-        SparkJobStatus.FAILED: (
-            "FAILED",
+        SparkJobStatus.SUSPENDED: (
+            "SUSPENDING",
+            "SUSPENDED",
+        ),
+        # Transition states of the operator restart cycle. They are not
+        # terminal: the operator resubmits the job, so waiters must keep
+        # polling instead of raising (see kubeflow/sdk#688).
+        SparkJobStatus.RETRYING: (
             "SUBMISSION_FAILED",
             "FAILING",
             "PENDING_RERUN",
             "INVALIDATING",
-            "UNKNOWN",
         ),
+        SparkJobStatus.UNKNOWN: ("UNKNOWN",),
+        SparkJobStatus.COMPLETED: ("COMPLETED",),
+        SparkJobStatus.FAILED: ("FAILED",),
     }.items()
     for state in operator_states
 }
@@ -194,6 +211,11 @@ class SparkJob:
         creation_timestamp: Timestamp when the SparkApplication was created.
         num_executors: Number of configured Spark executor instances.
         driver_pod_name: Name of the Spark driver pod, if available.
+        state: Raw SparkApplication ``applicationState.state`` reported by the
+            operator, if available. Useful for diagnosing retry cycles that are
+            collapsed into a single SparkJobStatus.
+        error_message: Error message reported by the operator in
+            ``applicationState.errorMessage``, if available.
     """
 
     name: str
@@ -202,6 +224,8 @@ class SparkJob:
     creation_timestamp: datetime | None = None
     num_executors: int | None = None
     driver_pod_name: str | None = None
+    state: str | None = None
+    error_message: str | None = None
 
 
 @dataclass

--- a/kubeflow/spark/types/types_test.py
+++ b/kubeflow/spark/types/types_test.py
@@ -257,6 +257,9 @@ def test_executor(test_case: TestCase):
     [
         (SparkJobStatus.CREATED, "Created"),
         (SparkJobStatus.RUNNING, "Running"),
+        (SparkJobStatus.SUSPENDED, "Suspended"),
+        (SparkJobStatus.RETRYING, "Retrying"),
+        (SparkJobStatus.UNKNOWN, "Unknown"),
         (SparkJobStatus.COMPLETED, "Completed"),
         (SparkJobStatus.FAILED, "Failed"),
     ],
@@ -271,6 +274,9 @@ def test_spark_job_status_values(status, expected):
     [
         SparkJobStatus.CREATED,
         SparkJobStatus.RUNNING,
+        SparkJobStatus.SUSPENDED,
+        SparkJobStatus.RETRYING,
+        SparkJobStatus.UNKNOWN,
         SparkJobStatus.COMPLETED,
         SparkJobStatus.FAILED,
     ],
@@ -288,16 +294,19 @@ def test_spark_job_status_is_string(status):
         ("SUBMITTED", SparkJobStatus.CREATED),
         ("RUNNING", SparkJobStatus.RUNNING),
         ("SUCCEEDING", SparkJobStatus.RUNNING),
-        ("SUSPENDING", SparkJobStatus.RUNNING),
-        ("SUSPENDED", SparkJobStatus.RUNNING),
         ("RESUMING", SparkJobStatus.RUNNING),
+        ("SUSPENDING", SparkJobStatus.SUSPENDED),
+        ("SUSPENDED", SparkJobStatus.SUSPENDED),
         ("COMPLETED", SparkJobStatus.COMPLETED),
         ("FAILED", SparkJobStatus.FAILED),
-        ("SUBMISSION_FAILED", SparkJobStatus.FAILED),
-        ("FAILING", SparkJobStatus.FAILED),
-        ("PENDING_RERUN", SparkJobStatus.FAILED),
-        ("INVALIDATING", SparkJobStatus.FAILED),
-        ("UNKNOWN", SparkJobStatus.FAILED),
+        ("SUBMISSION_FAILED", SparkJobStatus.RETRYING),
+        ("FAILING", SparkJobStatus.RETRYING),
+        ("PENDING_RERUN", SparkJobStatus.RETRYING),
+        ("INVALIDATING", SparkJobStatus.RETRYING),
+        ("UNKNOWN", SparkJobStatus.UNKNOWN),
+        # Case-insensitive matching of the raw operator state.
+        ("running", SparkJobStatus.RUNNING),
+        ("pending_rerun", SparkJobStatus.RETRYING),
     ],
 )
 def test_from_operator_state(operator_state, expected_status):
@@ -306,13 +315,13 @@ def test_from_operator_state(operator_state, expected_status):
 
 
 def test_unknown_operator_state():
-    """Verify unknown SparkApplication states default to FAILED."""
+    """Verify unrecognized SparkApplication states default to non-terminal UNKNOWN."""
     with patch("kubeflow.spark.types.types.logger") as mock_logger:
         status = SparkJobStatus.from_operator_state("SOME_NEW_STATE")
 
-    assert status == SparkJobStatus.FAILED
+    assert status == SparkJobStatus.UNKNOWN
     mock_logger.warning.assert_called_once_with(
-        "Unknown SparkApplication state '%s'. Defaulting to FAILED.",
+        "Unknown SparkApplication state '%s'. Defaulting to UNKNOWN.",
         "SOME_NEW_STATE",
     )
 
@@ -334,10 +343,12 @@ def test_unknown_operator_state():
             config={
                 "name": "full-job",
                 "namespace": "spark-ns",
-                "status": SparkJobStatus.RUNNING,
+                "status": SparkJobStatus.RETRYING,
                 "creation_timestamp": datetime(2025, 1, 12, 10, 30, 0),
                 "num_executors": 10,
                 "driver_pod_name": "driver-pod-1",
+                "state": "PENDING_RERUN",
+                "error_message": "driver pod failed, retrying",
             },
         ),
     ],
@@ -359,6 +370,8 @@ def test_spark_job(test_case: TestCase):
         assert job.creation_timestamp is None
         assert job.num_executors is None
         assert job.driver_pod_name is None
+        assert job.state is None
+        assert job.error_message is None
 
     print("test execution complete")
 


### PR DESCRIPTION


### Summary

`SparkClient.wait_for_job_status()` prematurely failed whenever the Spark Operator retried a job. `SparkJobStatus.from_operator_state()` mapped the operator's retry/transition states (`SUBMISSION_FAILED`, `FAILING`, `PENDING_RERUN`, `INVALIDATING`) and the transient `UNKNOWN` state to the terminal `SparkJobStatus.FAILED`, and the polling loop raises `RuntimeError` as soon as it observes `FAILED`. A normal retry sequence such as:

```
SUBMISSION_FAILED -> PENDING_RERUN -> SUBMITTED -> RUNNING -> COMPLETED
```

therefore aborted instead of being waited on.

Fixes #688.

### Changes

- **`kubeflow/spark/types/types.py`** — Added non-terminal `SparkJobStatus` values: `RETRYING`, `SUSPENDED`, `UNKNOWN`. Remapped operator states so only `COMPLETED` and `FAILED` are terminal:
  - `SUBMISSION_FAILED`, `FAILING`, `PENDING_RERUN`, `INVALIDATING` → `RETRYING`
  - `SUSPENDING`, `SUSPENDED` → `SUSPENDED`
  - operator `UNKNOWN` → `UNKNOWN`
  - Unrecognized states now default to non-terminal `UNKNOWN` instead of `FAILED`, so a future operator state isn't mistaken for a terminal failure.
  - Added `state` and `error_message` fields to `SparkJob` for diagnostics.
  - All existing public status values (`CREATED`, `RUNNING`, `COMPLETED`, `FAILED`) are preserved — backward compatible.

- **`kubeflow/spark/backends/kubernetes/utils.py`** — `get_spark_application_info_from_cr` now populates `SparkJob.state` (raw `applicationState.state`) and `SparkJob.error_message` (`applicationState.errorMessage`) from the CR.

- **`kubeflow/spark/backends/kubernetes/backend.py`** — `wait_for_job_status` now raises only on the terminal `FAILED` state; non-terminal states (including `RETRYING`) are polled through. The failure `RuntimeError` now includes the raw operator state and error message for troubleshooting.

- **Tests** (`types_test.py`, `utils_test.py`, `backend_test.py`) — Updated mapping expectations for all reclassified states, plus new coverage for:
  - a job polling through a full retry cycle to `COMPLETED` without raising
  - `SparkJob.state`/`error_message` being surfaced end-to-end
  - the terminal-failure `RuntimeError` message including diagnostics

### Design note for reviewers

`SUBMISSION_FAILED` is mapped to `RETRYING` per the issue's example. The operator reuses this state name both when it *will* retry and when retries are exhausted (e.g. `restartPolicy: Never`). In the terminal-no-retry case, `wait_for_job_status(status={FAILED})` will now raise `TimeoutError` rather than failing immediately — `SparkJob.state`/`error_message` remain available for diagnosis. Happy to revisit if a faster-fail behavior is preferred for that case.

### Test plan

- [x] Added mapping coverage for every Spark Operator application state.
- [x] Added regression coverage for:
  - `PENDING_RERUN → RUNNING → COMPLETED`
  - terminal `FAILED` behavior
  - raw operator state and error-message propagation
  - unknown and suspended states
- [x] Ran the complete Spark unit-test suite:
  - `271 passed`
- [x] Ruff formatting and changed-code checks passed.