### PR TITLE
feat: [KEP-107] Support spark_conf for Spark batch job submission

### DIFF
--- a/examples/spark/batch_job_lifecycle.py
+++ b/examples/spark/batch_job_lifecycle.py
@@ -58,6 +58,9 @@ def example_submit_and_wait():
             "cpu": "1",
             "memory": "512Mi",
         },
+        spark_conf={
+            "spark.sql.shuffle.partitions": "8",
+        },
     )
 
     print(f"Job submitted successfully: {JOB_NAME}")

--- a/kubeflow/spark/api/spark_client.py
+++ b/kubeflow/spark/api/spark_client.py
@@ -200,7 +200,7 @@ class SparkClient:
                 Format: ``{"cpu": "5", "memory": "10Gi"}``.
 
             spark_conf:
-                Spark configuration dictionary.
+                Spark configuration properties.
 
             options:
                 List of additional Spark configuration options.
@@ -215,14 +215,13 @@ class SparkClient:
             NotImplementedError:
                 If unsupported features are requested.
         """
-        if spark_conf is not None:
-            raise NotImplementedError("spark_conf support is not yet implemented.")
 
         return self.backend.submit_job(
             job=job,
             num_executors=num_executors,
             resources_per_executor=resources_per_executor,
             options=options,
+            spark_conf=spark_conf,
         ).name
 
     def get_job(self, name: str) -> SparkJob:

--- a/kubeflow/spark/api/spark_client_test.py
+++ b/kubeflow/spark/api/spark_client_test.py
@@ -100,10 +100,10 @@ def test_create_and_connect(test_case: TestCase):
         ),
         (
             FileJob(file_source="s3://bucket/job.py"),
-            {"spark.executor.memory": "4g"},
+            [],
             None,
-            None,
-            NotImplementedError,
+            ValueError("spark_conf must be a dictionary."),
+            ValueError,
         ),
     ],
 )
@@ -167,5 +167,9 @@ def test_submit_job_success(job, options):
         assert name == "spark-job-123"
 
         backend.submit_job.assert_called_once_with(
-            job=job, num_executors=None, resources_per_executor=None, options=options
+            job=job,
+            num_executors=None,
+            resources_per_executor=None,
+            spark_conf=None,
+            options=options,
         )

--- a/kubeflow/spark/backends/base.py
+++ b/kubeflow/spark/backends/base.py
@@ -150,6 +150,7 @@ class RuntimeBackend(abc.ABC):
         num_executors: int | None = None,
         resources_per_executor: dict[str, str] | None = None,
         options: list | None = None,
+        spark_conf: dict[str, str] | None = None,
     ) -> SparkJob:
         """Submit a Spark batch job.
 
@@ -158,6 +159,7 @@ class RuntimeBackend(abc.ABC):
             num_executors: Number of executor instances.
             resources_per_executor: Resource requirements for each executor.
             options: List of configuration options. Use the Name option for a custom job name.
+            spark_conf: Spark configuration properties to set on the SparkApplication.
 
         Returns:
             Submitted Spark job information.

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -893,6 +893,7 @@ class KubernetesBackend(RuntimeBackend):
         num_executors: int | None = None,
         resources_per_executor: dict[str, str] | None = None,
         options: list | None = None,
+        spark_conf: dict[str, str] | None = None,
     ) -> SparkJob:
         """Submit a SparkApplication for batch execution.
 
@@ -908,6 +909,8 @@ class KubernetesBackend(RuntimeBackend):
 
             options:
                 List of additional Spark configuration options.
+            spark_conf:
+                Spark configuration properties to set on the SparkApplication.
 
         Returns:
             SparkJob information object.
@@ -936,6 +939,7 @@ class KubernetesBackend(RuntimeBackend):
                 resources_per_executor=resources_per_executor,
                 options=options,
                 backend=self,
+                spark_conf=spark_conf,
             )
 
         else:
@@ -948,6 +952,7 @@ class KubernetesBackend(RuntimeBackend):
                 resources_per_executor=resources_per_executor,
                 options=options,
                 backend=self,
+                spark_conf=spark_conf,
             )
 
         # The Name option may override the auto-generated name.

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -1240,11 +1240,26 @@ def test_validate_job(kubernetes_backend, test_case):
             },
         ),
         TestCase(
+            name="valid remote file submission with spark conf",
+            expected_status=SUCCESS,
+            config={
+                "job": FileJob(
+                    file_source="s3://bucket/job.py",
+                    args=["--date", "2026-06-30"],
+                ),
+                "spark_conf": {
+                    "spark.executor.memory": "4g",
+                    "spark.sql.shuffle.partitions": "10",
+                },
+            },
+        ),
+        TestCase(
             name="valid remote file submission with options",
             expected_status=SUCCESS,
             config={
                 "job": FileJob(
                     file_source="s3://bucket/job.py",
+                    args=["--date", "2026-06-30"],
                 ),
                 "options": [
                     Name("custom-job"),
@@ -1275,6 +1290,7 @@ def test_submit_job(kubernetes_backend, test_case):
                 job = kubernetes_backend.submit_job(
                     job=test_case.config["job"],
                     options=test_case.config.get("options"),
+                    spark_conf=test_case.config.get("spark_conf"),
                 )
 
                 mock_build.assert_called_once()
@@ -1284,11 +1300,15 @@ def test_submit_job(kubernetes_backend, test_case):
                 if test_case.config.get("options"):
                     assert mock_build.call_args.kwargs["options"] == test_case.config["options"]
                     assert mock_build.call_args.kwargs["backend"] is kubernetes_backend
+                assert mock_build.call_args.kwargs["spark_conf"] == test_case.config.get(
+                    "spark_conf"
+                )
 
         else:
             job = kubernetes_backend.submit_job(
                 job=test_case.config["job"],
                 options=test_case.config.get("options"),
+                spark_conf=test_case.config.get("spark_conf"),
             )
 
         assert test_case.expected_status == SUCCESS

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -136,18 +136,8 @@ def _resolve_executor_resources(
     executor: Executor | None = None,
     num_executors: int | None = None,
     resources_per_executor: dict[str, str] | None = None,
-    spark_conf: dict[str, str] | None = None,
 ) -> tuple[int, int, str]:
     """Resolve executor configuration.
-
-    Precedence rules:
-        - Executor instances:
-          ``spark_conf`` > ``executor.num_instances`` >
-          ``num_executors`` > default.
-        - Executor resources:
-          ``spark_conf`` >
-          ``executor.resources_per_executor`` >
-          ``resources_per_executor`` > default.
 
     Args:
         executor:
@@ -158,9 +148,6 @@ def _resolve_executor_resources(
 
         resources_per_executor:
             Resource requirements.
-
-        spark_conf:
-            Spark configuration properties.
 
     Returns:
         Tuple containing ``(instances, cores, memory)``.
@@ -196,22 +183,6 @@ def _resolve_executor_resources(
         if "memory" in resource_dict:
             memory = _memory_kubernetes_to_spark(
                 resource_dict["memory"],
-            )
-
-    if spark_conf:
-        if "spark.executor.instances" in spark_conf:
-            instances = int(
-                spark_conf["spark.executor.instances"],
-            )
-
-        if "spark.executor.cores" in spark_conf:
-            cores = _validate_cpu_value(
-                spark_conf["spark.executor.cores"],
-            )
-
-        if "spark.executor.memory" in spark_conf:
-            memory = _memory_kubernetes_to_spark(
-                spark_conf["spark.executor.memory"],
             )
 
     return instances, cores, memory
@@ -722,6 +693,11 @@ def get_spark_job_executor_spec(
     Args:
         num_executors: Number of executor instances.
         resources_per_executor: Resource requirements for each executor.
+        spark_conf:
+            Spark configuration properties. Executor-related properties
+            (``spark.executor.instances``, ``spark.executor.cores``, and
+            ``spark.executor.memory``) override values provided through
+            ``num_executors`` and ``resources_per_executor``.
 
     Returns:
         SparkApplication ExecutorSpec model.
@@ -733,8 +709,23 @@ def get_spark_job_executor_spec(
     instances, cores, memory = _resolve_executor_resources(
         num_executors=num_executors,
         resources_per_executor=resources_per_executor,
-        spark_conf=spark_conf,
     )
+
+    if spark_conf:
+        if "spark.executor.instances" in spark_conf:
+            instances = int(
+                spark_conf["spark.executor.instances"],
+            )
+
+        if "spark.executor.cores" in spark_conf:
+            cores = _validate_cpu_value(
+                spark_conf["spark.executor.cores"],
+            )
+
+        if "spark.executor.memory" in spark_conf:
+            memory = _memory_kubernetes_to_spark(
+                spark_conf["spark.executor.memory"],
+            )
 
     return models.SparkV1beta2ExecutorSpec(
         instances=instances,

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -769,6 +769,7 @@ def get_spark_application_cr_from_file_job(
     resources_per_executor: dict[str, str] | None = None,
     options: list | None = None,
     backend: Any | None = None,
+    spark_conf: dict[str, str] | None = None,
 ) -> models.SparkV1beta2SparkApplication:
     """Build a SparkApplication custom resource for a file-based Spark job.
 
@@ -781,6 +782,7 @@ def get_spark_application_cr_from_file_job(
         resources_per_executor: Resource requirements for each executor.
         options: List of configuration options.
         backend: Backend instance used for option validation.
+        spark_conf: Spark configuration properties.
 
     Returns:
         SparkApplication custom resource model.
@@ -808,6 +810,7 @@ def get_spark_application_cr_from_file_job(
                 num_executors=num_executors,
                 resources_per_executor=resources_per_executor,
             ),
+            spark_conf=spark_conf,
         ),
     )
 
@@ -829,6 +832,7 @@ def get_spark_application_cr_from_func_job(
     resources_per_executor: dict[str, str] | None = None,
     options: list | None = None,
     backend: Any | None = None,
+    spark_conf: dict[str, str] | None = None,
 ) -> models.SparkV1beta2SparkApplication:
     """Build a SparkApplication custom resource for a function-based Spark job.
 
@@ -841,6 +845,7 @@ def get_spark_application_cr_from_func_job(
         resources_per_executor: Resource requirements for each executor.
         options: List of configuration options.
         backend: Backend instance used for option validation.
+        spark_conf: Spark configuration properties.
 
     Returns:
         SparkApplication custom resource model.
@@ -874,6 +879,7 @@ def get_spark_application_cr_from_func_job(
                 num_executors=num_executors,
                 resources_per_executor=resources_per_executor,
             ),
+            spark_conf=spark_conf,
         ),
     )
 

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -686,18 +686,12 @@ def get_spark_job_driver_spec(
 def get_spark_job_executor_spec(
     num_executors: int | None = None,
     resources_per_executor: dict[str, str] | None = None,
-    spark_conf: dict[str, str] | None = None,
 ) -> models.SparkV1beta2ExecutorSpec:
     """Build ExecutorSpec for SparkApplication.
 
     Args:
         num_executors: Number of executor instances.
         resources_per_executor: Resource requirements for each executor.
-        spark_conf:
-            Spark configuration properties. Executor-related properties
-            (``spark.executor.instances``, ``spark.executor.cores``, and
-            ``spark.executor.memory``) override values provided through
-            ``num_executors`` and ``resources_per_executor``.
 
     Returns:
         SparkApplication ExecutorSpec model.
@@ -710,22 +704,6 @@ def get_spark_job_executor_spec(
         num_executors=num_executors,
         resources_per_executor=resources_per_executor,
     )
-
-    if spark_conf:
-        if "spark.executor.instances" in spark_conf:
-            instances = int(
-                spark_conf["spark.executor.instances"],
-            )
-
-        if "spark.executor.cores" in spark_conf:
-            cores = _validate_cpu_value(
-                spark_conf["spark.executor.cores"],
-            )
-
-        if "spark.executor.memory" in spark_conf:
-            memory = _memory_kubernetes_to_spark(
-                spark_conf["spark.executor.memory"],
-            )
 
     return models.SparkV1beta2ExecutorSpec(
         instances=instances,
@@ -865,7 +843,6 @@ def get_spark_application_cr_from_file_job(
             executor=get_spark_job_executor_spec(
                 num_executors=num_executors,
                 resources_per_executor=resources_per_executor,
-                spark_conf=spark_conf,
             ),
             spark_conf=spark_conf or None,
         ),
@@ -936,7 +913,6 @@ def get_spark_application_cr_from_func_job(
             executor=get_spark_job_executor_spec(
                 num_executors=num_executors,
                 resources_per_executor=resources_per_executor,
-                spark_conf=spark_conf,
             ),
             spark_conf=spark_conf or None,
         ),

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -136,16 +136,34 @@ def _resolve_executor_resources(
     executor: Executor | None = None,
     num_executors: int | None = None,
     resources_per_executor: dict[str, str] | None = None,
+    spark_conf: dict[str, str] | None = None,
 ) -> tuple[int, int, str]:
     """Resolve executor configuration.
 
+    Precedence rules:
+        - Executor instances:
+          ``spark_conf`` > ``executor.num_instances`` >
+          ``num_executors`` > default.
+        - Executor resources:
+          ``spark_conf`` >
+          ``executor.resources_per_executor`` >
+          ``resources_per_executor`` > default.
+
     Args:
-        executor: Executor configuration.
-        num_executors: Number of executor instances.
-        resources_per_executor: Resource requirements.
+        executor:
+            Executor configuration.
+
+        num_executors:
+            Number of executor instances.
+
+        resources_per_executor:
+            Resource requirements.
+
+        spark_conf:
+            Spark configuration properties.
 
     Returns:
-        Tuple containing (instances, cores, memory).
+        Tuple containing ``(instances, cores, memory)``.
 
     Raises:
         ValueError:
@@ -178,6 +196,22 @@ def _resolve_executor_resources(
         if "memory" in resource_dict:
             memory = _memory_kubernetes_to_spark(
                 resource_dict["memory"],
+            )
+
+    if spark_conf:
+        if "spark.executor.instances" in spark_conf:
+            instances = int(
+                spark_conf["spark.executor.instances"],
+            )
+
+        if "spark.executor.cores" in spark_conf:
+            cores = _validate_cpu_value(
+                spark_conf["spark.executor.cores"],
+            )
+
+        if "spark.executor.memory" in spark_conf:
+            memory = _memory_kubernetes_to_spark(
+                spark_conf["spark.executor.memory"],
             )
 
     return instances, cores, memory
@@ -330,6 +364,33 @@ def apply_options(
             )
 
         option(resource, backend)
+
+
+def _validate_spark_conf(
+    spark_conf: dict[str, str] | None,
+) -> None:
+    """Validate Spark configuration.
+
+    Args:
+        spark_conf:
+            Spark configuration properties.
+
+    Raises:
+        ValueError:
+            If ``spark_conf`` is not a dictionary of string keys and values.
+    """
+    if spark_conf is None:
+        return
+
+    if not isinstance(spark_conf, dict):
+        raise ValueError("spark_conf must be a dictionary.")
+
+    for key, value in spark_conf.items():
+        if not isinstance(key, str):
+            raise ValueError("All spark_conf keys must be strings.")
+
+        if not isinstance(value, str):
+            raise ValueError("All spark_conf values must be strings.")
 
 
 # ----------------------------------------------------------------------
@@ -510,6 +571,8 @@ def build_spark_connect_cr(
         ValueError:
             If the provided driver or executor resource configuration is invalid.
     """
+    _validate_spark_conf(spark_conf)
+
     spark_version = spark_version or constants.DEFAULT_SPARK_VERSION
 
     # Build server spec using conversion function
@@ -652,6 +715,7 @@ def get_spark_job_driver_spec(
 def get_spark_job_executor_spec(
     num_executors: int | None = None,
     resources_per_executor: dict[str, str] | None = None,
+    spark_conf: dict[str, str] | None = None,
 ) -> models.SparkV1beta2ExecutorSpec:
     """Build ExecutorSpec for SparkApplication.
 
@@ -669,6 +733,7 @@ def get_spark_job_executor_spec(
     instances, cores, memory = _resolve_executor_resources(
         num_executors=num_executors,
         resources_per_executor=resources_per_executor,
+        spark_conf=spark_conf,
     )
 
     return models.SparkV1beta2ExecutorSpec(
@@ -809,8 +874,9 @@ def get_spark_application_cr_from_file_job(
             executor=get_spark_job_executor_spec(
                 num_executors=num_executors,
                 resources_per_executor=resources_per_executor,
+                spark_conf=spark_conf,
             ),
-            spark_conf=spark_conf,
+            spark_conf=spark_conf or None,
         ),
     )
 
@@ -855,6 +921,7 @@ def get_spark_application_cr_from_func_job(
             If the provided function is invalid or the executor resource
             configuration is invalid.
     """
+    _validate_spark_conf(spark_conf)
 
     command = get_command_using_spark_func(
         func=func,
@@ -878,8 +945,9 @@ def get_spark_application_cr_from_func_job(
             executor=get_spark_job_executor_spec(
                 num_executors=num_executors,
                 resources_per_executor=resources_per_executor,
+                spark_conf=spark_conf,
             ),
-            spark_conf=spark_conf,
+            spark_conf=spark_conf or None,
         ),
     )
 

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -1387,7 +1387,6 @@ def test_get_spark_job_executor_spec(test_case: TestCase) -> None:
 
     assert test_case.expected_status == SUCCESS
 
-
     assert spec.instances == constants.DEFAULT_NUM_EXECUTORS
     assert spec.cores == constants.DEFAULT_EXECUTOR_CPU
     assert spec.memory == _memory_kubernetes_to_spark(

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -1353,6 +1353,10 @@ def test_get_spark_job_executor_spec(test_case: TestCase) -> None:
                     "cpu": "2",
                     "memory": "4Gi",
                 },
+                "spark_conf": {
+                    "spark.sql.shuffle.partitions": "8",
+                    "spark.executor.memoryOverhead": "512m",
+                },
             },
         ),
         TestCase(
@@ -1389,6 +1393,7 @@ def test_get_spark_application_cr_from_file_job(test_case: TestCase, mock_k8s_ba
         resources_per_executor=test_case.config["resources_per_executor"],
         options=test_case.config.get("options"),
         backend=mock_k8s_backend,
+        spark_conf=test_case.config.get("spark_conf"),
     )
 
     assert test_case.expected_status == SUCCESS
@@ -1413,6 +1418,8 @@ def test_get_spark_application_cr_from_file_job(test_case: TestCase, mock_k8s_ba
     if test_case.name == "build spark application with options":
         assert app.metadata.labels["team"] == "ml"
 
+    assert app.spec.spark_conf == test_case.config.get("spark_conf")
+
     print("test execution complete")
 
 
@@ -1431,6 +1438,9 @@ def test_get_spark_application_cr_from_file_job(test_case: TestCase, mock_k8s_ba
                 "resources_per_executor": {
                     "cpu": "2",
                     "memory": "4Gi",
+                },
+                "spark_conf": {
+                    "spark.sql.shuffle.partitions": "8",
                 },
             },
         ),
@@ -1471,6 +1481,7 @@ def test_get_spark_application_cr_from_func_job(
         resources_per_executor=test_case.config["resources_per_executor"],
         options=test_case.config.get("options"),
         backend=mock_k8s_backend,
+        spark_conf=test_case.config.get("spark_conf"),
     )
 
     assert test_case.expected_status == SUCCESS
@@ -1498,6 +1509,7 @@ def test_get_spark_application_cr_from_func_job(
 
     if test_case.name == "build spark application from function with options":
         assert app.metadata.labels["team"] == "ml"
+    assert app.spec.spark_conf == test_case.config.get("spark_conf")
 
     print("test execution complete")
 

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -28,6 +28,7 @@ from kubeflow.spark.backends.kubernetes.utils import (
     _resolve_driver_resources,
     _resolve_executor_resources,
     _validate_cpu_value,
+    _validate_spark_conf,
     apply_options,
     build_service_url,
     build_spark_connect_cr,
@@ -302,8 +303,61 @@ def test_apply_options(
     if test_case.name == "apply label option":
         assert spark_connect_resource.metadata.labels["team"] == "ml"
 
+    print("test execution complete")
 
-print("test execution complete")
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid spark conf",
+            expected_status=SUCCESS,
+            config={
+                "spark_conf": {
+                    "spark.executor.memory": "4g",
+                    "spark.sql.shuffle.partitions": "200",
+                },
+            },
+        ),
+        TestCase(
+            name="invalid spark conf key",
+            expected_status=FAILED,
+            config={
+                "spark_conf": {
+                    1: "4g",
+                },
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid spark conf value",
+            expected_status=FAILED,
+            config={
+                "spark_conf": {
+                    "spark.executor.memory": 4,
+                },
+            },
+            expected_error=ValueError,
+        ),
+    ],
+)
+def test_validate_spark_conf(test_case: TestCase) -> None:
+    """Tests _validate_spark_conf."""
+
+    print("Executing test:", test_case.name)
+
+    try:
+        _validate_spark_conf(
+            test_case.config["spark_conf"],
+        )
+
+        assert test_case.expected_status == SUCCESS
+
+    except Exception as e:
+        assert test_case.expected_status == FAILED
+        assert isinstance(e, test_case.expected_error)
+
+    print("test execution complete")
 
 
 @pytest.mark.parametrize(
@@ -1021,6 +1075,29 @@ def test_resolve_driver_resources(test_case: TestCase) -> None:
                 },
             },
         ),
+        TestCase(
+            name="spark conf overrides executor configuration",
+            expected_status=SUCCESS,
+            config={
+                "executor": Executor(
+                    num_instances=5,
+                    resources_per_executor={
+                        "cpu": "8",
+                        "memory": "16Gi",
+                    },
+                ),
+                "num_executors": 2,
+                "resources_per_executor": {
+                    "cpu": "4",
+                    "memory": "8Gi",
+                },
+                "spark_conf": {
+                    "spark.executor.instances": "10",
+                    "spark.executor.cores": "12",
+                    "spark.executor.memory": "32Gi",
+                },
+            },
+        ),
     ],
 )
 def test_resolve_executor_resources(test_case: TestCase) -> None:
@@ -1032,6 +1109,7 @@ def test_resolve_executor_resources(test_case: TestCase) -> None:
         executor=test_case.config.get("executor"),
         num_executors=test_case.config.get("num_executors"),
         resources_per_executor=test_case.config.get("resources_per_executor"),
+        spark_conf=test_case.config.get("spark_conf"),
     )
 
     assert test_case.expected_status == SUCCESS
@@ -1052,6 +1130,11 @@ def test_resolve_executor_resources(test_case: TestCase) -> None:
         assert instances == 5
         assert cores == 8
         assert memory == "16g"
+
+    elif test_case.name == "spark conf overrides executor configuration":
+        assert instances == 10
+        assert cores == 12
+        assert memory == "32g"
 
     elif test_case.name == "fractional executor memory":
         assert instances == constants.DEFAULT_NUM_EXECUTORS
@@ -1341,18 +1424,45 @@ def test_get_spark_job_executor_spec(test_case: TestCase) -> None:
     "test_case",
     [
         TestCase(
-            name="build spark application for remote uri job",
+            name="minimal file job",
+            expected_status=SUCCESS,
+            config={
+                "name": "test-job",
+                "namespace": "default",
+                "main_file": "s3://bucket/job.py",
+            },
+        ),
+        TestCase(
+            name="file job with arguments",
             expected_status=SUCCESS,
             config={
                 "name": "test-job",
                 "namespace": "default",
                 "main_file": "s3://bucket/job.py",
                 "arguments": ["--date", "2026-06-30"],
+            },
+        ),
+        TestCase(
+            name="file job with executor configuration",
+            expected_status=SUCCESS,
+            config={
+                "name": "test-job",
+                "namespace": "default",
+                "main_file": "s3://bucket/job.py",
                 "num_executors": 3,
                 "resources_per_executor": {
                     "cpu": "2",
                     "memory": "4Gi",
                 },
+            },
+        ),
+        TestCase(
+            name="file job with spark conf",
+            expected_status=SUCCESS,
+            config={
+                "name": "test-job",
+                "namespace": "default",
+                "main_file": "s3://bucket/job.py",
                 "spark_conf": {
                     "spark.sql.shuffle.partitions": "8",
                     "spark.executor.memoryOverhead": "512m",
@@ -1388,37 +1498,39 @@ def test_get_spark_application_cr_from_file_job(test_case: TestCase, mock_k8s_ba
         name=test_case.config["name"],
         namespace=test_case.config["namespace"],
         main_file=test_case.config["main_file"],
-        arguments=test_case.config["arguments"],
-        num_executors=test_case.config["num_executors"],
-        resources_per_executor=test_case.config["resources_per_executor"],
+        arguments=test_case.config.get("arguments"),
+        num_executors=test_case.config.get("num_executors"),
+        resources_per_executor=test_case.config.get("resources_per_executor"),
         options=test_case.config.get("options"),
         backend=mock_k8s_backend,
         spark_conf=test_case.config.get("spark_conf"),
     )
-
     assert test_case.expected_status == SUCCESS
 
     assert app.metadata.name == test_case.config["name"]
     assert app.metadata.namespace == test_case.config["namespace"]
 
-    assert app.spec.main_application_file == test_case.config["main_file"]
-    assert app.spec.arguments == test_case.config["arguments"]
+    if test_case.name == "minimal file job":
+        assert app.spec.main_application_file == test_case.config["main_file"]
 
-    assert app.spec.driver.cores == constants.DEFAULT_DRIVER_CPU
-    assert app.spec.driver.memory == _memory_kubernetes_to_spark(
-        constants.DEFAULT_DRIVER_MEMORY,
-    )
-    assert app.spec.driver.service_account == constants.DEFAULT_SERVICE_ACCOUNT
+        assert app.spec.driver.cores == constants.DEFAULT_DRIVER_CPU
+        assert app.spec.driver.memory == _memory_kubernetes_to_spark(
+            constants.DEFAULT_DRIVER_MEMORY,
+        )
 
-    assert app.spec.executor.instances == test_case.config["num_executors"]
-    assert app.spec.executor.cores == 2
-    assert app.spec.executor.memory == _memory_kubernetes_to_spark(
-        "4Gi",
-    )
-    if test_case.name == "build spark application with options":
+    elif test_case.name == "file job with arguments":
+        assert app.spec.arguments == test_case.config["arguments"]
+
+    elif test_case.name == "file job with executor configuration":
+        assert app.spec.executor.instances == 3
+        assert app.spec.executor.cores == 2
+        assert app.spec.executor.memory == "4g"
+
+    elif test_case.name == "build spark application with options":
         assert app.metadata.labels["team"] == "ml"
 
-    assert app.spec.spark_conf == test_case.config.get("spark_conf")
+    elif test_case.name == "file job with spark conf":
+        assert app.spec.spark_conf == test_case.config["spark_conf"]
 
     print("test execution complete")
 
@@ -1427,18 +1539,48 @@ def test_get_spark_application_cr_from_file_job(test_case: TestCase, mock_k8s_ba
     "test_case",
     [
         TestCase(
-            name="build spark application for function job",
+            name="minimal function job",
             expected_status=SUCCESS,
             config={
                 "name": "test-job",
                 "namespace": "default",
                 "func": sample_function,
-                "func_args": None,
+            },
+        ),
+        TestCase(
+            name="function job with args",
+            expected_status=SUCCESS,
+            config={
+                "name": "test-job",
+                "namespace": "default",
+                "func": sample_function_with_args,
+                "func_args": {
+                    "name": "Alice",
+                    "age": 20,
+                },
+            },
+        ),
+        TestCase(
+            name="function job with executor configuration",
+            expected_status=SUCCESS,
+            config={
+                "name": "test-job",
+                "namespace": "default",
+                "func": sample_function,
                 "num_executors": 3,
                 "resources_per_executor": {
                     "cpu": "2",
                     "memory": "4Gi",
                 },
+            },
+        ),
+        TestCase(
+            name="function job with spark conf",
+            expected_status=SUCCESS,
+            config={
+                "name": "test-job",
+                "namespace": "default",
+                "func": sample_function,
                 "spark_conf": {
                     "spark.sql.shuffle.partitions": "8",
                 },
@@ -1476,9 +1618,9 @@ def test_get_spark_application_cr_from_func_job(
         name=test_case.config["name"],
         namespace=test_case.config["namespace"],
         func=test_case.config["func"],
-        func_args=test_case.config["func_args"],
-        num_executors=test_case.config["num_executors"],
-        resources_per_executor=test_case.config["resources_per_executor"],
+        func_args=test_case.config.get("func_args"),
+        num_executors=test_case.config.get("num_executors"),
+        resources_per_executor=test_case.config.get("resources_per_executor"),
         options=test_case.config.get("options"),
         backend=mock_k8s_backend,
         spark_conf=test_case.config.get("spark_conf"),
@@ -1489,27 +1631,38 @@ def test_get_spark_application_cr_from_func_job(
     assert app.metadata.name == test_case.config["name"]
     assert app.metadata.namespace == test_case.config["namespace"]
 
-    assert app.spec.main_application_file == constants.FUNC_JOB_MAIN_FILE
+    if test_case.name == "minimal function job":
+        assert app.spec.main_application_file == constants.FUNC_JOB_MAIN_FILE
 
-    assert app.spec.driver.init_containers is not None
-    assert len(app.spec.driver.init_containers) == 1
-    assert app.spec.driver.init_containers[0].name == constants.FUNC_JOB_INIT_CONTAINER_NAME
+        assert app.spec.driver.init_containers is not None
+        assert len(app.spec.driver.init_containers) == 1
+        assert app.spec.driver.init_containers[0].name == constants.FUNC_JOB_INIT_CONTAINER_NAME
 
-    assert app.spec.driver.volume_mounts is not None
-    assert len(app.spec.driver.volume_mounts) == 1
-    assert app.spec.driver.volume_mounts[0].name == constants.FUNC_JOB_VOLUME_NAME
+        assert app.spec.driver.volume_mounts is not None
+        assert len(app.spec.driver.volume_mounts) == 1
+        assert app.spec.driver.volume_mounts[0].name == constants.FUNC_JOB_VOLUME_NAME
 
-    assert app.spec.volumes is not None
-    assert len(app.spec.volumes) == 1
-    assert app.spec.volumes[0].name == constants.FUNC_JOB_VOLUME_NAME
+        assert app.spec.volumes is not None
+        assert len(app.spec.volumes) == 1
+        assert app.spec.volumes[0].name == constants.FUNC_JOB_VOLUME_NAME
 
-    assert app.spec.executor.instances == 3
-    assert app.spec.executor.cores == 2
-    assert app.spec.executor.memory == "4g"
+    elif test_case.name == "function job with args":
+        command = app.spec.driver.init_containers[0].command[2]
 
-    if test_case.name == "build spark application from function with options":
+        assert "sample_function_with_args(**" in command
+        assert "'name': 'Alice'" in command
+        assert "'age': 20" in command
+
+    elif test_case.name == "function job with executor configuration":
+        assert app.spec.executor.instances == 3
+        assert app.spec.executor.cores == 2
+        assert app.spec.executor.memory == "4g"
+
+    elif test_case.name == "build spark application from function with options":
         assert app.metadata.labels["team"] == "ml"
-    assert app.spec.spark_conf == test_case.config.get("spark_conf")
+
+    elif test_case.name == "function job with spark conf":
+        assert app.spec.spark_conf == test_case.config["spark_conf"]
 
     print("test execution complete")
 

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -1371,22 +1371,6 @@ def test_get_command_using_spark_func(test_case: TestCase) -> None:
             expected_status=SUCCESS,
             config={},
         ),
-        TestCase(
-            name="spark conf overrides executor spec",
-            expected_status=SUCCESS,
-            config={
-                "num_executors": 2,
-                "resources_per_executor": {
-                    "cpu": "2",
-                    "memory": "4Gi",
-                },
-                "spark_conf": {
-                    "spark.executor.instances": "5",
-                    "spark.executor.cores": "4",
-                    "spark.executor.memory": "8Gi",
-                },
-            },
-        ),
     ],
 )
 def test_get_spark_job_executor_spec(test_case: TestCase) -> None:
@@ -1399,22 +1383,16 @@ def test_get_spark_job_executor_spec(test_case: TestCase) -> None:
         resources_per_executor=test_case.config.get(
             "resources_per_executor",
         ),
-        spark_conf=test_case.config.get("spark_conf"),
     )
 
     assert test_case.expected_status == SUCCESS
 
-    if test_case.name == "default spark job executor spec":
-        assert spec.instances == constants.DEFAULT_NUM_EXECUTORS
-        assert spec.cores == constants.DEFAULT_EXECUTOR_CPU
-        assert spec.memory == _memory_kubernetes_to_spark(
-            constants.DEFAULT_EXECUTOR_MEMORY,
-        )
 
-    elif test_case.name == "spark conf overrides executor spec":
-        assert spec.instances == 5
-        assert spec.cores == 4
-        assert spec.memory == "8g"
+    assert spec.instances == constants.DEFAULT_NUM_EXECUTORS
+    assert spec.cores == constants.DEFAULT_EXECUTOR_CPU
+    assert spec.memory == _memory_kubernetes_to_spark(
+        constants.DEFAULT_EXECUTOR_MEMORY,
+    )
 
     print("test execution complete")
 

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -1075,29 +1075,6 @@ def test_resolve_driver_resources(test_case: TestCase) -> None:
                 },
             },
         ),
-        TestCase(
-            name="spark conf overrides executor configuration",
-            expected_status=SUCCESS,
-            config={
-                "executor": Executor(
-                    num_instances=5,
-                    resources_per_executor={
-                        "cpu": "8",
-                        "memory": "16Gi",
-                    },
-                ),
-                "num_executors": 2,
-                "resources_per_executor": {
-                    "cpu": "4",
-                    "memory": "8Gi",
-                },
-                "spark_conf": {
-                    "spark.executor.instances": "10",
-                    "spark.executor.cores": "12",
-                    "spark.executor.memory": "32Gi",
-                },
-            },
-        ),
     ],
 )
 def test_resolve_executor_resources(test_case: TestCase) -> None:
@@ -1109,7 +1086,6 @@ def test_resolve_executor_resources(test_case: TestCase) -> None:
         executor=test_case.config.get("executor"),
         num_executors=test_case.config.get("num_executors"),
         resources_per_executor=test_case.config.get("resources_per_executor"),
-        spark_conf=test_case.config.get("spark_conf"),
     )
 
     assert test_case.expected_status == SUCCESS
@@ -1130,11 +1106,6 @@ def test_resolve_executor_resources(test_case: TestCase) -> None:
         assert instances == 5
         assert cores == 8
         assert memory == "16g"
-
-    elif test_case.name == "spark conf overrides executor configuration":
-        assert instances == 10
-        assert cores == 12
-        assert memory == "32g"
 
     elif test_case.name == "fractional executor memory":
         assert instances == constants.DEFAULT_NUM_EXECUTORS
@@ -1400,6 +1371,22 @@ def test_get_command_using_spark_func(test_case: TestCase) -> None:
             expected_status=SUCCESS,
             config={},
         ),
+        TestCase(
+            name="spark conf overrides executor spec",
+            expected_status=SUCCESS,
+            config={
+                "num_executors": 2,
+                "resources_per_executor": {
+                    "cpu": "2",
+                    "memory": "4Gi",
+                },
+                "spark_conf": {
+                    "spark.executor.instances": "5",
+                    "spark.executor.cores": "4",
+                    "spark.executor.memory": "8Gi",
+                },
+            },
+        ),
     ],
 )
 def test_get_spark_job_executor_spec(test_case: TestCase) -> None:
@@ -1407,15 +1394,27 @@ def test_get_spark_job_executor_spec(test_case: TestCase) -> None:
 
     print("Executing test:", test_case.name)
 
-    spec = get_spark_job_executor_spec()
+    spec = get_spark_job_executor_spec(
+        num_executors=test_case.config.get("num_executors"),
+        resources_per_executor=test_case.config.get(
+            "resources_per_executor",
+        ),
+        spark_conf=test_case.config.get("spark_conf"),
+    )
 
     assert test_case.expected_status == SUCCESS
 
-    assert spec.cores == constants.DEFAULT_EXECUTOR_CPU
-    assert spec.memory == _memory_kubernetes_to_spark(
-        constants.DEFAULT_EXECUTOR_MEMORY,
-    )
-    assert spec.instances == constants.DEFAULT_NUM_EXECUTORS
+    if test_case.name == "default spark job executor spec":
+        assert spec.instances == constants.DEFAULT_NUM_EXECUTORS
+        assert spec.cores == constants.DEFAULT_EXECUTOR_CPU
+        assert spec.memory == _memory_kubernetes_to_spark(
+            constants.DEFAULT_EXECUTOR_MEMORY,
+        )
+
+    elif test_case.name == "spark conf overrides executor spec":
+        assert spec.instances == 5
+        assert spec.cores == 4
+        assert spec.memory == "8g"
 
     print("test execution complete")
 


### PR DESCRIPTION
## Summary

This PR adds support for `spark_conf` when submitting Spark batch jobs with `SparkClient`.

Previously, passing `spark_conf` to `SparkClient.submit_job()` resulted in a `NotImplementedError`. With this change, user-provided Spark configuration is propagated to the generated `SparkApplication` resource.

## Changes

- Remove `NotImplementedError` for `spark_conf` in `SparkClient.submit_job()`.
- Forward `spark_conf` through the Kubernetes backend.
- Populate `SparkApplication.spec.sparkConf` with the provided Spark configuration.
- Update public API docstrings.
- Add unit tests covering `spark_conf` propagation to the generated `SparkApplication`.

## Example

```python
client.submit_job(
    job=FileJob(
        file_source="s3://bucket/job.py",
    ),
    spark_conf={
        "spark.sql.shuffle.partitions": "8",
        "spark.sql.adaptive.enabled": "true",
    },
)
```
closes: #646 
ref: #520 