### PR TITLE
feat(spark): add failing Spark job example for batch job lifecycle

### DIFF
--- a/examples/spark/batch_failed_job.py
+++ b/examples/spark/batch_failed_job.py
@@ -19,7 +19,7 @@ import os
 from kubeflow.common.types import KubernetesBackendConfig
 from kubeflow.spark import FileJob, SparkClient, SparkJobStatus
 
-REMOTE_PI = "https://raw.githubusercontent.com/apache/spark/master/examples/src/main/python/pi.py"
+REMOTE_JOB = "https://raw.githubusercontent.com/kubeflow/sdk/main/examples/spark/spark_failed_job.py"
 
 JOB_NAME: str | None = None
 
@@ -50,7 +50,7 @@ def example_submit_and_wait():
 
     JOB_NAME = client.submit_job(
         job=FileJob(
-            file_source=REMOTE_PI,
+            file_source=REMOTE_JOB,
             args=["hello"],
         ),
         num_executors=1,

--- a/examples/spark/spark_failed_job.py
+++ b/examples/spark/spark_failed_job.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Simple Spark application for SDK batch failed job examples."""
+
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col
+
+# Create a Spark session for the application.
+spark = SparkSession.builder.appName("KubeflowSparkFailureExample").getOrCreate()
+
+try:
+    # Create a small DataFrame.
+    df = spark.range(10).withColumn("square", col("id") * col("id"))
+
+    print("Input DataFrame:")
+    df.show()
+
+    # Trigger a Spark action to ensure the job executes successfully
+    # before intentionally failing.
+    count = df.count()
+    print(f"Row count: {count}")
+
+    print("Intentionally failing the Spark application...")
+
+    # Raise an exception to intentionally fail the Spark application.
+    raise RuntimeError("Intentional failure for Spark SDK E2E testing")
+
+finally:
+    # Stop the Spark session before exiting.
+    spark.stop()


### PR DESCRIPTION
## What this PR does

This PR adds a Spark application that intentionally fails and updates the batch job lifecycle examples to use it via a remote GitHub URI.

The failing example is intended for end-to-end testing of the SparkClient lifecycle APIs for failed batch jobs, including:

- `wait_for_job_status()`
- `get_job()`
- `get_job_logs()`
- `delete_job()`

## Changes

- Add `examples/spark/spark_failed_job.py`
  - Creates a simple Spark DataFrame.
  - Executes a Spark action.
  - Raises a `RuntimeError` intentionally to transition the SparkApplication to the `FAILED` state.

- Update the failed batch job lifecycle example to reference the new script through a remote GitHub URI.

## Why

Previously, the failed batch job example relied on failing an existing Spark example using invalid arguments. This change provides a deterministic and self-contained Spark application that fails intentionally, making the E2E lifecycle tests more reliable and easier to understand.

## Testing

- Ran the failed batch job lifecycle example locally.
- Verified the SparkApplication reaches the `FAILED` state.
- Verified `get_job()` returns the expected status.
- Verified `get_job_logs()` returns the driver logs containing the intentional exception.
- Verified `delete_job()` successfully deletes the SparkApplication.

ref - #611 comment ref - https://github.com/kubeflow/sdk/pull/521/changes#r3585429937