### PR TITLE
fix: populate TrainJob status in LocalProcessBackend.list_jobs    

### DIFF
--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -152,16 +152,18 @@ class LocalProcessBackend(RuntimeBackend):
         for _job in self.__local_jobs:
             if runtime and _job.runtime.name != runtime.name:
                 continue
+            status = self.__get_job_status(_job)
             result.append(
                 types.TrainJob(
                     name=_job.name,
                     creation_timestamp=_job.created,
-                    runtime=runtime,
+                    runtime=_job.runtime,
                     num_nodes=1,
                     steps=[
                         types.Step(name=s.step_name, pod_name=s.step_name, status=s.job.status)
                         for s in _job.steps
                     ],
+                    status=status,
                 )
             )
         return result

--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -22,6 +22,7 @@ import pytest
 
 from kubeflow.trainer.backends.localprocess.backend import LocalProcessBackend
 from kubeflow.trainer.backends.localprocess.constants import LOCAL_RUNTIME_IMAGE
+from kubeflow.trainer.backends.localprocess.job import LocalJob
 from kubeflow.trainer.backends.localprocess.types import (
     LocalProcessBackendConfig,
     LocalRuntimeTrainer,
@@ -409,6 +410,33 @@ def test_list_jobs(local_backend, test_case):
     runtime = test_case.config.get("runtime")
     jobs = local_backend.list_jobs(runtime=runtime)
     assert isinstance(jobs, list)
+
+
+def test_list_jobs_sets_job_status(local_backend):
+    """Test LocalProcessBackend.list_jobs() returns the actual TrainJob status."""
+    runtime = local_backend.get_runtime(TORCH_RUNTIME)
+    step_job = LocalJob(
+        name=f"{BASIC_TRAIN_JOB_NAME}-train",
+        command=["python", "-c", "print('training')"],
+    )
+    step_job._status = constants.TRAINJOB_COMPLETE
+    local_backend._LocalProcessBackend__register_job(
+        train_job_name=BASIC_TRAIN_JOB_NAME,
+        step_name="train",
+        job=step_job,
+        runtime=runtime,
+    )
+
+    jobs = local_backend.list_jobs()
+
+    assert len(jobs) == 1
+    listed_job = jobs[0]
+    fetched_job = local_backend.get_job(BASIC_TRAIN_JOB_NAME)
+    assert listed_job.name == fetched_job.name
+    assert listed_job.creation_timestamp == fetched_job.creation_timestamp
+    assert listed_job.steps == fetched_job.steps
+    assert listed_job.runtime is runtime
+    assert listed_job.status == fetched_job.status == constants.TRAINJOB_COMPLETE
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an inconsistency between `LocalProcessBackend.get_job()` and `LocalProcessBackend.list_jobs()`.

Previously, `list_jobs()` constructed `TrainJob` objects without setting the `status` field, causing every job returned by `list_jobs()` to report `Unknown` regardless of its actual state.

This change computes the job status using the existing `__get_job_status()` helper before constructing each `TrainJob`, making the behavior of `list_jobs()` consistent with `get_job()` and ensuring callers receive the correct job status.

**Which issue(s) this PR fixes**:

Fixes #703

**Checklist:**

- [ ] Docs included if any changes are user facing