### PR TITLE
fix: classify HuggingFace dataset dir with a dotted parent as data_dir, not data_files

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -527,7 +527,7 @@ def get_args_using_torchtune_config(
         parts = storage_uri_parsed.path.strip("/").split("/")
         relative_path = "/".join(parts[1:]) if len(parts) > 1 else "."
 
-        if relative_path != "." and "." in relative_path:
+        if relative_path != "." and "." in relative_path.split("/")[-1]:
             args.append(f"dataset.data_files={os.path.join(constants.DATASET_PATH, relative_path)}")
         else:
             args.append(f"dataset.data_dir={os.path.join(constants.DATASET_PATH, relative_path)}")

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -997,6 +997,21 @@ def _build_builtin_runtime() -> types.Runtime:
             ],
         ),
         TestCase(
+            name="directory dataset with a dot in a parent path produces data_dir arg",
+            expected_status=SUCCESS,
+            config={
+                "fine_tuning_config": types.TorchTuneConfig(),
+                "initializer": types.Initializer(
+                    dataset=types.HuggingFaceDatasetInitializer(
+                        storage_uri="hf://tatsu-lab/alpaca/my.v2/train",
+                    ),
+                ),
+            },
+            expected_output=[
+                f"dataset.data_dir={os.path.join(constants.DATASET_PATH, 'my.v2/train')}",
+            ],
+        ),
+        TestCase(
             name="nested directory dataset uri produces data_dir arg",
             expected_status=SUCCESS,
             config={

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -1012,6 +1012,22 @@ def _build_builtin_runtime() -> types.Runtime:
             ],
         ),
         TestCase(
+            name="file dataset under a dotted parent path still produces data_files arg",
+            expected_status=SUCCESS,
+            config={
+                "fine_tuning_config": types.TorchTuneConfig(),
+                "initializer": types.Initializer(
+                    dataset=types.HuggingFaceDatasetInitializer(
+                        storage_uri="hf://tatsu-lab/alpaca/my.v2/train/data.json",
+                    ),
+                ),
+            },
+            expected_output=[
+                f"dataset.data_files="
+                f"{os.path.join(constants.DATASET_PATH, 'my.v2/train/data.json')}",
+            ],
+        ),
+        TestCase(
             name="nested directory dataset uri produces data_dir arg",
             expected_status=SUCCESS,
             config={


### PR DESCRIPTION
get_args_using_torchtune_config decides dataset.data_files vs dataset.data_dir with `"." in relative_path`, which matches a dot anywhere in the path. so a directory whose parent segment contains a dot, e.g. hf://tatsu-lab/alpaca/my.v2/train (relative_path "my.v2/train"), is misclassified as data_files, and torchtune then tries to load a directory as a file.

fix: check only the final path component (`"." in relative_path.split("/")[-1]`) so the extension heuristic looks at the leaf name, not parent dirs. no change for the existing file/dir cases.

added a test case (directory with a dot in a parent path). before the change it emits data_files=.../my.v2/train (test fails); after, data_dir=.../my.v2/train:

    pytest kubeflow/trainer/backends/kubernetes/utils_test.py -k torchtune
