### PR TITLE
fix: populate job status in LocalProcessBackend.list_jobs()

### DIFF
--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -102,7 +102,6 @@ class LocalProcessBackend(RuntimeBackend):
         # localprocess backend only supports CustomTrainer
         if not isinstance(trainer, types.CustomTrainer):
             raise ValueError("CustomTrainer must be set with LocalProcessBackend")
-
         # create temp dir
         venv_dir = tempfile.mkdtemp(prefix=trainjob_name)
         logger.debug(f"operating in {venv_dir}")
@@ -162,6 +161,7 @@ class LocalProcessBackend(RuntimeBackend):
                         types.Step(name=s.step_name, pod_name=s.step_name, status=s.job.status)
                         for s in _job.steps
                     ],
+                    status=self.__get_job_status(_job),
                 )
             )
         return result

--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -401,6 +401,23 @@ def test_list_jobs(local_backend, test_case):
     runtime = test_case.config.get("runtime")
     jobs = local_backend.list_jobs(runtime=runtime)
     assert isinstance(jobs, list)
+    step = Mock()
+    step.step_name = "train"
+    step.job.status = constants.TRAINJOB_COMPLETE
+
+    job = Mock()
+    job.name = "job-1"
+    job.created = None
+    job.runtime = Mock()
+    job.runtime.name = TORCH_RUNTIME
+    job.steps = [step]
+
+    local_backend._LocalProcessBackend__local_jobs.append(job)
+
+    jobs = local_backend.list_jobs()
+
+    assert len(jobs) == 1
+    assert jobs[0].status == constants.TRAINJOB_COMPLETE
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an inconsistency in the LocalProcess backend.

`get_job()` computes and returns the current job status using `self.__get_job_status(_job)`, while `list_jobs()` did not populate the `status` field. As a result, every `TrainJob` returned by `list_jobs()` reported the default `"Unknown"` status, even when the underlying job had already completed, failed, or was still running.

This change updates `list_jobs()` to populate the `status` field using the same status resolution logic as `get_job()`, ensuring consistent behavior across both APIs.

A regression test has also been added to verify that `list_jobs()` returns the correct job status.

**Which issue(s) this PR fixes**:

Fixes #703

**Checklist:**

- [ ] Docs included if any changes are user facing