### PR TITLE
feat(spark): support spark_conf for batch job submission

### DIFF
--- a/kubeflow/spark/api/spark_client.py
+++ b/kubeflow/spark/api/spark_client.py
@@ -200,31 +200,34 @@ class SparkClient:
                 Format: ``{"cpu": "5", "memory": "10Gi"}``.
 
             spark_conf:
-                Spark configuration dictionary.
+                Optional Spark configuration properties applied to the
+                submitted application. Keys and values must be strings.
 
             options:
                 List of additional Spark configuration options.
 
+        Returns:
+            Name of the submitted Spark job.
+
         Raises:
             ValueError:
-                If unsupported Phase 1 features are requested or the job definition is invalid.
+                If the job definition, resource configuration, or Spark
+                configuration is invalid.
 
             TypeError:
                 If the job type is invalid.
 
             NotImplementedError:
-                If unsupported features are requested.
+                If ``options`` is provided.
         """
-        if spark_conf is not None:
-            raise NotImplementedError("spark_conf support is not yet implemented.")
-
         if options is not None:
-            raise NotImplementedError("options are not supported in Phase 1.")
+            raise NotImplementedError("options support is not yet implemented.")
 
         return self.backend.submit_job(
             job=job,
             num_executors=num_executors,
             resources_per_executor=resources_per_executor,
+            spark_conf=spark_conf,
         ).name
 
     def get_job(self, name: str) -> SparkJob:

--- a/kubeflow/spark/api/spark_client_test.py
+++ b/kubeflow/spark/api/spark_client_test.py
@@ -56,67 +56,58 @@ def test_create_and_connect(test_case: TestCase):
         if "namespace" in test_case.config:
             with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as mock:
                 SparkClient(
-                    backend_config=KubernetesBackendConfig(namespace=test_case.config["namespace"])
+                    backend_config=KubernetesBackendConfig(
+                        namespace=test_case.config["namespace"],
+                    )
                 )
                 mock.assert_called_once()
         elif "backend_config" in test_case.config:
-            SparkClient(backend_config=test_case.config["backend_config"])
+            SparkClient(
+                backend_config=test_case.config["backend_config"],
+            )
         else:
             with patch("kubeflow.spark.api.spark_client.KubernetesBackend"):
                 client = SparkClient()
                 assert client.backend is not None
 
-        # If we reach here but expected an exception, fail
+        # If we reach here but expected an exception, fail.
         assert test_case.expected_status == SUCCESS, (
             f"Expected exception but none was raised for {test_case.name}"
         )
     except Exception as e:
-        # If we got an exception but expected success, fail
+        # If we got an exception but expected success, fail.
         assert test_case.expected_status == FAILED, f"Unexpected exception in {test_case.name}: {e}"
-        # Validate the exception type if specified
+
+        # Validate the exception type if specified.
         if test_case.expected_error:
             assert isinstance(e, test_case.expected_error), (
-                f"Expected exception type '{test_case.expected_error.__name__}' but got '{type(e).__name__}: {str(e)}'"
+                f"Expected exception type "
+                f"'{test_case.expected_error.__name__}' but got "
+                f"'{type(e).__name__}: {str(e)}'"
             )
 
 
 @pytest.mark.parametrize(
-    "job,spark_conf,options,backend_error,expected_error",
+    "job,backend_error,expected_error",
     [
         (
             "not-a-job",
-            None,
-            None,
-            TypeError("job must be an instance of FileJob or FuncJob."),
+            TypeError(
+                "job must be an instance of FileJob or FuncJob.",
+            ),
             TypeError,
         ),
         (
             FileJob(file_source=""),
-            None,
-            None,
-            ValueError("`job.file_source` must be a non-empty string."),
+            ValueError(
+                "`job.file_source` must be a non-empty string.",
+            ),
             ValueError,
-        ),
-        (
-            FileJob(file_source="s3://bucket/job.py"),
-            {"spark.executor.memory": "4g"},
-            None,
-            None,
-            NotImplementedError,
-        ),
-        (
-            FileJob(file_source="s3://bucket/job.py"),
-            None,
-            [object()],
-            None,
-            NotImplementedError,
         ),
     ],
 )
 def test_submit_job_validation(
     job,
-    spark_conf,
-    options,
     backend_error,
     expected_error,
 ):
@@ -124,18 +115,42 @@ def test_submit_job_validation(
 
     with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as mock_backend:
         backend = mock_backend.return_value
-
-        if backend_error is not None:
-            backend.submit_job.side_effect = backend_error
+        backend.submit_job.side_effect = backend_error
 
         client = SparkClient()
 
         with pytest.raises(expected_error):
+            client.submit_job(job=job)
+
+        backend.submit_job.assert_called_once_with(
+            job=job,
+            num_executors=None,
+            resources_per_executor=None,
+            spark_conf=None,
+        )
+
+
+def test_submit_job_rejects_options():
+    """Test that unsupported batch job options are rejected."""
+
+    job = FileJob(
+        file_source="s3://bucket/job.py",
+    )
+
+    with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as mock_backend:
+        backend = mock_backend.return_value
+        client = SparkClient()
+
+        with pytest.raises(
+            NotImplementedError,
+            match="options support is not yet implemented",
+        ):
             client.submit_job(
                 job=job,
-                spark_conf=spark_conf,
-                options=options,
+                options=[object()],
             )
+
+        backend.submit_job.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -149,7 +164,21 @@ def test_submit_job_validation(
         ),
     ],
 )
-def test_submit_job_success(job):
+@pytest.mark.parametrize(
+    "spark_conf",
+    [
+        None,
+        {},
+        {
+            "spark.sql.adaptive.enabled": "true",
+            "spark.sql.shuffle.partitions": "200",
+        },
+    ],
+)
+def test_submit_job_success(
+    job,
+    spark_conf,
+):
     """Test successful submit_job."""
 
     with patch("kubeflow.spark.api.spark_client.KubernetesBackend") as mock_backend:
@@ -162,7 +191,10 @@ def test_submit_job_success(job):
 
         client = SparkClient()
 
-        name = client.submit_job(job=job)
+        name = client.submit_job(
+            job=job,
+            spark_conf=spark_conf,
+        )
 
         assert name == "spark-job-123"
 
@@ -170,4 +202,5 @@ def test_submit_job_success(job):
             job=job,
             num_executors=None,
             resources_per_executor=None,
+            spark_conf=spark_conf,
         )

--- a/kubeflow/spark/backends/base.py
+++ b/kubeflow/spark/backends/base.py
@@ -149,6 +149,7 @@ class RuntimeBackend(abc.ABC):
         job: FileJob | FuncJob,
         num_executors: int | None = None,
         resources_per_executor: dict[str, str] | None = None,
+        spark_conf: dict[str, str] | None = None,
     ) -> SparkJob:
         """Submit a Spark batch job.
 
@@ -156,6 +157,8 @@ class RuntimeBackend(abc.ABC):
             job: Spark application to execute.
             num_executors: Number of executor instances.
             resources_per_executor: Resource requirements for each executor.
+            spark_conf: Optional Spark configuration properties applied to the
+                submitted application. Keys and values must be strings.
 
         Returns:
             Submitted Spark job information.

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -917,6 +917,7 @@ class KubernetesBackend(RuntimeBackend):
         job: FileJob | FuncJob,
         num_executors: int | None = None,
         resources_per_executor: dict[str, str] | None = None,
+        spark_conf: dict[str, str] | None = None,
     ) -> SparkJob:
         """Submit a SparkApplication for batch execution.
 
@@ -930,12 +931,16 @@ class KubernetesBackend(RuntimeBackend):
             resources_per_executor:
                 Resource requirements per executor.
 
+            spark_conf:
+                Optional Spark configuration properties applied to the
+                submitted application. Keys and values must be strings.
+
         Returns:
             SparkJob information object.
 
         Raises:
             ValueError:
-                If job validation fails.
+                If job, resource, or Spark configuration validation fails.
 
             TimeoutError:
                 If SparkApplication creation times out.
@@ -960,6 +965,7 @@ class KubernetesBackend(RuntimeBackend):
                 arguments=job.args,
                 num_executors=num_executors,
                 resources_per_executor=resources_per_executor,
+                spark_conf=spark_conf,
             )
 
         else:
@@ -970,6 +976,7 @@ class KubernetesBackend(RuntimeBackend):
                 func_args=job.func_args,
                 num_executors=num_executors,
                 resources_per_executor=resources_per_executor,
+                spark_conf=spark_conf,
             )
 
         try:

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -1228,13 +1228,17 @@ def test_validate_job(kubernetes_backend, test_case):
     "test_case",
     [
         TestCase(
-            name="valid remote file submission",
+            name="valid remote file submission with spark configuration",
             expected_status=SUCCESS,
             config={
                 "job": FileJob(
                     file_source="s3://bucket/job.py",
                     args=["--date", "2026-06-30"],
                 ),
+                "spark_conf": {
+                    "spark.sql.adaptive.enabled": "true",
+                    "spark.sql.shuffle.partitions": "200",
+                },
             },
         ),
         TestCase(
@@ -1268,12 +1272,16 @@ def test_validate_job(kubernetes_backend, test_case):
             expected_error=ValueError,
         ),
         TestCase(
-            name="valid function job submission",
+            name="valid function job submission with spark configuration",
             expected_status=SUCCESS,
             config={
                 "job": FuncJob(
                     func=sample_func,
                 ),
+                "spark_conf": {
+                    "spark.sql.adaptive.enabled": "true",
+                    "spark.sql.shuffle.partitions": "200",
+                },
                 "use_mock_command": True,
             },
         ),
@@ -1289,6 +1297,8 @@ def test_submit_job(kubernetes_backend, test_case):
             DEFAULT_NAMESPACE,
         )
 
+        spark_conf = test_case.config.get("spark_conf")
+
         if test_case.config.get("use_mock_command"):
             with patch(
                 "kubeflow.spark.backends.kubernetes.backend.get_spark_application_cr_from_func_job",
@@ -1299,17 +1309,28 @@ def test_submit_job(kubernetes_backend, test_case):
 
                 job = kubernetes_backend.submit_job(
                     job=test_case.config["job"],
+                    spark_conf=spark_conf,
                 )
 
                 mock_build.assert_called_once()
 
-                assert mock_build.call_args.kwargs["func"] == test_case.config["job"].func
-                assert mock_build.call_args.kwargs["func_args"] == test_case.config["job"].func_args
+                assert mock_build.call_args.kwargs["func"] == (test_case.config["job"].func)
+                assert mock_build.call_args.kwargs["func_args"] == (
+                    test_case.config["job"].func_args
+                )
+                assert mock_build.call_args.kwargs["spark_conf"] == (spark_conf)
 
         else:
             job = kubernetes_backend.submit_job(
                 job=test_case.config["job"],
+                spark_conf=spark_conf,
             )
+
+            if test_case.expected_status == SUCCESS and spark_conf is not None:
+                create_mock = kubernetes_backend.custom_api.create_namespaced_custom_object
+                body = create_mock.call_args.kwargs["body"]
+
+                assert body["spec"]["sparkConf"] == spark_conf
 
         assert test_case.expected_status == SUCCESS
         assert job.name.startswith("spark-job-")

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -705,6 +705,7 @@ def get_spark_application_cr_from_file_job(
     arguments: list[str] | None = None,
     num_executors: int | None = None,
     resources_per_executor: dict[str, str] | None = None,
+    spark_conf: dict[str, str] | None = None,
 ) -> models.SparkV1beta2SparkApplication:
     """Build a SparkApplication custom resource for a file-based Spark job.
 
@@ -715,13 +716,15 @@ def get_spark_application_cr_from_file_job(
         arguments: Command-line arguments passed to the Spark application.
         num_executors: Number of executor instances.
         resources_per_executor: Resource requirements for each executor.
+        spark_conf: Optional Spark configuration properties applied to the
+            SparkApplication. Keys and values must be strings.
 
     Returns:
         SparkApplication custom resource model.
 
     Raises:
         ValueError:
-            If the executor resource configuration is invalid.
+            If the executor resource or Spark configuration is invalid.
     """
     return models.SparkV1beta2SparkApplication(
         api_version=f"{constants.SPARK_APPLICATION_GROUP}/{constants.SPARK_APPLICATION_VERSION}",
@@ -737,6 +740,7 @@ def get_spark_application_cr_from_file_job(
             image=constants.DEFAULT_SPARK_IMAGE,
             main_application_file=main_file,
             arguments=arguments or None,
+            spark_conf=spark_conf,
             driver=get_spark_job_driver_spec(),
             executor=get_spark_job_executor_spec(
                 num_executors=num_executors,
@@ -753,6 +757,7 @@ def get_spark_application_cr_from_func_job(
     func_args: dict[str, Any] | None = None,
     num_executors: int | None = None,
     resources_per_executor: dict[str, str] | None = None,
+    spark_conf: dict[str, str] | None = None,
 ) -> models.SparkV1beta2SparkApplication:
     """Build a SparkApplication custom resource for a function-based Spark job.
 
@@ -763,13 +768,15 @@ def get_spark_application_cr_from_func_job(
         func_args: Keyword arguments passed to the function.
         num_executors: Number of executor instances.
         resources_per_executor: Resource requirements for each executor.
+        spark_conf: Optional Spark configuration properties applied to the
+            SparkApplication. Keys and values must be strings.
 
     Returns:
         SparkApplication custom resource model.
 
     Raises:
         ValueError:
-            If the provided function is invalid or the executor resource
+            If the provided function, executor resource, or Spark
             configuration is invalid.
     """
 
@@ -791,6 +798,7 @@ def get_spark_application_cr_from_func_job(
             mode="cluster",
             image=constants.DEFAULT_SPARK_IMAGE,
             main_application_file=constants.FUNC_JOB_MAIN_FILE,
+            spark_conf=spark_conf,
             driver=get_spark_job_driver_spec(),
             executor=get_spark_job_executor_spec(
                 num_executors=num_executors,

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -1209,6 +1209,10 @@ def test_get_spark_job_executor_spec(test_case: TestCase) -> None:
                     "cpu": "2",
                     "memory": "4Gi",
                 },
+                "spark_conf": {
+                    "spark.sql.adaptive.enabled": "true",
+                    "spark.sql.shuffle.partitions": "200",
+                },
             },
         ),
     ],
@@ -1225,6 +1229,7 @@ def test_get_spark_application_cr_from_file_job(test_case: TestCase) -> None:
         arguments=test_case.config["arguments"],
         num_executors=test_case.config["num_executors"],
         resources_per_executor=test_case.config["resources_per_executor"],
+        spark_conf=test_case.config["spark_conf"],
     )
 
     assert test_case.expected_status == SUCCESS
@@ -1247,6 +1252,9 @@ def test_get_spark_application_cr_from_file_job(test_case: TestCase) -> None:
         "4Gi",
     )
 
+    assert app.spec.spark_conf == test_case.config["spark_conf"]
+    assert app.to_dict()["spec"]["sparkConf"] == (test_case.config["spark_conf"])
+
     print("test execution complete")
 
 
@@ -1266,6 +1274,10 @@ def test_get_spark_application_cr_from_file_job(test_case: TestCase) -> None:
                     "cpu": "2",
                     "memory": "4Gi",
                 },
+                "spark_conf": {
+                    "spark.sql.adaptive.enabled": "true",
+                    "spark.sql.shuffle.partitions": "200",
+                },
             },
         ),
     ],
@@ -1284,6 +1296,7 @@ def test_get_spark_application_cr_from_func_job(
         func_args=test_case.config["func_args"],
         num_executors=test_case.config["num_executors"],
         resources_per_executor=test_case.config["resources_per_executor"],
+        spark_conf=test_case.config["spark_conf"],
     )
 
     assert test_case.expected_status == SUCCESS
@@ -1309,7 +1322,40 @@ def test_get_spark_application_cr_from_func_job(
     assert app.spec.executor.cores == 2
     assert app.spec.executor.memory == "4g"
 
+    assert app.spec.spark_conf == test_case.config["spark_conf"]
+    assert app.to_dict()["spec"]["sparkConf"] == (test_case.config["spark_conf"])
+
     print("test execution complete")
+
+
+def test_spark_application_builders_reject_invalid_spark_conf() -> None:
+    """Tests strict Spark configuration value validation."""
+
+    invalid_spark_conf = {
+        "spark.sql.shuffle.partitions": 200,
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="Input should be a valid string",
+    ):
+        get_spark_application_cr_from_file_job(
+            name="file-job",
+            namespace="default",
+            main_file="s3://bucket/job.py",
+            spark_conf=invalid_spark_conf,
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="Input should be a valid string",
+    ):
+        get_spark_application_cr_from_func_job(
+            name="func-job",
+            namespace="default",
+            func=sample_function,
+            spark_conf=invalid_spark_conf,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Adds support for passing user-provided `spark_conf` through Spark batch job
submission.

The configuration is propagated from `SparkClient.submit_job()` through
the backend abstraction and Kubernetes backend into `spec.sparkConf` on
the generated SparkApplication custom resource.

Both `FileJob` and `FuncJob` submissions are supported.

## Changes

- Forward `spark_conf` from `SparkClient.submit_job()`.
- Add `spark_conf` to the backend submission interface.
- Propagate `spark_conf` through `KubernetesBackend.submit_job()`.
- Populate `spec.sparkConf` for FileJob SparkApplications.
- Populate `spec.sparkConf` for FuncJob SparkApplications.
- Preserve the existing unsupported `options` behavior.
- Add SparkClient API forwarding tests.
- Add Kubernetes backend propagation tests.
- Add SparkApplication serialization tests.
- Add validation coverage for non-string Spark configuration values.

## Example

```python
client.submit_job(
    job=FileJob(
        file_source="s3://bucket/job.py",
    ),
    spark_conf={
        "spark.sql.adaptive.enabled": "true",
        "spark.sql.shuffle.partitions": "200",
    },
)
```

The generated SparkApplication contains:
```python
spec:
  sparkConf:
    spark.sql.adaptive.enabled: "true"
    spark.sql.shuffle.partitions: "200"
```

Testing
✅ python -m py_compile for all seven changed Python files
✅ python -m pytest kubeflow/spark/backends/kubernetes/utils_test.py::test_get_spark_application_cr_from_file_job -vv — 1 passed
✅ python -m pytest kubeflow/spark/backends/kubernetes/utils_test.py::test_get_spark_application_cr_from_func_job -vv — 1 passed
✅ python -m pytest kubeflow/spark/backends/kubernetes/utils_test.py::test_spark_application_builders_reject_invalid_spark_conf -vv — 1 passed
✅ python -m pytest kubeflow/spark/api/spark_client_test.py -vv — 12 passed
✅ python -m pytest kubeflow/spark/backends/kubernetes/backend_test.py -vv — 111 passed
✅ python -m pytest kubeflow/spark/backends/kubernetes/utils_test.py -vv — 75 passed
✅ Combined SparkClient, Kubernetes backend, and utility suite — 198 passed
✅ pre-commit run --files kubeflow/spark/api/spark_client.py kubeflow/spark/api/spark_client_test.py kubeflow/spark/backends/base.py kubeflow/spark/backends/kubernetes/backend.py kubeflow/spark/backends/kubernetes/backend_test.py kubeflow/spark/backends/kubernetes/utils.py kubeflow/spark/backends/kubernetes/utils_test.py
✅ git diff --check

**Scope**
This PR implements the spark_conf portion of advanced batch job
configuration.

General options support, examples, and E2E tests remain separate
follow-up work under the SparkClient production-readiness epic.

Closes #705
Part of #655