### PR TITLE
feat(spark): allow log methods to wait for the driver pod

### DIFF
--- a/kubeflow/spark/api/spark_client.py
+++ b/kubeflow/spark/api/spark_client.py
@@ -152,7 +152,15 @@ class SparkClient:
         """
         self.backend.delete_session(name)
 
-    def get_session_logs(self, name: str, follow: bool = False) -> Iterator[str]:
+    def get_session_logs(
+        self,
+        name: str,
+        follow: bool = False,
+        *,
+        wait_for_driver: bool = False,
+        timeout: int = 300,
+        polling_interval: int = 2,
+    ) -> Iterator[str]:
         """Get logs from a SparkConnect session.
 
         Args:
@@ -162,10 +170,37 @@ class SparkClient:
             follow:
                 Whether to stream logs continuously.
 
+            wait_for_driver:
+                Whether to poll until the driver pod is available instead of
+                failing immediately when it does not exist yet. This is useful
+                right after session creation, while the Spark Operator is still
+                provisioning the driver pod.
+
+            timeout:
+                Maximum time in seconds to wait for the driver pod when
+                ``wait_for_driver`` is True.
+
+            polling_interval:
+                Time in seconds between driver pod checks when
+                ``wait_for_driver`` is True.
+
         Returns:
             Iterator of log lines from the SparkConnect driver pod.
+
+        Raises:
+            ValueError:
+                If the polling interval or timeout values are invalid.
         """
-        return self.backend.get_session_logs(name, follow=follow)
+        if wait_for_driver:
+            common_utils.validate_wait_for_job_status(polling_interval, timeout)
+
+        return self.backend.get_session_logs(
+            name,
+            follow=follow,
+            wait_for_driver=wait_for_driver,
+            timeout=timeout,
+            polling_interval=polling_interval,
+        )
 
     # ------------------------------------------------------------------
     # Spark batch jobs
@@ -301,17 +336,39 @@ class SparkClient:
         self,
         name: str,
         follow: bool = False,
+        *,
+        wait_for_driver: bool = False,
+        timeout: int = 300,
+        polling_interval: int = 2,
     ) -> Iterator[str]:
         """Get logs from a Spark job.
 
         Args:
             name: Spark job name.
             follow: Whether to stream logs in realtime.
+            wait_for_driver: Whether to poll until the driver pod is available
+                instead of failing immediately when it does not exist yet. This
+                is useful right after job submission, while the Spark Operator
+                is still provisioning the driver pod.
+            timeout: Maximum time in seconds to wait for the driver pod when
+                ``wait_for_driver`` is True.
+            polling_interval: Time in seconds between driver pod checks when
+                ``wait_for_driver`` is True.
 
         Returns:
             Iterator of log lines.
+
+        Raises:
+            ValueError:
+                If the polling interval or timeout values are invalid.
         """
+        if wait_for_driver:
+            common_utils.validate_wait_for_job_status(polling_interval, timeout)
+
         return self.backend.get_job_logs(
             name=name,
             follow=follow,
+            wait_for_driver=wait_for_driver,
+            timeout=timeout,
+            polling_interval=polling_interval,
         )

--- a/kubeflow/spark/api/spark_client_test.py
+++ b/kubeflow/spark/api/spark_client_test.py
@@ -171,3 +171,54 @@ def test_submit_job_success(job):
             num_executors=None,
             resources_per_executor=None,
         )
+
+
+@pytest.mark.parametrize("method", ["get_job_logs", "get_session_logs"])
+def test_get_logs_wait_for_driver_pass_through(method):
+    """wait_for_driver args are forwarded to the backend log methods."""
+
+    with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as mock_backend:
+        backend = mock_backend.return_value
+        getattr(backend, method).return_value = iter(["log line"])
+
+        client = SparkClient()
+
+        logs = list(
+            getattr(client, method)(
+                "spark-workload",
+                wait_for_driver=True,
+                timeout=120,
+                polling_interval=5,
+            )
+        )
+
+        assert logs == ["log line"]
+        mock_method = getattr(backend, method)
+        mock_method.assert_called_once()
+        args, kwargs = mock_method.call_args
+        # name may be passed positionally or by keyword depending on the method.
+        assert (args and args[0] == "spark-workload") or kwargs.get("name") == "spark-workload"
+        assert kwargs["follow"] is False
+        assert kwargs["wait_for_driver"] is True
+        assert kwargs["timeout"] == 120
+        assert kwargs["polling_interval"] == 5
+
+
+@pytest.mark.parametrize("method", ["get_job_logs", "get_session_logs"])
+def test_get_logs_wait_for_driver_invalid_args(method):
+    """Invalid timeout/polling_interval are rejected before calling the backend."""
+
+    with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as mock_backend:
+        backend = mock_backend.return_value
+
+        client = SparkClient()
+
+        with pytest.raises(ValueError):
+            getattr(client, method)(
+                "spark-workload",
+                wait_for_driver=True,
+                timeout=5,
+                polling_interval=10,
+            )
+
+        getattr(backend, method).assert_not_called()

--- a/kubeflow/spark/backends/base.py
+++ b/kubeflow/spark/backends/base.py
@@ -123,18 +123,28 @@ class RuntimeBackend(abc.ABC):
         self,
         name: str,
         follow: bool = False,
+        *,
+        wait_for_driver: bool = False,
+        timeout: int = 300,
+        polling_interval: int = 2,
     ) -> Iterator[str]:
         """Get logs from a SparkConnect session.
 
         Args:
             name: Session name.
             follow: If True, stream logs continuously.
+            wait_for_driver: If True, poll until the driver pod is available
+                instead of failing immediately when it does not exist yet.
+            timeout: Maximum time in seconds to wait for the driver pod when
+                ``wait_for_driver`` is True.
+            polling_interval: Time in seconds between driver pod checks when
+                ``wait_for_driver`` is True.
 
         Returns:
             Iterator of log lines.
 
         Raises:
-            TimeoutError: If reading logs times out.
+            TimeoutError: If waiting for the driver pod or reading logs times out.
             RuntimeError: If the session/pod is not found or reading fails.
         """
         raise NotImplementedError()
@@ -234,12 +244,22 @@ class RuntimeBackend(abc.ABC):
         self,
         name: str,
         follow: bool = False,
+        *,
+        wait_for_driver: bool = False,
+        timeout: int = 300,
+        polling_interval: int = 2,
     ) -> Iterator[str]:
         """Get logs from a Spark job.
 
         Args:
             name: Name of the Spark job.
             follow: Whether to stream logs in real time.
+            wait_for_driver: If True, poll until the driver pod is available
+                instead of failing immediately when it does not exist yet.
+            timeout: Maximum time in seconds to wait for the driver pod when
+                ``wait_for_driver`` is True.
+            polling_interval: Time in seconds between driver pod checks when
+                ``wait_for_driver`` is True.
 
         Returns:
             Iterator over log lines.

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -15,7 +15,7 @@
 """Kubernetes backend for Spark operations."""
 
 import ast
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 import contextlib
 import inspect
 import logging
@@ -708,10 +708,79 @@ class KubernetesBackend(RuntimeBackend):
 
         return self.connect(info, connect_timeout=connect_timeout)
 
+    def _wait_for_driver_pod(
+        self,
+        name: str,
+        kind: str,
+        get_info: Callable[[str], Any],
+        timeout: int,
+        polling_interval: int,
+    ) -> str:
+        """Poll a Spark resource until its driver pod name is populated.
+
+        The Spark Operator creates the driver pod asynchronously after the
+        SparkApplication or SparkConnect resource is created, so the resource
+        status may not expose a driver pod name immediately.
+
+        Args:
+            name:
+                Name of the Spark resource.
+
+            kind:
+                Kubernetes kind of the resource, used for log and error messages.
+
+            get_info:
+                Callable returning the resource info object (exposing
+                ``driver_pod_name``) for the given name.
+
+            timeout:
+                Maximum time in seconds to wait for the driver pod.
+
+            polling_interval:
+                Time in seconds between status checks.
+
+        Returns:
+            Name of the driver pod once it is available.
+
+        Raises:
+            TimeoutError:
+                If the driver pod does not become available within the timeout.
+        """
+        start_time = time.monotonic()
+        last_log_time = start_time
+
+        while True:
+            driver_pod_name = get_info(name).driver_pod_name
+            if driver_pod_name:
+                return driver_pod_name
+
+            now = time.monotonic()
+            if now - last_log_time >= 10.0:
+                logger.info(
+                    "Waiting for driver pod: %s %s/%s elapsed=%.0fs",
+                    kind,
+                    self.namespace,
+                    name,
+                    now - start_time,
+                )
+                last_log_time = now
+
+            if now - start_time >= timeout:
+                raise TimeoutError(
+                    f"Timeout waiting for driver pod for {kind}: "
+                    f"{self.namespace}/{name} (timeout: {timeout}s)"
+                )
+
+            time.sleep(polling_interval)
+
     def get_session_logs(
         self,
         name: str,
         follow: bool = False,
+        *,
+        wait_for_driver: bool = False,
+        timeout: int = 300,
+        polling_interval: int = 2,
     ) -> Iterator[str]:
         """Get logs from a SparkConnect session.
 
@@ -726,6 +795,20 @@ class KubernetesBackend(RuntimeBackend):
             follow:
                 Whether to stream logs continuously.
 
+            wait_for_driver:
+                Whether to poll until the driver pod is available instead of
+                failing immediately when it does not exist yet. This is useful
+                right after session creation, while the Spark Operator is still
+                provisioning the driver pod.
+
+            timeout:
+                Maximum time in seconds to wait for the driver pod when
+                ``wait_for_driver`` is True.
+
+            polling_interval:
+                Time in seconds between driver pod checks when
+                ``wait_for_driver`` is True.
+
         Yields:
             Log lines from the SparkConnect driver pod.
 
@@ -734,21 +817,29 @@ class KubernetesBackend(RuntimeBackend):
                 If the driver pod does not exist or logs cannot be retrieved.
 
             TimeoutError:
-                If retrieving the driver pod logs times out.
+                If waiting for the driver pod or retrieving its logs times out.
         """
-        info = self.get_session(name)
-
-        if not info.driver_pod_name:
-            raise RuntimeError(
-                f"No driver pod for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
+        if wait_for_driver:
+            driver_pod_name = self._wait_for_driver_pod(
+                name=name,
+                kind=constants.SPARK_CONNECT_KIND,
+                get_info=self.get_session,
+                timeout=timeout,
+                polling_interval=polling_interval,
             )
+        else:
+            driver_pod_name = self.get_session(name).driver_pod_name
+            if not driver_pod_name:
+                raise RuntimeError(
+                    f"No driver pod for {constants.SPARK_CONNECT_KIND}: {self.namespace}/{name}"
+                )
 
         def _stream() -> Iterator[str]:
             try:
                 yield from read_pod_logs(
                     core_api=self.core_api,
                     namespace=self.namespace,
-                    pod_name=info.driver_pod_name,
+                    pod_name=driver_pod_name,
                     follow=follow,
                 )
 
@@ -1211,6 +1302,10 @@ class KubernetesBackend(RuntimeBackend):
         self,
         name: str,
         follow: bool = False,
+        *,
+        wait_for_driver: bool = False,
+        timeout: int = 300,
+        polling_interval: int = 2,
     ) -> Iterator[str]:
         """Get logs from a Spark job.
 
@@ -1221,28 +1316,44 @@ class KubernetesBackend(RuntimeBackend):
         Args:
             name: Name of the SparkApplication.
             follow: Whether to stream logs continuously.
+            wait_for_driver: Whether to poll until the driver pod is available
+                instead of failing immediately when it does not exist yet. This
+                is useful right after job submission, while the Spark Operator
+                is still provisioning the driver pod.
+            timeout: Maximum time in seconds to wait for the driver pod when
+                ``wait_for_driver`` is True.
+            polling_interval: Time in seconds between driver pod checks when
+                ``wait_for_driver`` is True.
 
         Yields:
             Log lines from the SparkApplication driver pod.
 
         Raises:
             RuntimeError: If the driver pod does not exist or logs cannot be retrieved.
-            TimeoutError: If retrieving the driver pod logs times out.
+            TimeoutError: If waiting for the driver pod or retrieving its logs times out.
         """
 
-        job = self.get_job(name)
-
-        if not job.driver_pod_name:
-            raise RuntimeError(
-                f"No driver pod for {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{name}"
+        if wait_for_driver:
+            driver_pod_name = self._wait_for_driver_pod(
+                name=name,
+                kind=constants.SPARK_APPLICATION_KIND,
+                get_info=self.get_job,
+                timeout=timeout,
+                polling_interval=polling_interval,
             )
+        else:
+            driver_pod_name = self.get_job(name).driver_pod_name
+            if not driver_pod_name:
+                raise RuntimeError(
+                    f"No driver pod for {constants.SPARK_APPLICATION_KIND}: {self.namespace}/{name}"
+                )
 
         def _stream() -> Iterator[str]:
             try:
                 yield from read_pod_logs(
                     core_api=self.core_api,
                     namespace=self.namespace,
-                    pod_name=job.driver_pod_name,
+                    pod_name=driver_pod_name,
                     follow=follow,
                 )
 

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -1929,3 +1929,80 @@ def test_get_job_logs(kubernetes_backend, test_case):
             raise
 
     print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="job driver pod appears after polling",
+            expected_status=SUCCESS,
+            config={"kind": "job", "driver_pod_names": [None, "spark-job-driver"]},
+        ),
+        TestCase(
+            name="session driver pod appears after polling",
+            expected_status=SUCCESS,
+            config={"kind": "session", "driver_pod_names": [None, "spark-session-driver"]},
+        ),
+        TestCase(
+            name="job driver pod never appears times out",
+            expected_status=FAILED,
+            config={"kind": "job", "driver_pod_names": [None, None, None, None]},
+            expected_error=TimeoutError,
+        ),
+        TestCase(
+            name="session driver pod never appears times out",
+            expected_status=FAILED,
+            config={"kind": "session", "driver_pod_names": [None, None, None, None]},
+            expected_error=TimeoutError,
+        ),
+    ],
+)
+def test_get_logs_wait_for_driver(kubernetes_backend, test_case):
+    """Test get_job_logs/get_session_logs poll for the driver pod when wait_for_driver=True."""
+    print("Executing test:", test_case.name)
+
+    is_job = test_case.config["kind"] == "job"
+    getter = "get_job" if is_job else "get_session"
+    infos = [Mock(driver_pod_name=name) for name in test_case.config["driver_pod_names"]]
+
+    # Drive the polling clock deterministically so the timeout is reached without
+    # relying on wall-clock time or busy-looping.
+    clock = iter([0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+
+    with (
+        patch.object(kubernetes_backend, getter, side_effect=infos),
+        patch(
+            "kubeflow.spark.backends.kubernetes.backend.time.monotonic",
+            side_effect=lambda: next(clock),
+        ),
+        patch("kubeflow.spark.backends.kubernetes.backend.time.sleep", return_value=None),
+        patch(
+            "kubeflow.spark.backends.kubernetes.backend.read_pod_logs",
+            return_value=iter(["log line 1", "log line 2"]),
+        ) as mock_read_pod_logs,
+    ):
+        get_logs = (
+            kubernetes_backend.get_job_logs if is_job else kubernetes_backend.get_session_logs
+        )
+
+        if test_case.expected_status == SUCCESS:
+            logs = list(
+                get_logs("spark-workload", wait_for_driver=True, timeout=5, polling_interval=1)
+            )
+            assert logs == ["log line 1", "log line 2"]
+            expected_pod = test_case.config["driver_pod_names"][-1]
+            mock_read_pod_logs.assert_called_once_with(
+                core_api=kubernetes_backend.core_api,
+                namespace=kubernetes_backend.namespace,
+                pod_name=expected_pod,
+                follow=False,
+            )
+        else:
+            with pytest.raises(test_case.expected_error):
+                list(
+                    get_logs("spark-workload", wait_for_driver=True, timeout=1, polling_interval=1)
+                )
+            mock_read_pod_logs.assert_not_called()
+
+    print("test execution complete")


### PR DESCRIPTION


### Summary

Fixes #691.

`SparkClient.get_job_logs()` and `SparkClient.get_session_logs()` raise `RuntimeError("No driver pod ...")` when called immediately after creating a Spark resource. This happens because the Spark Operator provisions the SparkApplication/SparkConnect resource first and creates the driver pod asynchronously afterward — so the resource status has no `driver_pod_name` yet for a short window. Users had to implement their own retry/polling logic around log retrieval to work around this timing gap.

This PR adds opt-in polling so the SDK can wait for the driver pod internally instead of failing immediately.

### Changes

- Added keyword-only parameters `wait_for_driver: bool = False`, `timeout: int = 300`, and `polling_interval: int = 2` to `get_job_logs()` and `get_session_logs()` on `SparkClient` and the Kubernetes backend.
- When `wait_for_driver=True`, the backend polls the resource (via a new `_wait_for_driver_pod` helper, following the same pattern as `_wait_for_session_ready`/`wait_for_job_status`) until `driver_pod_name` is populated, then streams logs. Raises `TimeoutError` if the pod doesn't appear in time.
- Default behavior (`wait_for_driver=False`) is unchanged — this is fully backward compatible.
- `timeout`/`polling_interval` are validated via the existing `common_utils.validate_wait_for_job_status` helper, consistent with `wait_for_job_status`.
- Updated the abstract backend contract in `backends/base.py` to match.

### Backward compatibility

New parameters are keyword-only and default to the existing behavior, so no existing call sites (positional or keyword) are affected.

### Testing

- Added backend tests covering: driver pod appearing after N polls, and timeout when it never appears (clock is mocked deterministically — no reliance on wall-clock sleeps).
- Added client tests covering: `wait_for_driver` args passing through to the backend, and invalid `timeout`/`polling_interval` being rejected before the backend is called.

```bash
make verify
uv run pytest -q kubeflow/spark/backends/kubernetes/backend_test.py kubeflow/spark/api/spark_client_test.py
```

### Example usage

```python
client = SparkClient()
job_name = client.submit_job(job)

# Instead of a manual retry loop, wait for the driver pod internally:
for line in client.get_job_logs(job_name, wait_for_driver=True, timeout=120):
    print(line)
```