### PR TITLE
fix(trainer): copy default ignore_patterns for model initializers

### DIFF
--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -427,7 +427,7 @@ class HuggingFaceModelInitializer(BaseInitializer):
     """
 
     ignore_patterns: list[str] | None = field(
-        default_factory=lambda: constants.INITIALIZER_DEFAULT_IGNORE_PATTERNS
+        default_factory=lambda: list(constants.INITIALIZER_DEFAULT_IGNORE_PATTERNS)
     )
     access_token: str | None = None
 
@@ -448,7 +448,7 @@ class S3ModelInitializer(BaseInitializer):
     """
 
     ignore_patterns: list[str] | None = field(
-        default_factory=lambda: constants.INITIALIZER_DEFAULT_IGNORE_PATTERNS
+        default_factory=lambda: list(constants.INITIALIZER_DEFAULT_IGNORE_PATTERNS)
     )
     endpoint: str | None = None
     access_key_id: str | None = None

--- a/kubeflow/trainer/types/types_test.py
+++ b/kubeflow/trainer/types/types_test.py
@@ -149,6 +149,27 @@ def test_hugging_face_model_initializer(test_case: TestCase):
 
 
 @pytest.mark.parametrize(
+    "initializer_cls,storage_uri",
+    [
+        (types.HuggingFaceModelInitializer, "hf://user/model"),
+        (types.S3ModelInitializer, "s3://bucket/model"),
+    ],
+)
+def test_model_initializer_ignore_patterns_are_independent(initializer_cls, storage_uri):
+    """Each model initializer instance gets its own ignore_patterns list."""
+    first = initializer_cls(storage_uri=storage_uri)
+    second = initializer_cls(storage_uri=storage_uri)
+
+    assert first.ignore_patterns is not second.ignore_patterns
+    assert first.ignore_patterns == second.ignore_patterns
+
+    first.ignore_patterns.append("*.custom")
+
+    assert "*.custom" in first.ignore_patterns
+    assert "*.custom" not in second.ignore_patterns
+
+
+@pytest.mark.parametrize(
     "test_case",
     [
         TestCase(


### PR DESCRIPTION
## Summary
- Copy `INITIALIZER_DEFAULT_IGNORE_PATTERNS` in `HuggingFaceModelInitializer` and `S3ModelInitializer` default factories so each instance gets its own list
- Add unit tests verifying mutations on one initializer do not affect another

Fixes #612

## Test plan
- [x] `uv run pytest kubeflow/trainer/types/types_test.py -v`