### PR TITLE
fix: strip trailing newline in get_default_target_namespace

### DIFF
--- a/kubeflow/common/utils.py
+++ b/kubeflow/common/utils.py
@@ -30,13 +30,15 @@ def get_default_target_namespace(context: str | None = None) -> str:
             if context:
                 for c in all_contexts:
                     if isinstance(c, dict) and c.get("name") == context:
-                        return c["context"]["namespace"]
+                        return c.get("context", {}).get("namespace") or constants.DEFAULT_NAMESPACE
             # Otherwise, try to get namespace from the current context.
-            return current_context["context"]["namespace"]
+            return (
+                current_context.get("context", {}).get("namespace") or constants.DEFAULT_NAMESPACE
+            )
         except Exception:
             return constants.DEFAULT_NAMESPACE
     with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace") as f:
-        return f.readline()
+        return f.read().strip()
 
 
 def validate_wait_for_job_status(polling_interval: int, timeout: int) -> None:

--- a/kubeflow/common/utils_test.py
+++ b/kubeflow/common/utils_test.py
@@ -67,3 +67,42 @@ def test_validate_wait_for_job_status(test_case):
             utils.validate_wait_for_job_status(polling_interval, timeout)
     else:
         utils.validate_wait_for_job_status(polling_interval, timeout)
+
+
+def test_get_default_target_namespace_in_k8s(mocker):
+    """Test get_default_target_namespace strips trailing newlines when running in k8s."""
+    mocker.patch("kubeflow.common.utils.is_running_in_k8s", return_value=True)
+    mock_open = mocker.patch("builtins.open", mocker.mock_open(read_data="my-namespace\n"))
+
+    namespace = utils.get_default_target_namespace()
+
+    assert namespace == "my-namespace"
+    mock_open.assert_called_once_with("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+
+
+def test_get_default_target_namespace_out_of_k8s_with_context(mocker):
+    """Test get_default_target_namespace resolves namespace from specified or current context."""
+    mocker.patch("kubeflow.common.utils.is_running_in_k8s", return_value=False)
+    all_contexts = [
+        {"name": "ctx1", "context": {"namespace": "ns1"}},
+        {"name": "ctx2", "context": {"namespace": "ns2"}},
+    ]
+    current_context = {"name": "ctx1", "context": {"namespace": "ns1"}}
+    mocker.patch(
+        "kubernetes.config.list_kube_config_contexts",
+        return_value=(all_contexts, current_context),
+    )
+
+    assert utils.get_default_target_namespace(context="ctx2") == "ns2"
+    assert utils.get_default_target_namespace() == "ns1"
+
+
+def test_get_default_target_namespace_out_of_k8s_fallback(mocker):
+    """Test get_default_target_namespace fallback to DEFAULT_NAMESPACE on exception."""
+    mocker.patch("kubeflow.common.utils.is_running_in_k8s", return_value=False)
+    mocker.patch(
+        "kubernetes.config.list_kube_config_contexts",
+        side_effect=Exception("No kubeconfig"),
+    )
+
+    assert utils.get_default_target_namespace() == "default"


### PR DESCRIPTION
**What this PR does / why we need it**:
When `get_default_target_namespace()` runs in-cluster (`is_running_in_k8s()` returns `True`), reading `/var/run/secrets/kubernetes.io/serviceaccount/namespace` via `f.readline()` retains the trailing newline character `\n` from the mounted service account file.

This PR updates `get_default_target_namespace()` in `kubeflow/common/utils.py` to call `.strip()` when reading the service account file, ensuring that clean, valid namespace strings without trailing whitespace or newlines are returned. It also safely accesses the `"namespace"` key in `kubeconfig` contexts with fallback to `DEFAULT_NAMESPACE`.

**Which issue(s) this PR fixes**:

Fixes #710

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
