### PR TITLE
feat: add mcp page to sdk website

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -100,7 +100,7 @@ Supported Projects
 Kubeflow MCP Server
 --------------------
 
-We also have the `MCP Server <https://github.com/kubeflow/mcp-server>`_,that exposes the SDK as `Model Context Protocol <https://modelcontextprotocol.io/>`_
+We also have the `MCP Server <https://github.com/kubeflow/mcp-server>`_, that exposes the SDK as `Model Context Protocol <https://modelcontextprotocol.io/>`_
 tools, so agents like Claude, Cursor, or Claude Code can plan, submit, and monitor training jobs
 conversationally — without users needing to learn Kubernetes or the SDK directly.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -97,6 +97,17 @@ Supported Projects
 
 ----
 
+Kubeflow MCP Server
+--------------------
+
+We also have the `MCP Server <https://github.com/kubeflow/mcp-server>`_,that exposes the SDK as `Model Context Protocol <https://modelcontextprotocol.io/>`_
+tools, so agents like Claude, Cursor, or Claude Code can plan, submit, and monitor training jobs
+conversationally — without users needing to learn Kubernetes or the SDK directly.
+
+:doc:`Learn more about the MCP Server → <mcp-server/index>`
+
+----
+
 Getting Involved
 ----------------
 *Join the community and help shape the future of ML on Kubernetes.*
@@ -186,6 +197,15 @@ Getting Involved
 
    hub/index
    hub/api
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   :caption: MCP Server
+
+   mcp-server/index
+   mcp-server/tools
+   mcp-server/configuration
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -98,11 +98,12 @@ Supported Projects
 ----
 
 Kubeflow MCP Server
---------------------
+-------------------
 
-We also have the `MCP Server <https://github.com/kubeflow/mcp-server>`_, that exposes the SDK as `Model Context Protocol <https://modelcontextprotocol.io/>`_
-tools, so agents like Claude, Cursor, or Claude Code can plan, submit, and monitor training jobs
-conversationally — without users needing to learn Kubernetes or the SDK directly.
+We also have the `MCP Server <https://github.com/kubeflow/mcp-server>`_, which exposes the SDK as
+`Model Context Protocol <https://modelcontextprotocol.io/>`_ tools, so agents like Claude, Cursor,
+or Claude Code can plan, submit, and monitor training jobs conversationally — without users
+needing to learn Kubernetes or the SDK directly.
 
 :doc:`Learn more about the MCP Server → <mcp-server/index>`
 

--- a/docs/source/mcp-server/configuration.rst
+++ b/docs/source/mcp-server/configuration.rst
@@ -82,22 +82,6 @@ CLI Reference
      --log-format console \          # console | json (auto-detected if omitted)
      --no-banner                     # suppress startup banner
 
-``kubeflow-mcp agent``
-~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code-block:: bash
-
-   kubeflow-mcp agent \
-     --backend ollama \              # ollama (default; more backends planned)
-     --model qwen3:8b \              # model name for the backend
-     --mode full \                   # full | progressive | semantic
-     --thinking                      # enable thinking output (supported models)
-
-.. note::
-
-   ``kubeflow-mcp agent --otel-endpoint ...`` emits spans under a separate
-   ``kubeflow-mcp-agent`` service in Jaeger, distinct from the ``kubeflow-mcp`` server spans.
-
 Authentication
 --------------
 
@@ -154,7 +138,7 @@ OpenTelemetry tracing is optional and can be enabled without changing tool code.
    export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
    kubeflow-mcp serve
 
-Each tool invocation emits a span with attributes: ``tool.name``, ``tool.args_preview``
+Each tool invocation emits a span with attributes: ``gen_ai.tool.name``, ``tool.args_preview``
 (masked, truncated to 300 chars), ``tool.success``, ``tool.duration_ms``, ``kubeflow.persona``,
 and ``correlation_id``. The OTLP exporter uses a 2s timeout to avoid blocking tool calls, and
 tracing is a no-op when OTel packages are not installed.

--- a/docs/source/mcp-server/configuration.rst
+++ b/docs/source/mcp-server/configuration.rst
@@ -1,0 +1,160 @@
+Configuration
+=============
+
+Environment variables, CLI flags, authentication, and observability for the Kubeflow MCP Server.
+
+Environment Variables
+----------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Variable
+     - Default
+     - Description
+   * - ``MCP_TRANSPORT``
+     - ``http``
+     - Transport protocol (``http``, ``sse``, ``stdio``)
+   * - ``KUBEFLOW_MCP_AUTH_TOKEN``
+     - *(none)*
+     - Bearer token for HTTP auth
+   * - ``KUBEFLOW_MCP_JWKS_URI``
+     - *(none)*
+     - JWKS endpoint for JWT verification (production)
+   * - ``KUBEFLOW_MCP_JWT_ISSUER``
+     - *(none)*
+     - Expected JWT issuer
+   * - ``KUBEFLOW_MCP_JWT_AUDIENCE``
+     - *(none)*
+     - Expected JWT audience
+   * - ``KUBEFLOW_MCP_CLIENTS``
+     - ``trainer``
+     - Comma-separated client modules to load
+   * - ``KUBEFLOW_MCP_PERSONA``
+     - ``readonly``
+     - Tool persona (``readonly``, ``data-scientist``, ``ml-engineer``, ``platform-admin``)
+   * - ``KUBEFLOW_MCP_ALLOWED_HOSTS``
+     - *(loopback)*
+     - Comma-separated ``Host`` header allowlist for DNS rebinding protection; ``:*`` port
+       wildcard supported (e.g. ``mcp.example.com,mcp.example.com:*``)
+   * - ``KUBEFLOW_MCP_ALLOWED_ORIGINS``
+     - *(loopback)*
+     - Comma-separated ``Origin`` header allowlist; ``:*`` port wildcard supported
+       (e.g. ``https://mcp.example.com``)
+   * - ``KUBEFLOW_MCP_DNS_REBINDING_PROTECTION``
+     - ``true``
+     - Set ``false`` to disable Host/Origin validation (not recommended)
+   * - ``LOG_FORMAT``
+     - ``json``
+     - Log format (``json``, ``console``)
+   * - ``LOG_LEVEL``
+     - ``INFO``
+     - Log level (``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``)
+
+.. note::
+
+   DNS rebinding protection allows only loopback ``Host``/``Origin`` headers by default. When
+   exposing the server through a Service or Ingress, set ``KUBEFLOW_MCP_ALLOWED_HOSTS`` (e.g.
+   ``KUBEFLOW_MCP_ALLOWED_HOSTS=kubeflow-mcp.kubeflow.svc:*,mcp.example.com``) or requests will
+   be rejected with HTTP 421.
+
+For in-cluster deployments, replace ``localhost:8000`` with the Kubernetes Service address and
+mount ``KUBEFLOW_MCP_AUTH_TOKEN`` from a Secret.
+
+CLI Reference
+--------------
+
+``kubeflow-mcp serve``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   kubeflow-mcp serve \
+     --clients trainer \             # modules: trainer, optimizer (stub), hub (stub)
+     --persona ml-engineer \         # readonly | data-scientist | ml-engineer | platform-admin
+     --mode full \                   # full | progressive | semantic
+     --instruction-tier full \       # full | compact | minimal
+     --transport stdio \             # stdio | http | sse
+     --auth-token SECRET \           # bearer token for HTTP auth (dev/staging)
+     --otel-endpoint URL \           # OTLP HTTP endpoint (optional tracing)
+     --log-level INFO \              # DEBUG | INFO | WARNING | ERROR
+     --log-format console \          # console | json (auto-detected if omitted)
+     --no-banner                     # suppress startup banner
+
+``kubeflow-mcp agent``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   kubeflow-mcp agent \
+     --backend ollama \              # ollama (default; more backends planned)
+     --model qwen3:8b \              # model name for the backend
+     --mode full \                   # full | progressive | semantic
+     --thinking                      # enable thinking output (supported models)
+
+.. note::
+
+   ``kubeflow-mcp agent --otel-endpoint ...`` emits spans under a separate
+   ``kubeflow-mcp-agent`` service in Jaeger, distinct from the ``kubeflow-mcp`` server spans.
+
+Authentication
+--------------
+
+When using ``--transport http``, configure auth to secure the endpoint:
+
+.. code-block:: bash
+
+   # Simple API key (dev/staging)
+   kubeflow-mcp serve --transport http --auth-token my-secret-token
+
+   # Or via env var
+   export KUBEFLOW_MCP_AUTH_TOKEN=my-secret-token
+   kubeflow-mcp serve --transport http
+
+   # JWT verification (production)
+   export KUBEFLOW_MCP_JWKS_URI=https://auth.example.com/.well-known/jwks.json
+   export KUBEFLOW_MCP_JWT_ISSUER=https://auth.example.com
+   export KUBEFLOW_MCP_JWT_AUDIENCE=kubeflow-mcp
+   kubeflow-mcp serve --transport http
+
+Without auth configured, the server logs a warning that the HTTP endpoint is open.
+
+Security Model
+---------------
+
+- **Persona-based tool filtering** restricts which tools are visible to the AI agent (default
+  ``--persona readonly``, which hides all write tools)
+- **Policy file** (``~/.kf-mcp-policy.yaml``) can further restrict tools and namespaces
+- **Two-phase confirmation** requires ``confirmed=True`` on write tools (preview first, submit
+  after)
+- **Input validation** covers Kubernetes name format, CPU/memory format, resource limits, and
+  training parameter bounds (batch size, epochs, nodes, GPU count, LoRA rank, script size,
+  package count)
+
+``kubeflow-mcp serve`` is single-tenant: one token, one persona, one cluster per instance. In
+multi-user HTTP deployments there is no per-user Kubernetes RBAC enforcement at the MCP layer —
+configure ``--auth-token`` or JWT and enforce identity at the ingress/gateway layer. See
+`ARCHITECTURE.md#security-model <https://github.com/kubeflow/mcp-server/blob/main/ARCHITECTURE.md#security-model>`_
+for the full threat model.
+
+Observability
+-------------
+
+OpenTelemetry tracing is optional and can be enabled without changing tool code.
+
+.. code-block:: bash
+
+   # Install optional dependencies
+   pip install ".[otel]"
+
+   # Enable tracing with CLI flag or env var
+   kubeflow-mcp serve --otel-endpoint http://localhost:4318
+   # or
+   export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+   kubeflow-mcp serve
+
+Each tool invocation emits a span with attributes: ``tool.name``, ``tool.args_preview``
+(masked, truncated to 300 chars), ``tool.success``, ``tool.duration_ms``, ``kubeflow.persona``,
+and ``correlation_id``. The OTLP exporter uses a 2s timeout to avoid blocking tool calls, and
+tracing is a no-op when OTel packages are not installed.

--- a/docs/source/mcp-server/configuration.rst
+++ b/docs/source/mcp-server/configuration.rst
@@ -14,8 +14,9 @@ Environment Variables
      - Default
      - Description
    * - ``MCP_TRANSPORT``
-     - ``http``
-     - Transport protocol (``http``, ``sse``, ``stdio``)
+     - ``stdio``
+     - Transport protocol (``stdio``, ``http``, ``sse``). The Docker image overrides this
+       default to ``http``.
    * - ``KUBEFLOW_MCP_AUTH_TOKEN``
      - *(none)*
      - Bearer token for HTTP auth
@@ -46,8 +47,9 @@ Environment Variables
      - ``true``
      - Set ``false`` to disable Host/Origin validation (not recommended)
    * - ``LOG_FORMAT``
-     - ``json``
-     - Log format (``json``, ``console``)
+     - *(auto)*
+     - Log format (``json``, ``console``); auto-detected when unset — ``console`` when stderr
+       is a TTY, otherwise ``json``
    * - ``LOG_LEVEL``
      - ``INFO``
      - Log level (``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``)
@@ -68,7 +70,7 @@ CLI Reference
 ``kubeflow-mcp serve``
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code-block:: bash
+.. code-block:: text
 
    kubeflow-mcp serve \
      --clients trainer \             # modules: trainer, optimizer (stub), hub (stub)
@@ -108,7 +110,7 @@ Security Model
 ---------------
 
 - **Persona-based tool filtering** restricts which tools are visible to the AI agent (default
-  ``--persona readonly``, which hides all write tools)
+  ``--persona readonly``, which exposes only planning, discovery, monitoring, and health tools)
 - **Policy file** (``~/.kf-mcp-policy.yaml``) can further restrict tools and namespaces
 - **Two-phase confirmation** requires ``confirmed=True`` on write tools (preview first, submit
   after)
@@ -129,8 +131,8 @@ OpenTelemetry tracing is optional and can be enabled without changing tool code.
 
 .. code-block:: bash
 
-   # Install optional dependencies
-   pip install ".[otel]"
+   # Install optional dependencies (a uv dependency group, not a pip extra)
+   uv sync --group otel
 
    # Enable tracing with CLI flag or env var
    kubeflow-mcp serve --otel-endpoint http://localhost:4318

--- a/docs/source/mcp-server/index.rst
+++ b/docs/source/mcp-server/index.rst
@@ -30,17 +30,17 @@ Benefits
 Installation
 ------------
 
-Install from source:
+.. code-block:: bash
+
+   pip install kubeflow-mcp
+
+Alternatively, install from source:
 
 .. code-block:: bash
 
    git clone https://github.com/kubeflow/mcp-server.git
    cd mcp-server
    pip install .
-
-.. note::
-
-   Once published to PyPI, install with ``pip install kubeflow-mcp``.
 
 Or run the pre-built multi-arch image published to GHCR on every release:
 
@@ -91,19 +91,19 @@ Once connected, your AI agent can run a complete training workflow through natur
 
 .. code-block:: text
 
-   User: "Fine-tune gemma-2b on the alpaca dataset"
+   User: "Fine-tune Llama 3.2 1B on the alpaca dataset"
 
    Agent calls: check_compatibility()        → ✅ K8s 1.29, Trainer CRD installed
    Agent calls: get_cluster_resources()      → 4x A100 GPUs available
-   Agent calls: estimate_resources("google/gemma-2b") → needs ~16GB GPU, 1x A100
-   Agent calls: list_runtimes()              → torchtune-llama, torchtune-gemma, ...
+   Agent calls: estimate_resources("meta-llama/Llama-3.2-1B") → needs ~8GB GPU, 1x A100
+   Agent calls: list_runtimes()              → torchtune-llama3.2-1b, torchtune-llama3.2-3b, ...
    Agent calls: fine_tune(                   → preview config (confirmed=False)
-       model="hf://google/gemma-2b",
+       model="hf://meta-llama/Llama-3.2-1B",
        dataset="hf://tatsu-lab/alpaca",
-       runtime="torchtune-gemma-2b"
+       runtime="torchtune-llama3.2-1b"
    )
-   Agent calls: fine_tune(..., confirmed=True) → TrainJob "train-gemma-abc" created
-   Agent calls: get_training_logs("train-gemma-abc") → training progress...
+   Agent calls: fine_tune(..., confirmed=True) → TrainJob "train-llama-abc" created
+   Agent calls: get_training_logs("train-llama-abc") → training progress...
 
 Every mutating tool requires ``confirmed=True`` — agents always preview before submitting.
 
@@ -123,7 +123,7 @@ Key Concepts
 ------------
 
 **Persona**: A server-side role filter restricting which tools are visible to a caller.
-Defaults to ``readonly``, which hides all write tools.
+Defaults to ``readonly``, which exposes only planning, discovery, monitoring, and health tools.
 
 **Phase**: One of Planning, Discovery, Training, Monitoring, Lifecycle, Platform, or Health —
 see :doc:`tools` for the full catalog.

--- a/docs/source/mcp-server/index.rst
+++ b/docs/source/mcp-server/index.rst
@@ -1,5 +1,5 @@
-Introduction
-============
+MCP Server
+==========
 
 Let AI agents drive Kubeflow training workflows through natural language.
 
@@ -60,7 +60,18 @@ Quick Start
 
    kubeflow-mcp serve
 
-Add it to your agent's MCP client config (HTTP transport):
+This defaults to the ``stdio`` transport. For Claude Code, register it directly:
+
+.. code-block:: bash
+
+   claude mcp add kubeflow -- kubeflow-mcp serve
+
+To use the HTTP transport instead (e.g. the Docker image, which defaults to HTTP), start the
+server with ``--transport http`` and add it to your agent's MCP client config:
+
+.. code-block:: bash
+
+   kubeflow-mcp serve --transport http --auth-token my-secret-token
 
 .. code-block:: json
 
@@ -72,12 +83,6 @@ Add it to your agent's MCP client config (HTTP transport):
        }
      }
    }
-
-For Claude Code, register it directly:
-
-.. code-block:: bash
-
-   claude mcp add kubeflow -- kubeflow-mcp serve
 
 Example: Fine-Tune a Model via AI Agent
 ----------------------------------------

--- a/docs/source/mcp-server/index.rst
+++ b/docs/source/mcp-server/index.rst
@@ -1,0 +1,141 @@
+Introduction
+============
+
+Let AI agents drive Kubeflow training workflows through natural language.
+
+Overview
+--------
+
+The `Kubeflow MCP Server <https://github.com/kubeflow/mcp-server>`_ exposes Kubeflow Trainer
+operations as `Model Context Protocol <https://modelcontextprotocol.io/>`_ tools, built on top
+of the Kubeflow SDK's ``TrainerClient``. It lets AI agents (Claude, Cursor, Claude Code, or any
+custom agent) plan, submit, monitor, and manage training jobs conversationally, without users
+needing to learn Kubernetes or the Kubeflow SDK directly.
+
+It is developed and released as a separate project from the SDK — see
+`KEP-936 <https://github.com/kubeflow/community/tree/master/proposals/936-kubeflow-mcp-server>`_
+for the design proposal.
+
+Benefits
+--------
+
+- **Agent-Native** - Tools are auto-discovered via MCP, with no manual API wiring
+- **Guided Workflow** - Phase ordering with next-step hints (Plan → Discover → Train → Monitor)
+- **Preview-Before-Submit** - Every mutating operation requires explicit confirmation
+- **Security-First** - Persona gating, namespace enforcement, input validation, bearer/JWT auth
+- **Multi-Platform** - Auto-detects OpenShift, EKS, and GKE with platform-specific guidance
+- **Token-Efficient** - Progressive/semantic modes compress 23 tools into 2-3 meta-tools
+- **Extensible** - Plugin architecture for additional Kubeflow clients (optimizer and hub planned)
+
+Installation
+------------
+
+Install from source:
+
+.. code-block:: bash
+
+   git clone https://github.com/kubeflow/mcp-server.git
+   cd mcp-server
+   pip install .
+
+.. note::
+
+   Once published to PyPI, install with ``pip install kubeflow-mcp``.
+
+Or run the pre-built multi-arch image published to GHCR on every release:
+
+.. code-block:: bash
+
+   docker run --rm -p 8000:8000 \
+     -e KUBEFLOW_MCP_AUTH_TOKEN=my-secret-token \
+     ghcr.io/kubeflow/mcp-server:latest
+
+The server listens on ``http://localhost:8000/mcp``. See :doc:`configuration` for environment
+variables, authentication, and CLI flags.
+
+Quick Start
+-----------
+
+.. code-block:: bash
+
+   kubeflow-mcp serve
+
+Add it to your agent's MCP client config (HTTP transport):
+
+.. code-block:: json
+
+   {
+     "mcpServers": {
+       "kubeflow": {
+         "url": "http://localhost:8000/mcp",
+         "headers": { "Authorization": "Bearer my-secret-token" }
+       }
+     }
+   }
+
+For Claude Code, register it directly:
+
+.. code-block:: bash
+
+   claude mcp add kubeflow -- kubeflow-mcp serve
+
+Example: Fine-Tune a Model via AI Agent
+----------------------------------------
+
+Once connected, your AI agent can run a complete training workflow through natural language:
+
+.. code-block:: text
+
+   User: "Fine-tune gemma-2b on the alpaca dataset"
+
+   Agent calls: check_compatibility()        → ✅ K8s 1.29, Trainer CRD installed
+   Agent calls: get_cluster_resources()      → 4x A100 GPUs available
+   Agent calls: estimate_resources("google/gemma-2b") → needs ~16GB GPU, 1x A100
+   Agent calls: list_runtimes()              → torchtune-llama, torchtune-gemma, ...
+   Agent calls: fine_tune(                   → preview config (confirmed=False)
+       model="hf://google/gemma-2b",
+       dataset="hf://tatsu-lab/alpaca",
+       runtime="torchtune-gemma-2b"
+   )
+   Agent calls: fine_tune(..., confirmed=True) → TrainJob "train-gemma-abc" created
+   Agent calls: get_training_logs("train-gemma-abc") → training progress...
+
+Every mutating tool requires ``confirmed=True`` — agents always preview before submitting.
+
+How It Works
+------------
+
+1. **Connect** - The server loads Kubeflow SDK clients (``trainer``, with ``optimizer`` and
+   ``hub`` planned) and registers their operations as MCP tools
+2. **Filter by persona** - The active persona (``readonly``, ``data-scientist``,
+   ``ml-engineer``, ``platform-admin``) determines which tools are visible to the caller
+3. **Preview, then confirm** - Mutating tools return a preview when called without
+   ``confirmed=True``, and only apply the change on a confirmed follow-up call
+4. **Guide by phase** - Tool responses include next-step hints so agents follow the
+   Plan → Discover → Train → Monitor workflow instead of guessing what to call next
+
+Key Concepts
+------------
+
+**Persona**: A server-side role filter restricting which tools are visible to a caller.
+Defaults to ``readonly``, which hides all write tools.
+
+**Phase**: One of Planning, Discovery, Training, Monitoring, Lifecycle, Platform, or Health —
+see :doc:`tools` for the full catalog.
+
+**Two-Phase Confirmation**: Write tools require ``confirmed=True``; the first call always
+returns a preview so agents (and the humans supervising them) can review before mutating
+cluster state.
+
+**Mode**: ``full`` exposes all tools directly; ``progressive`` and ``semantic`` collapse them
+into 2-3 meta-tools for hierarchical or embedding-based discovery, reducing token usage.
+
+See Also
+--------
+
+- :doc:`tools` - Full tool catalog by workflow phase, and version compatibility
+- :doc:`configuration` - Environment variables, CLI reference, authentication, observability
+- `Demo (OSS India) <https://youtu.be/cZ2BP5hQjc8>`_ - Recorded walkthrough of the MCP Server
+- `kubeflow/mcp-server on GitHub <https://github.com/kubeflow/mcp-server>`_
+- `ROADMAP <https://github.com/kubeflow/mcp-server/blob/main/ROADMAP.md>`_ and
+  `SECURITY <https://github.com/kubeflow/mcp-server/blob/main/SECURITY.md>`_

--- a/docs/source/mcp-server/tools.rst
+++ b/docs/source/mcp-server/tools.rst
@@ -1,7 +1,8 @@
 Tools
 =====
 
-The Kubeflow MCP Server exposes 23 tools organized by workflow phase.
+The Kubeflow MCP Server exposes tools organized by workflow phase — see the catalog below for
+the current count.
 
 Tool Catalog
 ------------
@@ -50,17 +51,18 @@ Tool Discovery Modes
      - Tools exposed
      - Description
    * - ``full``
-     - 23
-     - All tools registered directly (default)
+     - up to 23
+     - All persona-allowed tools registered directly (default mode; the default ``readonly``
+       persona exposes 12 of the 23)
    * - ``progressive``
-     - ~3 meta-tools
+     - 3 meta-tools
      - Hierarchical discovery (~85 tokens); agents drill down by phase
    * - ``semantic``
-     - ~2 meta-tools
+     - 2 meta-tools
      - Embedding-search discovery (~69 tokens); agents query by intent
 
 ``progressive`` and ``semantic`` modes significantly reduce token consumption for agent
-workflows compared to registering all 23 tools directly.
+workflows compared to registering all persona-allowed tools directly.
 
 Requirements
 ------------
@@ -76,7 +78,7 @@ Requirements
      - Kubernetes
    * - 0.1.x
      - >= 2.2.0
-     - >= 0.4.0
+     - == 0.4.0
      - 3.10 - 3.12
      - >= 1.27
 
@@ -90,8 +92,9 @@ Container and Kubernetes probes are available without MCP authentication:
    GET /health  # liveness: the server process is accepting HTTP requests
    GET /ready   # readiness: configured clients imported and packaged resources loaded
 
-``/ready`` returns 200 only when both ``clients_ready`` and ``resources_ready`` are true. It
-does not contact Kubernetes or other APIs, so it is not a live dependency check. A missing
-packaged resource Markdown file keeps ``/ready`` at 503 even though ``/health`` and registered
-tools remain available; check the server logs and package contents rather than cluster
-dependencies.
+``/ready`` returns ``{"status": "ready"}`` with HTTP 200 only when the configured clients
+imported successfully **and** all packaged resources loaded; otherwise it returns
+``{"status": "not_ready"}`` with HTTP 503. It does not contact Kubernetes or other APIs, so it
+is not a live dependency check. A missing packaged resource Markdown file keeps ``/ready`` at
+503 even though ``/health`` and registered tools remain available; check the server logs and
+package contents rather than cluster dependencies.

--- a/docs/source/mcp-server/tools.rst
+++ b/docs/source/mcp-server/tools.rst
@@ -1,0 +1,97 @@
+Tools
+=====
+
+The Kubeflow MCP Server exposes 23 tools organized by workflow phase.
+
+Tool Catalog
+------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 40 45
+
+   * - Phase
+     - Tools
+     - Description
+   * - Planning
+     - ``pre_flight``, ``check_compatibility``, ``get_cluster_resources``, ``estimate_resources``
+     - Environment validation and resource estimation
+   * - Discovery
+     - ``list_training_jobs``, ``get_training_job``, ``list_runtimes``, ``get_runtime``
+     - Browse jobs and available runtimes
+   * - Training
+     - ``fine_tune``, ``run_custom_training``, ``run_container_training``
+     - Submit LoRA/QLoRA fine-tuning, custom scripts, or container jobs
+   * - Monitoring
+     - ``get_training_logs``, ``get_training_events``, ``wait_for_training``
+     - Track progress and debug failures
+   * - Lifecycle
+     - ``delete_training_job``, ``update_training_job``
+     - Manage existing jobs (ownership-guarded)
+   * - Platform
+     - ``inspect_crd``, ``inspect_controller``, ``patch_runtime``, ``create_runtime``, ``delete_runtime``
+     - Cluster inspection and runtime management
+   * - Health
+     - ``health_check``, ``get_server_logs``
+     - Server diagnostics
+
+Every mutating tool (``fine_tune``, ``run_custom_training``, ``run_container_training``,
+``delete_training_job``, ``update_training_job``, ``patch_runtime``, ``create_runtime``,
+``delete_runtime``) requires ``confirmed=True`` — the first call always returns a preview.
+
+Tool Discovery Modes
+---------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Mode
+     - Tools exposed
+     - Description
+   * - ``full``
+     - 23
+     - All tools registered directly (default)
+   * - ``progressive``
+     - ~3 meta-tools
+     - Hierarchical discovery (~85 tokens); agents drill down by phase
+   * - ``semantic``
+     - ~2 meta-tools
+     - Embedding-search discovery (~69 tokens); agents query by intent
+
+``progressive`` and ``semantic`` modes significantly reduce token consumption for agent
+workflows compared to registering all 23 tools directly.
+
+Requirements
+------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 20 20
+
+   * - MCP Server
+     - Kubeflow Trainer
+     - Kubeflow SDK
+     - Python
+     - Kubernetes
+   * - 0.1.x
+     - >= 2.2.0
+     - >= 0.4.0
+     - 3.10 - 3.12
+     - >= 1.27
+
+Health and Readiness
+---------------------
+
+Container and Kubernetes probes are available without MCP authentication:
+
+.. code-block:: text
+
+   GET /health  # liveness: the server process is accepting HTTP requests
+   GET /ready   # readiness: configured clients imported and packaged resources loaded
+
+``/ready`` returns 200 only when both ``clients_ready`` and ``resources_ready`` are true. It
+does not contact Kubernetes or other APIs, so it is not a live dependency check. A missing
+packaged resource Markdown file keeps ``/ready`` at 503 even though ``/health`` and registered
+tools remain available; check the server logs and package contents rather than cluster
+dependencies.


### PR DESCRIPTION
**What this PR does / why we need it**:
I am adding the [kubeflow-mcp](https://github.com/kubeflow/mcp-server) page to sdk website with its intro, setup and tool capabilities.


**Which issue(s) this PR fixes** 
Related: https://github.com/kubeflow/mcp-server/issues/116

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
