### PR TITLE
fix(trainer): reject job names with path separators before they reach the filesystem

### DIFF
--- a/kubeflow/common/utils.py
+++ b/kubeflow/common/utils.py
@@ -39,6 +39,22 @@ def get_default_target_namespace(context: str | None = None) -> str:
         return f.readline()
 
 
+def validate_filesystem_safe_name(name: str) -> None:
+    """Validate that a job name is safe to use as a filesystem path component.
+
+    Args:
+        name: The job name to validate.
+
+    Raises:
+        ValueError: If the name contains path separators or path traversal sequences.
+    """
+    if "/" in name or "\\" in name or name in (".", ".."):
+        raise ValueError(
+            f'Invalid job name "{name}". Job name must not contain path separators '
+            "('/' or '\\\\') or path traversal sequences ('.' or '..')."
+        )
+
+
 def validate_wait_for_job_status(polling_interval: int, timeout: int) -> None:
     """Validate polling_interval and timeout values used by wait_for_job_status methods.
 

--- a/kubeflow/common/utils_test.py
+++ b/kubeflow/common/utils_test.py
@@ -67,3 +67,66 @@ def test_validate_wait_for_job_status(test_case):
             utils.validate_wait_for_job_status(polling_interval, timeout)
     else:
         utils.validate_wait_for_job_status(polling_interval, timeout)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid simple name",
+            expected_status=SUCCESS,
+            config={"name": "my-train-job"},
+        ),
+        TestCase(
+            name="valid name with uuid suffix",
+            expected_status=SUCCESS,
+            config={"name": "a1b2c3d4e5f6"},
+        ),
+        TestCase(
+            name="forward slash rejected",
+            expected_status=SUCCESS,
+            config={"name": "experiment/run_1"},
+            expected_error=ValueError,
+            expected_output="Invalid job name",
+        ),
+        TestCase(
+            name="backslash rejected",
+            expected_status=SUCCESS,
+            config={"name": "experiment\\run_1"},
+            expected_error=ValueError,
+            expected_output="Invalid job name",
+        ),
+        TestCase(
+            name="path traversal rejected",
+            expected_status=SUCCESS,
+            config={"name": "../run"},
+            expected_error=ValueError,
+            expected_output="Invalid job name",
+        ),
+        TestCase(
+            name="current directory rejected",
+            expected_status=SUCCESS,
+            config={"name": "."},
+            expected_error=ValueError,
+            expected_output="Invalid job name",
+        ),
+        TestCase(
+            name="parent directory rejected",
+            expected_status=SUCCESS,
+            config={"name": ".."},
+            expected_error=ValueError,
+            expected_output="Invalid job name",
+        ),
+    ],
+)
+def test_validate_filesystem_safe_name(test_case):
+    """Test validate_filesystem_safe_name across valid and invalid inputs."""
+    print("Executing test:", test_case.name)
+
+    name = test_case.config["name"]
+
+    if test_case.expected_error:
+        with pytest.raises(test_case.expected_error, match=test_case.expected_output):
+            utils.validate_filesystem_safe_name(name)
+    else:
+        utils.validate_filesystem_safe_name(name)

--- a/kubeflow/trainer/backends/container/backend.py
+++ b/kubeflow/trainer/backends/container/backend.py
@@ -47,6 +47,7 @@ import shutil
 import string
 import uuid
 
+import kubeflow.common.utils as common_utils
 from kubeflow.trainer.backends.base import RuntimeBackend
 from kubeflow.trainer.backends.container import utils as container_utils
 from kubeflow.trainer.backends.container.adapters.base import (
@@ -286,6 +287,7 @@ class ContainerBackend(RuntimeBackend):
             random.choice(string.ascii_lowercase)
             + uuid.uuid4().hex[: constants.JOB_NAME_UUID_LENGTH]
         )
+        common_utils.validate_filesystem_safe_name(trainjob_name)
 
         logger.debug(f"Starting training job: {trainjob_name}")
         try:

--- a/kubeflow/trainer/backends/container/backend_test.py
+++ b/kubeflow/trainer/backends/container/backend_test.py
@@ -34,6 +34,7 @@ from kubeflow.trainer.backends.container.adapters.base import (
 from kubeflow.trainer.backends.container.backend import ContainerBackend
 from kubeflow.trainer.backends.container.types import ContainerBackendConfig
 from kubeflow.trainer.constants import constants
+from kubeflow.trainer.options.common import Name
 from kubeflow.trainer.test.common import FAILED, SUCCESS, TestCase
 from kubeflow.trainer.types import types
 
@@ -691,6 +692,19 @@ def test_train(container_backend, test_case):
     except Exception as e:
         assert type(e) is test_case.expected_error
     print("test execution complete")
+
+
+def test_train_rejects_unsafe_job_name(container_backend):
+    """Test that a job name with path separators raises ValueError."""
+    trainer = types.CustomTrainer(func=simple_train_func)
+    runtime = container_backend.get_runtime(constants.DEFAULT_TRAINING_RUNTIME)
+
+    with pytest.raises(ValueError, match="Invalid job name"):
+        container_backend.train(
+            runtime=runtime,
+            trainer=trainer,
+            options=[Name(name="experiment/run_1")],
+        )
 
 
 @pytest.mark.parametrize(

--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -20,6 +20,7 @@ import tempfile
 import time
 import uuid
 
+import kubeflow.common.utils as common_utils
 from kubeflow.trainer.backends.base import RuntimeBackend
 from kubeflow.trainer.backends.localprocess import utils as local_utils
 from kubeflow.trainer.backends.localprocess.constants import local_runtimes
@@ -98,6 +99,7 @@ class LocalProcessBackend(RuntimeBackend):
             random.choice(string.ascii_lowercase)
             + uuid.uuid4().hex[: constants.JOB_NAME_UUID_LENGTH]
         )
+        common_utils.validate_filesystem_safe_name(trainjob_name)
 
         # localprocess backend only supports CustomTrainer
         if not isinstance(trainer, types.CustomTrainer):

--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -523,6 +523,33 @@ def test_name_option_sets_job_name(local_backend, mock_train_environment):
     assert job_name == custom_name
 
 
+def test_name_option_rejects_unsafe_job_name(local_backend, mock_train_environment):
+    """Test that Name option with path separators raises ValueError."""
+
+    def dummy_func():
+        pass
+
+    runtime = types.Runtime(
+        name=TORCH_RUNTIME,
+        trainer=types.RuntimeTrainer(
+            trainer_type=types.TrainerType.CUSTOM_TRAINER,
+            framework="torch",
+            image=LOCAL_RUNTIME_IMAGE,
+        ),
+        kind=types.RuntimeKind.TRAINING_RUNTIME,
+    )
+
+    trainer = types.CustomTrainer(func=dummy_func)
+    options = [Name(name="experiment/run_1")]
+
+    with pytest.raises(ValueError, match="Invalid job name"):
+        local_backend.train(
+            runtime=runtime,
+            trainer=trainer,
+            options=options,
+        )
+
+
 @pytest.mark.parametrize(
     "test_case",
     [


### PR DESCRIPTION
## Summary

Fixes #714. `LocalProcessBackend.train()` forwarded a user-supplied job name straight into `tempfile.mkdtemp(prefix=trainjob_name)` without validating it. A name containing a path separator (e.g. `Name("experiment/run_1")`) is interpreted as a path component, so on Windows this fails with an unhandled `FileNotFoundError` instead of a clear error. `ContainerBackend.train()` has the identical issue — it passes the same unsanitized name into `create_workdir()`, which joins it onto a host directory path — so I fixed both rather than just the one named in the issue.

## Changes

- `kubeflow/common/utils.py`: added `validate_filesystem_safe_name()`, next to the existing `validate_wait_for_job_status()` helper that already centralizes shared validation used by multiple backends.
- `kubeflow/trainer/backends/localprocess/backend.py`: validate `trainjob_name` right after it's resolved, before it's used for the temp dir.
- `kubeflow/trainer/backends/container/backend.py`: same validation, same place in the flow.
- Rejects names containing `/`, `\`, or that are exactly `.` or `..`, and raises `ValueError` with a message naming the offending name, per the issue's ask.

## Test plan

- Added parametrized tests for `validate_filesystem_safe_name()` in `kubeflow/common/utils_test.py` covering valid names, `/`, `\`, `.`, and `..`.
- Added `test_name_option_rejects_unsafe_job_name` (LocalProcess) and `test_train_rejects_unsafe_job_name` (Container) using the `Name` option with a path-separator value.
- Verified both backend tests fail without the fix and pass with it.
- `make verify` (ruff check, ruff format, ty check) passes.
- Full `kubeflow/` unit test suite passes: 671 passed, no regressions.