### PR TITLE
fix(trainer): stop wait_for_job_status from timing out early when timeout/polling_interval rounds down

### DIFF
--- a/kubeflow/optimizer/backends/kubernetes/backend.py
+++ b/kubeflow/optimizer/backends/kubernetes/backend.py
@@ -294,7 +294,8 @@ class KubernetesBackend(RuntimeBackend):
                 f"Received polling_interval={polling_interval}, timeout={timeout}"
             )
 
-        for _ in range(round(timeout / polling_interval)):
+        end_time = time.time() + timeout
+        while time.time() < end_time:
             optimization_job = self.get_job(name)
             logger.debug(
                 f"{constants.OPTIMIZATION_JOB_KIND} {name}, status {optimization_job.status}"

--- a/kubeflow/optimizer/backends/kubernetes/backend_test.py
+++ b/kubeflow/optimizer/backends/kubernetes/backend_test.py
@@ -1088,6 +1088,55 @@ def test_wait_for_job_status(optimizer_backend, test_case):
     print("test execution complete")
 
 
+def test_wait_for_job_status_polls_for_full_timeout(optimizer_backend):
+    """Regression test for round(timeout / polling_interval) truncating the poll loop.
+
+    With timeout=5 and polling_interval=2, round(5 / 2) == 2 under Python's
+    banker's rounding, which previously stopped polling after 2 iterations
+    (~4s) instead of covering the full 5s timeout. The loop must keep polling
+    until the elapsed time reaches the timeout, regardless of rounding.
+    """
+    # No status conditions -> OptimizationJob stays at its default CREATED
+    # status, which never matches the COMPLETE status we wait for below.
+    experiment = create_experiment_cr(name=BASIC_OPTIMIZATION_JOB_NAME)
+
+    poll_count = 0
+
+    def patched_get(*args, **kwargs):
+        nonlocal poll_count
+        mock_thread = Mock()
+        if args[3] == constants.EXPERIMENT_PLURAL:
+            poll_count += 1
+            mock_thread.get.return_value = normalize_model(experiment, models.V1beta1Experiment)
+        return mock_thread
+
+    optimizer_backend.custom_api.get_namespaced_custom_object.side_effect = patched_get
+
+    fake_time = [0.0]
+
+    def fake_time_time():
+        return fake_time[0]
+
+    def fake_sleep(seconds):
+        fake_time[0] += seconds
+
+    with (
+        patch("time.time", side_effect=fake_time_time),
+        patch("time.sleep", side_effect=fake_sleep),
+        pytest.raises(TimeoutError),
+    ):
+        optimizer_backend.wait_for_job_status(
+            name=BASIC_OPTIMIZATION_JOB_NAME,
+            status={constants.OPTIMIZATION_JOB_COMPLETE},
+            timeout=5,
+            polling_interval=2,
+        )
+
+    # Old code: range(round(5 / 2)) == range(2) -> exactly 2 polls.
+    # Fixed code must poll a 3rd time before the 5s timeout elapses.
+    assert poll_count == 3
+
+
 @pytest.mark.parametrize(
     "test_case",
     [

--- a/kubeflow/optimizer/backends/kubernetes/backend_test.py
+++ b/kubeflow/optimizer/backends/kubernetes/backend_test.py
@@ -1089,15 +1089,7 @@ def test_wait_for_job_status(optimizer_backend, test_case):
 
 
 def test_wait_for_job_status_polls_for_full_timeout(optimizer_backend):
-    """Regression test for round(timeout / polling_interval) truncating the poll loop.
-
-    With timeout=5 and polling_interval=2, round(5 / 2) == 2 under Python's
-    banker's rounding, which previously stopped polling after 2 iterations
-    (~4s) instead of covering the full 5s timeout. The loop must keep polling
-    until the elapsed time reaches the timeout, regardless of rounding.
-    """
-    # No status conditions -> OptimizationJob stays at its default CREATED
-    # status, which never matches the COMPLETE status we wait for below.
+    """Test KubernetesBackend.wait_for_job_status polls until timeout elapses."""
     experiment = create_experiment_cr(name=BASIC_OPTIMIZATION_JOB_NAME)
 
     poll_count = 0
@@ -1132,8 +1124,6 @@ def test_wait_for_job_status_polls_for_full_timeout(optimizer_backend):
             polling_interval=2,
         )
 
-    # Old code: range(round(5 / 2)) == range(2) -> exactly 2 polls.
-    # Fixed code must poll a 3rd time before the 5s timeout elapses.
     assert poll_count == 3
 
 

--- a/kubeflow/trainer/backends/kubernetes/backend.py
+++ b/kubeflow/trainer/backends/kubernetes/backend.py
@@ -491,7 +491,8 @@ class KubernetesBackend(RuntimeBackend):
                 f"Received polling_interval={polling_interval}, timeout={timeout}"
             )
 
-        for _ in range(round(timeout / polling_interval)):
+        end_time = time.time() + timeout
+        while time.time() < end_time:
             # Check the status after event is generated for the TrainJob's Pods.
             trainjob = self.get_job(name)
             logger.debug(f"TrainJob {name}, status {trainjob.status}")

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -1743,13 +1743,7 @@ def test_wait_for_job_status(kubernetes_backend, test_case):
 
 
 def test_wait_for_job_status_polls_for_full_timeout(kubernetes_backend):
-    """Regression test for round(timeout / polling_interval) truncating the poll loop.
-
-    With timeout=5 and polling_interval=2, round(5 / 2) == 2 under Python's
-    banker's rounding, which previously stopped polling after 2 iterations
-    (~4s) instead of covering the full 5s timeout. The loop must keep polling
-    until the elapsed time reaches the timeout, regardless of rounding.
-    """
+    """Test KubernetesBackend.wait_for_job_status polls until timeout elapses."""
     original_get_job = kubernetes_backend.get_job
     poll_count = 0
 
@@ -1782,8 +1776,6 @@ def test_wait_for_job_status_polls_for_full_timeout(kubernetes_backend):
             polling_interval=2,
         )
 
-    # Old code: range(round(5 / 2)) == range(2) -> exactly 2 polls.
-    # Fixed code must poll a 3rd time before the 5s timeout elapses.
     assert poll_count == 3
 
 

--- a/kubeflow/trainer/backends/kubernetes/backend_test.py
+++ b/kubeflow/trainer/backends/kubernetes/backend_test.py
@@ -1742,6 +1742,51 @@ def test_wait_for_job_status(kubernetes_backend, test_case):
     print("test execution complete")
 
 
+def test_wait_for_job_status_polls_for_full_timeout(kubernetes_backend):
+    """Regression test for round(timeout / polling_interval) truncating the poll loop.
+
+    With timeout=5 and polling_interval=2, round(5 / 2) == 2 under Python's
+    banker's rounding, which previously stopped polling after 2 iterations
+    (~4s) instead of covering the full 5s timeout. The loop must keep polling
+    until the elapsed time reaches the timeout, regardless of rounding.
+    """
+    original_get_job = kubernetes_backend.get_job
+    poll_count = 0
+
+    def mock_get_job(name):
+        nonlocal poll_count
+        poll_count += 1
+        job = original_get_job(name)
+        job.status = constants.TRAINJOB_RUNNING
+        return job
+
+    kubernetes_backend.get_job = mock_get_job
+
+    fake_time = [0.0]
+
+    def fake_time_time():
+        return fake_time[0]
+
+    def fake_sleep(seconds):
+        fake_time[0] += seconds
+
+    with (
+        patch("time.time", side_effect=fake_time_time),
+        patch("time.sleep", side_effect=fake_sleep),
+        pytest.raises(TimeoutError),
+    ):
+        kubernetes_backend.wait_for_job_status(
+            name=BASIC_TRAIN_JOB_NAME,
+            status={constants.TRAINJOB_COMPLETE},
+            timeout=5,
+            polling_interval=2,
+        )
+
+    # Old code: range(round(5 / 2)) == range(2) -> exactly 2 polls.
+    # Fixed code must poll a 3rd time before the 5s timeout elapses.
+    assert poll_count == 3
+
+
 @pytest.mark.parametrize(
     "test_case",
     [

--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -236,7 +236,8 @@ class LocalProcessBackend(RuntimeBackend):
         if _job is None:
             raise ValueError(f"No TrainJob with name {name}")
 
-        for _ in range(round(timeout / polling_interval)):
+        end_time = time.time() + timeout
+        while time.time() < end_time:
             # Get current job status
             trainjob = self.get_job(name)
 

--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -475,16 +475,7 @@ def test_wait_for_job_status(local_backend, test_case):
 
 
 def test_wait_for_job_status_polls_for_full_timeout(local_backend):
-    """Regression test for round(timeout / polling_interval) truncating the poll loop.
-
-    With timeout=5 and polling_interval=2, round(5 / 2) == 2 under Python's
-    banker's rounding, which previously stopped polling after 2 iterations
-    (~4s) instead of covering the full 5s timeout. The loop must keep polling
-    until the elapsed time reaches the timeout, regardless of rounding.
-    """
-    # Register a job so the pre-loop existence check passes.
-    # `Mock(name=...)` sets the mock's repr, not the `.name` attribute, so set
-    # it explicitly to match what `wait_for_job_status` filters on.
+    """Test LocalProcessBackend.wait_for_job_status polls until timeout elapses."""
     stub_job = Mock()
     stub_job.name = BASIC_TRAIN_JOB_NAME
     local_backend._LocalProcessBackend__local_jobs.append(stub_job)
@@ -520,8 +511,6 @@ def test_wait_for_job_status_polls_for_full_timeout(local_backend):
             polling_interval=2,
         )
 
-    # Old code: range(round(5 / 2)) == range(2) -> exactly 2 polls.
-    # Fixed code must poll a 3rd time before the 5s timeout elapses.
     assert poll_count == 3
 
 

--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -474,6 +474,57 @@ def test_wait_for_job_status(local_backend, test_case):
             local_backend.wait_for_job_status(**test_case.config)
 
 
+def test_wait_for_job_status_polls_for_full_timeout(local_backend):
+    """Regression test for round(timeout / polling_interval) truncating the poll loop.
+
+    With timeout=5 and polling_interval=2, round(5 / 2) == 2 under Python's
+    banker's rounding, which previously stopped polling after 2 iterations
+    (~4s) instead of covering the full 5s timeout. The loop must keep polling
+    until the elapsed time reaches the timeout, regardless of rounding.
+    """
+    # Register a job so the pre-loop existence check passes.
+    # `Mock(name=...)` sets the mock's repr, not the `.name` attribute, so set
+    # it explicitly to match what `wait_for_job_status` filters on.
+    stub_job = Mock()
+    stub_job.name = BASIC_TRAIN_JOB_NAME
+    local_backend._LocalProcessBackend__local_jobs.append(stub_job)
+
+    poll_count = 0
+
+    def mock_get_job(name):
+        nonlocal poll_count
+        poll_count += 1
+        job = Mock(spec=types.TrainJob)
+        job.status = constants.TRAINJOB_RUNNING
+        return job
+
+    local_backend.get_job = mock_get_job
+
+    fake_time = [0.0]
+
+    def fake_time_time():
+        return fake_time[0]
+
+    def fake_sleep(seconds):
+        fake_time[0] += seconds
+
+    with (
+        patch("time.time", side_effect=fake_time_time),
+        patch("time.sleep", side_effect=fake_sleep),
+        pytest.raises(TimeoutError),
+    ):
+        local_backend.wait_for_job_status(
+            name=BASIC_TRAIN_JOB_NAME,
+            status={constants.TRAINJOB_COMPLETE},
+            timeout=5,
+            polling_interval=2,
+        )
+
+    # Old code: range(round(5 / 2)) == range(2) -> exactly 2 polls.
+    # Fixed code must poll a 3rd time before the 5s timeout elapses.
+    assert poll_count == 3
+
+
 @pytest.mark.parametrize(
     "test_case",
     [


### PR DESCRIPTION
## Summary

Fixes #592. `wait_for_job_status()` in the Trainer Kubernetes backend, the Trainer LocalProcess backend, and the Optimizer Kubernetes backend all built their poll loop as `for _ in range(round(timeout / polling_interval))`. Python's `round()` uses banker's rounding, so a call like `timeout=5, polling_interval=2` gives `round(2.5) == 2`, and the loop stops after ~4 seconds instead of running for the full 5 seconds the caller asked for — raising `TimeoutError` early. I replaced the fixed iteration count with elapsed-time polling (`while time.time() < start + timeout`), which is the same pattern the container backend already uses, so all backends are now consistent.

## Changes

- `kubeflow/trainer/backends/kubernetes/backend.py`
- `kubeflow/trainer/backends/localprocess/backend.py`
- `kubeflow/optimizer/backends/kubernetes/backend.py` (same bug, not called out in the issue but hit by the identical pattern)

## Test plan

- Added a regression test per backend that mocks `time.time`/`time.sleep` and asserts the loop polls a 3rd time before raising `TimeoutError` for `timeout=5, polling_interval=2` — the exact case that used to round down and cut the loop short.
- Verified each new test fails against the old `range(round(...))` code and passes against the fix.
- `make verify` (ruff check, ruff format, ty check) passes.
- Full `kubeflow/` unit test suite passes: 665 passed, no regressions.