### PR TITLE
update default spark version

### DIFF
--- a/kubeflow/spark/backends/kubernetes/constants.py
+++ b/kubeflow/spark/backends/kubernetes/constants.py
@@ -41,8 +41,8 @@ SPARK_APPLICATION_PLURAL = "sparkapplications"
 SPARK_APPLICATION_KIND = "SparkApplication"
 
 # Default values; keep major.minor aligned with pyspark-connect in pyproject.toml
-DEFAULT_SPARK_VERSION = "4.0.1"
-DEFAULT_SPARK_IMAGE = "apache/spark:4.0.1"
+DEFAULT_SPARK_VERSION = "4.0.4"
+DEFAULT_SPARK_IMAGE = "apache/spark:4.0.4"
 DEFAULT_NUM_EXECUTORS = 1  # Kind-friendly: 1 driver + 1 executor = 2 cores
 
 # Minimal defaults for Kind / resource-constrained clusters (driver and executor)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

This updates the default spark image / version used by the SDK to `4.0.4` which has many security fixes.

We have updated the version to `4.0.4` here: https://github.com/kubeflow/spark-operator/pull/3052
So I'd like to keep the SDK in-sync with the spark operator repository.


