### PR TITLE
fix(trainer): merge custom env with parent environment in LocalJob

### DIFF
--- a/kubeflow/trainer/backends/localprocess/job.py
+++ b/kubeflow/trainer/backends/localprocess/job.py
@@ -76,6 +76,14 @@ class LocalJob(threading.Thread):
             # change working directory to venv before executing script
             os.chdir(self.execution_dir)
 
+            # Merge custom env vars with parent environment to prevent losing
+            # inherited variables like PATH, HOME, PYTHONPATH, etc.
+            # subprocess.Popen's env parameter replaces ALL env vars, so we must
+            # explicitly merge with os.environ (see subprocess.Popen documentation)
+            merged_env = os.environ.copy()
+            if self.env:
+                merged_env.update(self.env)
+
             self._process = subprocess.Popen(
                 self.command,
                 stdout=subprocess.PIPE,
@@ -83,7 +91,7 @@ class LocalJob(threading.Thread):
                 text=True,
                 encoding="utf-8",
                 bufsize=1,
-                env=self.env,
+                env=merged_env,
             )
             # set job status
             self._status = constants.TRAINJOB_RUNNING

--- a/kubeflow/trainer/backends/localprocess/job_test.py
+++ b/kubeflow/trainer/backends/localprocess/job_test.py
@@ -1,0 +1,57 @@
+# Copyright 2025 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the LocalJob class in the Kubeflow Trainer SDK.
+"""
+
+import sys
+
+from kubeflow.trainer.backends.localprocess.job import LocalJob
+
+# A child script that reports whether it received an inherited PATH and the
+# value of a custom variable. Uses sys.executable so the interpreter itself is
+# resolvable via an absolute path regardless of the child's PATH, isolating the
+# test to the env-inheritance behaviour under test.
+_PROBE = (
+    "import os;"
+    "print('HAS_PATH', bool(os.environ.get('PATH')));"
+    "print('CUSTOM', os.environ.get('KF_TEST_CUSTOM'))"
+)
+
+
+def _run(env):
+    job = LocalJob(name="env-probe", command=[sys.executable, "-c", _PROBE], env=env)
+    job.start()
+    job.join(timeout=30)
+    return job
+
+
+def test_local_job_inherits_parent_env_when_env_not_set():
+    """With no custom env, the child must still inherit the parent environment
+    (e.g. PATH). Passing env=None previously wiped it via subprocess.Popen."""
+    job = _run(None)
+
+    assert job.success, job.stdout
+    assert "HAS_PATH True" in job.stdout
+
+
+def test_local_job_merges_custom_env_with_parent_env():
+    """Custom env vars must be merged on top of the inherited environment, not
+    replace it, so both the custom var and PATH are present in the child."""
+    job = _run({"KF_TEST_CUSTOM": "hello"})
+
+    assert job.success, job.stdout
+    assert "HAS_PATH True" in job.stdout
+    assert "CUSTOM hello" in job.stdout


### PR DESCRIPTION
## What

`LocalJob` (localprocess backend) passed the user-supplied `env` dict straight into `subprocess.Popen(env=...)`. Per the CPython docs, `Popen`'s `env` argument does not merge with the parent environment, it replaces it entirely. `LocalJob.__init__` also normalises a missing env to an empty dict (`self.env = env or {}`), so the common case of creating a job without custom env vars results in `Popen(env={})`, which launches the child process with no environment at all: no `PATH`, no `HOME`, no `PYTHONPATH`.

## Why it matters

This is the default path, not an edge case. A local training job created without an explicit `env` loses the inherited environment, so the child cannot resolve interpreters or tools on `PATH` and cannot import anything that depends on the parent environment. On the failing run the child Python interpreter cannot even initialise (`_Py_HashRandomization_Init: failed to get random numbers`) and exits non-zero. Users who do pass custom env vars also silently lose their inherited environment, since the custom dict replaces rather than extends it.

## The fix

Merge the custom env on top of a copy of the parent environment before spawning:

```python
merged_env = os.environ.copy()
if self.env:
    merged_env.update(self.env)
...
subprocess.Popen(..., env=merged_env)
```

`os` is already imported. This is the standard documented pattern for extending, rather than replacing, the subprocess environment. No behaviour change for callers that relied on custom vars taking precedence, since `update()` still lets them override inherited keys.

## Tests

Added `kubeflow/trainer/backends/localprocess/job_test.py` with two cases, both driving a real subprocess (no mocks) so they exercise the actual `Popen` env path:

- `test_local_job_inherits_parent_env_when_env_not_set` — with no custom env, the child must still see `PATH`.
- `test_local_job_merges_custom_env_with_parent_env` — a custom var is present in the child AND `PATH` is still inherited.

The probe runs via `sys.executable` so the interpreter resolves by absolute path regardless of the child's `PATH`, isolating the test to the env-inheritance behaviour and keeping it portable across OSes.

Verified red then green: reverting the one-line change to `env=self.env` fails both tests (child exits non-zero, env wiped); the fix makes both pass.

```
kubeflow/trainer/backends/localprocess/job_test.py::test_local_job_inherits_parent_env_when_env_not_set PASSED
kubeflow/trainer/backends/localprocess/job_test.py::test_local_job_merges_custom_env_with_parent_env PASSED
```
