### PR TITLE
feat(optimizer): add trainer-native OptimizationJob backend

### DIFF
--- a/kubeflow/optimizer/__init__.py
+++ b/kubeflow/optimizer/__init__.py
@@ -18,6 +18,9 @@ from kubeflow.common.types import KubernetesBackendConfig
 # Import the Kubeflow Optimizer client.
 from kubeflow.optimizer.api.optimizer_client import OptimizerClient
 
+# Import the Kubeflow Optimizer backend configs.
+from kubeflow.optimizer.backends.trainer_native.types import TrainerNativeBackendConfig
+
 # Import the Kubeflow Optimizer types.
 from kubeflow.optimizer.types.algorithm_types import GridSearch, RandomSearch
 from kubeflow.optimizer.types.optimization_types import (
@@ -41,5 +44,6 @@ __all__ = [
     "Result",
     "Search",
     "TrainJobTemplate",
+    "TrainerNativeBackendConfig",
     "TrialConfig",
 ]

--- a/kubeflow/optimizer/api/optimizer_client.py
+++ b/kubeflow/optimizer/api/optimizer_client.py
@@ -19,6 +19,8 @@ from typing import Any
 from kubeflow.common.types import KubernetesBackendConfig
 import kubeflow.common.utils as common_utils
 from kubeflow.optimizer.backends.kubernetes.backend import KubernetesBackend
+from kubeflow.optimizer.backends.trainer_native.backend import TrainerNativeBackend
+from kubeflow.optimizer.backends.trainer_native.types import TrainerNativeBackendConfig
 from kubeflow.optimizer.constants import constants
 from kubeflow.optimizer.types.algorithm_types import BaseAlgorithm
 from kubeflow.optimizer.types.optimization_types import (
@@ -35,13 +37,14 @@ logger = logging.getLogger(__name__)
 class OptimizerClient:
     def __init__(
         self,
-        backend_config: KubernetesBackendConfig | None = None,
+        backend_config: KubernetesBackendConfig | TrainerNativeBackendConfig | None = None,
     ):
         """Initialize a Kubeflow Optimizer client.
 
         Args:
-            backend_config: Backend configuration. Either KubernetesBackendConfig or None to use
-                default config class. Defaults to KubernetesBackendConfig.
+            backend_config: Backend configuration. Either KubernetesBackendConfig (Katib-based
+                backend), TrainerNativeBackendConfig (trainer-native OptimizationJob backend),
+                or None to use the default config class. Defaults to KubernetesBackendConfig.
 
         Raises:
             ValueError: Invalid backend configuration.
@@ -51,7 +54,10 @@ class OptimizerClient:
         if not backend_config:
             backend_config = KubernetesBackendConfig()
 
-        if isinstance(backend_config, KubernetesBackendConfig):
+        # TrainerNativeBackendConfig subclasses KubernetesBackendConfig, so check it first.
+        if isinstance(backend_config, TrainerNativeBackendConfig):
+            self.backend = TrainerNativeBackend(backend_config)
+        elif isinstance(backend_config, KubernetesBackendConfig):
             self.backend = KubernetesBackend(backend_config)
         else:
             raise ValueError(f"Invalid backend config '{backend_config}'")

--- a/kubeflow/optimizer/backends/trainer_native/__init__.py
+++ b/kubeflow/optimizer/backends/trainer_native/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/kubeflow/optimizer/backends/trainer_native/backend.py
+++ b/kubeflow/optimizer/backends/trainer_native/backend.py
@@ -1,0 +1,450 @@
+# Copyright 2026 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Trainer-native backend for the Kubeflow Optimizer.
+
+This backend creates OptimizationJob resources from the `trainer.kubeflow.org/v1alpha1`
+API group introduced by KEP-2605 in kubeflow/trainer, instead of Katib Experiment
+resources. Hyperparameter suggestions are injected into trials by the OptimizationJob
+controller via `KUBEFLOW_TRAINER_OPT_<NAME>` environment variables, so the trial
+template is submitted without any parameter placeholder substitution.
+"""
+
+from collections.abc import Callable, Iterator
+import copy
+import datetime
+import logging
+import multiprocessing
+import random
+import string
+import time
+from typing import Any
+import uuid
+
+from kubernetes import client, config
+
+import kubeflow.common.constants as common_constants
+import kubeflow.common.utils as common_utils
+from kubeflow.optimizer.backends.base import RuntimeBackend
+from kubeflow.optimizer.backends.trainer_native import utils
+from kubeflow.optimizer.backends.trainer_native.types import TrainerNativeBackendConfig
+from kubeflow.optimizer.constants import constants
+from kubeflow.optimizer.types.algorithm_types import BaseAlgorithm, RandomSearch
+from kubeflow.optimizer.types.optimization_types import (
+    Objective,
+    OptimizationJob,
+    Result,
+    Trial,
+    TrialConfig,
+)
+from kubeflow.trainer.backends.kubernetes.backend import KubernetesBackend as TrainerBackend
+import kubeflow.trainer.constants.constants as trainer_constants
+from kubeflow.trainer.types.types import Event, TrainJobTemplate
+
+logger = logging.getLogger(__name__)
+
+
+class TrainerNativeBackend(RuntimeBackend):
+    """Backend that manages trainer-native OptimizationJob resources."""
+
+    def __init__(self, cfg: TrainerNativeBackendConfig):
+        if cfg.namespace is None:
+            cfg.namespace = common_utils.get_default_target_namespace(cfg.context)
+
+        # If client configuration is not set, use kube-config to access Kubernetes APIs.
+        if cfg.client_configuration is None:
+            # Load kube-config or in-cluster config.
+            if cfg.config_file or not common_utils.is_running_in_k8s():
+                config.load_kube_config(config_file=cfg.config_file, context=cfg.context)
+            else:
+                config.load_incluster_config()
+
+        k8s_client = client.ApiClient(cfg.client_configuration)
+        self.custom_api = client.CustomObjectsApi(k8s_client)
+        self.core_api = client.CoreV1Api(k8s_client)
+
+        self.namespace = cfg.namespace
+        self.trainer_backend = TrainerBackend(cfg)
+
+    def optimize(
+        self,
+        trial_template: TrainJobTemplate,
+        *,
+        search_space: dict[str, Any],
+        trial_config: TrialConfig | None = None,
+        objectives: list[Objective] | None = None,
+        algorithm: BaseAlgorithm | None = None,
+    ) -> str:
+        # Generate unique name for the OptimizationJob.
+        optimization_job_name = random.choice(string.ascii_lowercase) + uuid.uuid4().hex[:11]
+
+        # Validate search_space
+        if not search_space:
+            raise ValueError("Search space must be set.")
+
+        # Set defaults.
+        objectives = objectives or [Objective()]
+        algorithm = algorithm or RandomSearch()
+        trial_config = trial_config or TrialConfig()
+
+        if trial_config.max_failed_trials is not None:
+            raise ValueError(
+                "max_failed_trials is not supported by the trainer-native OptimizationJob"
+            )
+
+        trial_template = copy.deepcopy(trial_template)
+
+        # The OptimizationJob controller injects hyperparameter suggestions into every
+        # trial via KUBEFLOW_TRAINER_OPT_<NAME> environment variables, so the trial
+        # template is used as-is without parameter placeholder substitution.
+        optimization_job = {
+            "apiVersion": trainer_constants.API_VERSION,
+            "kind": constants.OPTIMIZATION_JOB_KIND,
+            "metadata": {"name": optimization_job_name},
+            "spec": {
+                "objectives": utils.get_crd_objectives(objectives),
+                "searchAlgorithm": utils.get_crd_search_algorithm(algorithm),
+                "parameters": utils.get_crd_parameters(search_space),
+                "numTrials": trial_config.num_trials,
+                "parallelTrials": trial_config.parallel_trials,
+                "trainJobTemplate": {
+                    "spec": self.trainer_backend._get_trainjob_spec(
+                        runtime=trial_template.runtime,
+                        trainer=trial_template.trainer,
+                        initializer=trial_template.initializer,
+                    ).to_dict(),
+                },
+            },
+        }
+
+        # Create the OptimizationJob.
+        try:
+            self.custom_api.create_namespaced_custom_object(
+                trainer_constants.GROUP,
+                trainer_constants.VERSION,
+                self.namespace,
+                constants.OPTIMIZATION_JOB_PLURAL,
+                optimization_job,
+            )
+        except multiprocessing.TimeoutError as e:
+            raise TimeoutError(
+                f"Timeout to create {constants.OPTIMIZATION_JOB_KIND}: "
+                f"{self.namespace}/{optimization_job_name}"
+            ) from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to create {constants.OPTIMIZATION_JOB_KIND}: "
+                f"{self.namespace}/{optimization_job_name}"
+            ) from e
+
+        logger.debug(
+            f"{constants.OPTIMIZATION_JOB_KIND} {self.namespace}/{optimization_job_name} "
+            "has been created"
+        )
+
+        return optimization_job_name
+
+    def list_jobs(self) -> list[OptimizationJob]:
+        """List of the created OptimizationJobs"""
+        result = []
+
+        try:
+            thread = self.custom_api.list_namespaced_custom_object(
+                trainer_constants.GROUP,
+                trainer_constants.VERSION,
+                self.namespace,
+                constants.OPTIMIZATION_JOB_PLURAL,
+                async_req=True,
+            )
+
+            optimization_job_list = thread.get(common_constants.DEFAULT_TIMEOUT)
+
+            for optimization_job in optimization_job_list.get("items", []):
+                result.append(self.__get_optimization_job_from_cr(optimization_job))
+
+        except multiprocessing.TimeoutError as e:
+            raise TimeoutError(
+                f"Timeout to list {constants.OPTIMIZATION_JOB_KIND}s in namespace: {self.namespace}"
+            ) from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to list {constants.OPTIMIZATION_JOB_KIND}s in namespace: {self.namespace}"
+            ) from e
+
+        return result
+
+    def get_job(self, name: str) -> OptimizationJob:
+        """Get the OptimizationJob object"""
+        optimization_job = self.__get_optimization_job_cr(name)
+        return self.__get_optimization_job_from_cr(optimization_job)
+
+    def get_job_logs(
+        self,
+        name: str,
+        trial_name: str | None = None,
+        follow: bool = False,
+    ) -> Iterator[str]:
+        """Get the OptimizationJob logs from a Trial"""
+        # Determine what trial to get logs from.
+        if trial_name is None:
+            # Get logs from the best current trial.
+            best_trial = self._get_best_trial(name)
+            if best_trial is None:
+                return
+            trial_name = best_trial.name
+            logger.debug(f"Getting logs from trial: {trial_name}")
+
+        # Trials are plain TrainJobs, so delegate to the trainer backend.
+        yield from self.trainer_backend.get_job_logs(name=trial_name, follow=follow)
+
+    def get_best_results(self, name: str) -> Result | None:
+        """Get the best hyperparameters and metrics from an OptimizationJob"""
+        best_trial = self._get_best_trial(name)
+
+        if best_trial is None:
+            return None
+
+        return Result(
+            parameters=best_trial.parameters,
+            metrics=best_trial.metrics,
+        )
+
+    def wait_for_job_status(
+        self,
+        name: str,
+        status: set[str] = {constants.OPTIMIZATION_JOB_COMPLETE},
+        timeout: int = 3600,
+        polling_interval: int = 2,
+        callbacks: list[Callable[[OptimizationJob], None]] | None = None,
+    ) -> OptimizationJob:
+        job_statuses = {
+            constants.OPTIMIZATION_JOB_CREATED,
+            constants.OPTIMIZATION_JOB_RUNNING,
+            constants.OPTIMIZATION_JOB_COMPLETE,
+            constants.OPTIMIZATION_JOB_FAILED,
+        }
+
+        if not status.issubset(job_statuses):
+            raise ValueError(f"Expected status {status} must be a subset of {job_statuses}")
+
+        if polling_interval <= 0:
+            raise ValueError(
+                f"Polling interval must be a positive number, got polling_interval={polling_interval}"
+            )
+        if polling_interval >= timeout:
+            raise ValueError(
+                f"Polling interval must be strictly less than timeout. "
+                f"Received polling_interval={polling_interval}, timeout={timeout}"
+            )
+
+        for _ in range(round(timeout / polling_interval)):
+            optimization_job = self.get_job(name)
+            logger.debug(
+                f"{constants.OPTIMIZATION_JOB_KIND} {name}, status {optimization_job.status}"
+            )
+
+            # Invoke callbacks if provided
+            if callbacks:
+                for callback in callbacks:
+                    callback(optimization_job)
+
+            if (
+                constants.OPTIMIZATION_JOB_FAILED not in status
+                and optimization_job.status == constants.OPTIMIZATION_JOB_FAILED
+            ):
+                raise RuntimeError(f"{constants.OPTIMIZATION_JOB_KIND} {name} is Failed")
+
+            if optimization_job.status in status:
+                return optimization_job
+
+            time.sleep(polling_interval)
+
+        raise TimeoutError(
+            f"Timeout waiting for {constants.OPTIMIZATION_JOB_KIND} {name} to reach status: "
+            f"{status}"
+        )
+
+    def delete_job(self, name: str):
+        """Delete the OptimizationJob"""
+
+        try:
+            self.custom_api.delete_namespaced_custom_object(
+                trainer_constants.GROUP,
+                trainer_constants.VERSION,
+                self.namespace,
+                constants.OPTIMIZATION_JOB_PLURAL,
+                name=name,
+            )
+        except multiprocessing.TimeoutError as e:
+            raise TimeoutError(
+                f"Timeout to delete {constants.OPTIMIZATION_JOB_KIND}: {self.namespace}/{name}"
+            ) from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to delete {constants.OPTIMIZATION_JOB_KIND}: {self.namespace}/{name}"
+            ) from e
+
+        logger.debug(f"{constants.OPTIMIZATION_JOB_KIND} {self.namespace}/{name} has been deleted")
+
+    def get_job_events(self, name: str) -> list[Event]:
+        # Get the OptimizationJob to ensure it exists.
+        self.get_job(name)
+
+        # Create set of all OptimizationJob-related resource names. Individual trial
+        # names are not tracked in the OptimizationJob status yet, so only the best
+        # trial's TrainJob is included.
+        # TODO(kubeflow/trainer#3856): include all trials once the trial history is
+        # stored natively in the OptimizationJob status.
+        optimization_job_resources = {name}
+        best_trial = self._get_best_trial(name)
+        if best_trial is not None:
+            optimization_job_resources.add(best_trial.name)
+
+        events = []
+        try:
+            # Retrieve events from the namespace
+            event_response = self.core_api.list_namespaced_event(
+                namespace=self.namespace,
+                async_req=True,
+            ).get(common_constants.DEFAULT_TIMEOUT)
+
+            # Filter events related to OptimizationJob resources
+            for event in event_response.items:
+                if not (event.metadata and event.involved_object and event.first_timestamp):
+                    continue
+
+                involved_object = event.involved_object
+
+                # Check if event is related to OptimizationJob resources
+                if (
+                    involved_object.kind
+                    in {constants.OPTIMIZATION_JOB_KIND, trainer_constants.TRAINJOB_KIND}
+                    and involved_object.name in optimization_job_resources
+                ):
+                    events.append(
+                        Event(
+                            involved_object_kind=involved_object.kind,
+                            involved_object_name=involved_object.name,
+                            message=event.message or "",
+                            reason=event.reason or "",
+                            event_time=event.first_timestamp,
+                        )
+                    )
+
+            # Sort events by first occurrence time
+            events.sort(key=lambda e: e.event_time)
+            return events
+        except multiprocessing.TimeoutError as e:
+            raise TimeoutError(
+                f"Timeout getting {constants.OPTIMIZATION_JOB_KIND} events: {self.namespace}/{name}"
+            ) from e
+
+    def _get_best_trial(self, name: str) -> Trial | None:
+        """Get the best current Trial for the OptimizationJob"""
+        optimization_job = self.__get_optimization_job_cr(name)
+
+        # The best trial is tracked in status.result of the OptimizationJob.
+        result = (optimization_job.get("status") or {}).get("result") or {}
+        trainjob_name = result.get("trainJobName")
+        if not trainjob_name:
+            return None
+
+        parameters = {
+            pa["name"]: pa["value"]
+            for pa in result.get("parameters", [])
+            if pa.get("name") is not None and pa.get("value") is not None
+        }
+
+        trainjob = self.trainer_backend.get_job(name=trainjob_name)
+
+        # TODO(kubeflow/trainer#3856): populate metrics once the trial history is
+        # stored natively in the OptimizationJob status.
+        return Trial(
+            name=trainjob_name,
+            parameters=parameters,
+            trainjob=trainjob,
+        )
+
+    def __get_optimization_job_cr(self, name: str) -> dict[str, Any]:
+        """Get the OptimizationJob CR from Kubernetes API"""
+        try:
+            thread = self.custom_api.get_namespaced_custom_object(
+                trainer_constants.GROUP,
+                trainer_constants.VERSION,
+                self.namespace,
+                constants.OPTIMIZATION_JOB_PLURAL,
+                name,
+                async_req=True,
+            )
+
+            optimization_job = thread.get(common_constants.DEFAULT_TIMEOUT)
+
+        except multiprocessing.TimeoutError as e:
+            raise TimeoutError(
+                f"Timeout to get {constants.OPTIMIZATION_JOB_KIND}: {self.namespace}/{name}"
+            ) from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to get {constants.OPTIMIZATION_JOB_KIND}: {self.namespace}/{name}"
+            ) from e
+
+        return optimization_job
+
+    def __get_optimization_job_from_cr(
+        self,
+        optimization_job_cr: dict[str, Any],
+    ) -> OptimizationJob:
+        metadata = optimization_job_cr.get("metadata") or {}
+        spec = optimization_job_cr.get("spec") or {}
+
+        if not (
+            metadata.get("name")
+            and metadata.get("creationTimestamp")
+            and spec.get("parameters")
+            and spec.get("objectives")
+        ):
+            raise ValueError(
+                f"{constants.OPTIMIZATION_JOB_KIND} CR is invalid: {optimization_job_cr}"
+            )
+
+        optimization_job = OptimizationJob(
+            name=metadata["name"],
+            search_space=utils.get_search_space_from_crd(spec["parameters"]),
+            objectives=utils.get_objectives_from_crd(spec["objectives"]),
+            algorithm=utils.get_algorithm_from_crd(spec.get("searchAlgorithm") or {}),
+            trial_config=TrialConfig(
+                num_trials=spec.get("numTrials", 1),
+                parallel_trials=spec.get("parallelTrials", 1),
+                max_failed_trials=None,
+            ),
+            # TODO(kubeflow/trainer#3856): populate trials once the trial history is
+            # stored natively in the OptimizationJob status.
+            trials=[],
+            creation_timestamp=datetime.datetime.fromisoformat(
+                metadata["creationTimestamp"].replace("Z", "+00:00")
+            ),
+            status=constants.OPTIMIZATION_JOB_CREATED,  # The default OptimizationJob status.
+        )
+
+        # Update the OptimizationJob status from the CR conditions.
+        conditions = (optimization_job_cr.get("status") or {}).get("conditions") or []
+        for c in conditions:
+            if c.get("status") != "True":
+                continue
+            if c.get("type") == constants.OPTIMIZATION_JOB_COMPLETE:
+                optimization_job.status = constants.OPTIMIZATION_JOB_COMPLETE
+            elif c.get("type") == constants.OPTIMIZATION_JOB_FAILED:
+                optimization_job.status = constants.OPTIMIZATION_JOB_FAILED
+
+        return optimization_job

--- a/kubeflow/optimizer/backends/trainer_native/backend_test.py
+++ b/kubeflow/optimizer/backends/trainer_native/backend_test.py
@@ -1,0 +1,1148 @@
+# Copyright 2026 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the TrainerNativeBackend class in the Kubeflow Optimizer SDK.
+
+This module uses pytest and unittest.mock to simulate Kubernetes API interactions.
+It tests TrainerNativeBackend's behavior across OptimizationJob creation, listing,
+retrieval, deletion, log retrieval, event filtering, and status waiting against
+the trainer-native OptimizationJob CRD (trainer.kubeflow.org/v1alpha1).
+"""
+
+from dataclasses import asdict
+import datetime
+import multiprocessing
+from typing import Any
+from unittest.mock import Mock, patch
+
+from kubernetes import client as k8s_client
+import pytest
+
+from kubeflow.optimizer.backends.trainer_native.backend import TrainerNativeBackend
+from kubeflow.optimizer.backends.trainer_native.types import TrainerNativeBackendConfig
+from kubeflow.optimizer.constants import constants
+from kubeflow.optimizer.types.algorithm_types import GridSearch, RandomSearch
+from kubeflow.optimizer.types.optimization_types import (
+    Objective,
+    OptimizationJob,
+    Result,
+    TrialConfig,
+)
+from kubeflow.optimizer.types.search_types import (
+    ContinuousSearchSpace,
+    Distribution,
+    Search,
+)
+import kubeflow.trainer.constants.constants as trainer_constants
+from kubeflow.trainer.test.common import (
+    DEFAULT_NAMESPACE,
+    FAILED,
+    RUNTIME,
+    SUCCESS,
+    TIMEOUT,
+    TestCase,
+)
+from kubeflow.trainer.types import types as trainer_types
+from kubeflow.trainer.types.types import (
+    CustomTrainer,
+    Event,
+    Runtime,
+    RuntimeTrainer,
+    Step,
+    TrainerType,
+    TrainJob,
+    TrainJobTemplate,
+)
+
+BASIC_OPTIMIZATION_JOB_NAME = "basic-opt-job"
+BASIC_TRIAL_NAME = "basic-trial"
+
+# --------------------------
+# Fixtures
+# --------------------------
+
+
+@pytest.fixture
+def trainer_native_backend():
+    """Provide a TrainerNativeBackend with mocked Kubernetes APIs."""
+    with (
+        patch("kubernetes.config.load_kube_config", return_value=None),
+        patch(
+            "kubernetes.client.CustomObjectsApi",
+            return_value=Mock(
+                create_namespaced_custom_object=Mock(side_effect=conditional_error_handler),
+                delete_namespaced_custom_object=Mock(side_effect=conditional_error_handler),
+                get_namespaced_custom_object=Mock(
+                    side_effect=get_namespaced_custom_object_response
+                ),
+                list_namespaced_custom_object=Mock(
+                    side_effect=list_namespaced_custom_object_response
+                ),
+            ),
+        ),
+        patch(
+            "kubernetes.client.CoreV1Api",
+            return_value=Mock(
+                list_namespaced_event=Mock(side_effect=mock_list_namespaced_event),
+            ),
+        ),
+        patch(
+            "kubeflow.trainer.backends.kubernetes.backend.KubernetesBackend.verify_backend",
+            return_value=None,
+        ),
+    ):
+        backend = TrainerNativeBackend(TrainerNativeBackendConfig())
+        backend.trainer_backend._get_trainjob_spec = Mock(
+            return_value=Mock(to_dict=Mock(return_value={}))
+        )
+        backend.trainer_backend.get_job = Mock(side_effect=mock_trainer_get_job)
+        backend.trainer_backend.get_job_logs = Mock(return_value=iter(["test log content"]))
+        yield backend
+
+
+# --------------------------
+# Mock Handlers
+# --------------------------
+
+
+def conditional_error_handler(*args: Any, **kwargs: Any) -> None:
+    """Raise simulated errors based on namespace.
+
+    Args:
+        args: Positional args from the K8s API call.
+            args[2] is the namespace for create/delete/list_namespaced_custom_object.
+    """
+    if args[2] == TIMEOUT:
+        raise multiprocessing.TimeoutError()
+    elif args[2] == RUNTIME:
+        raise RuntimeError()
+
+
+def get_namespaced_custom_object_response(*args, **kwargs):
+    """Return a mocked OptimizationJob CR dict.
+
+    Args:
+        args: Positional args from the K8s API call.
+            args[4] is the resource name for get_namespaced_custom_object.
+    """
+    mock_thread = Mock()
+    if args[4] == TIMEOUT:
+        raise multiprocessing.TimeoutError()
+    if args[4] == RUNTIME:
+        raise RuntimeError()
+    if args[3] == constants.OPTIMIZATION_JOB_PLURAL:
+        mock_thread.get.return_value = create_optimization_job_cr(name=args[4])
+    return mock_thread
+
+
+def list_namespaced_custom_object_response(*args, **kwargs):
+    """Return a list of mocked OptimizationJob CR dicts.
+
+    Args:
+        args: Positional args from the K8s API call.
+            args[2] is the namespace for list_namespaced_custom_object.
+    """
+    mock_thread = Mock()
+    if args[2] == TIMEOUT:
+        raise multiprocessing.TimeoutError()
+    if args[2] == RUNTIME:
+        raise RuntimeError()
+    if args[3] == constants.OPTIMIZATION_JOB_PLURAL:
+        mock_thread.get.return_value = {
+            "items": [
+                create_optimization_job_cr(name="opt-job-1"),
+                create_optimization_job_cr(name="opt-job-2"),
+            ],
+        }
+    return mock_thread
+
+
+def mock_list_namespaced_event(*args, **kwargs):
+    """Simulate event listing from namespace."""
+    namespace = kwargs.get("namespace")
+
+    if namespace == TIMEOUT:
+        raise multiprocessing.TimeoutError()
+
+    mock_thread = Mock()
+    mock_thread.get.return_value = k8s_client.CoreV1EventList(
+        items=[
+            k8s_client.CoreV1Event(
+                metadata=k8s_client.V1ObjectMeta(
+                    name="test-event-1",
+                    namespace=DEFAULT_NAMESPACE,
+                ),
+                involved_object=k8s_client.V1ObjectReference(
+                    kind=constants.OPTIMIZATION_JOB_KIND,
+                    name=BASIC_OPTIMIZATION_JOB_NAME,
+                    namespace=DEFAULT_NAMESPACE,
+                ),
+                message="OptimizationJob created successfully",
+                reason="Created",
+                first_timestamp=datetime.datetime(2025, 6, 1, 10, 30, 0),
+            ),
+            k8s_client.CoreV1Event(
+                metadata=k8s_client.V1ObjectMeta(
+                    name="test-event-2",
+                    namespace=DEFAULT_NAMESPACE,
+                ),
+                involved_object=k8s_client.V1ObjectReference(
+                    kind=trainer_constants.TRAINJOB_KIND,
+                    name=BASIC_TRIAL_NAME,
+                    namespace=DEFAULT_NAMESPACE,
+                ),
+                message="TrainJob started",
+                reason="Running",
+                first_timestamp=datetime.datetime(2025, 6, 1, 10, 31, 0),
+            ),
+            # Non-matching event (Pod kind) to test filtering
+            k8s_client.CoreV1Event(
+                metadata=k8s_client.V1ObjectMeta(
+                    name="test-event-3",
+                    namespace=DEFAULT_NAMESPACE,
+                ),
+                involved_object=k8s_client.V1ObjectReference(
+                    kind="Pod",
+                    name="some-pod",
+                    namespace=DEFAULT_NAMESPACE,
+                ),
+                message="Pod scheduled",
+                reason="Scheduled",
+                first_timestamp=datetime.datetime(2025, 6, 1, 10, 32, 0),
+            ),
+        ]
+    )
+    return mock_thread
+
+
+def mock_trainer_get_job(name: str) -> TrainJob:
+    """Return a mock TrainJob for the given trial name."""
+    return create_mock_trainjob(name)
+
+
+# --------------------------
+# Object Creators
+# --------------------------
+
+
+def create_optimization_job_cr(
+    name: str = BASIC_OPTIMIZATION_JOB_NAME,
+    namespace: str = DEFAULT_NAMESPACE,
+    status_conditions: list[dict[str, Any]] | None = None,
+    result: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create a mock trainer-native OptimizationJob CR dict."""
+    optimization_job = {
+        "apiVersion": trainer_constants.API_VERSION,
+        "kind": constants.OPTIMIZATION_JOB_KIND,
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+            "creationTimestamp": "2025-06-01T10:30:00Z",
+        },
+        "spec": {
+            "objectives": [{"metric": "loss", "direction": "Minimize"}],
+            "searchAlgorithm": {"random": {}},
+            "parameters": [
+                {
+                    "name": "lr",
+                    "searchSpace": {
+                        "uniform": {"min": "0.001", "max": "0.1", "type": "Float"},
+                    },
+                },
+            ],
+            "numTrials": 10,
+            "parallelTrials": 1,
+            "trainJobTemplate": {"spec": {}},
+        },
+    }
+
+    status: dict[str, Any] = {}
+    if status_conditions is not None:
+        status["conditions"] = status_conditions
+    if result is not None:
+        status["result"] = result
+    if status:
+        optimization_job["status"] = status
+
+    return optimization_job
+
+
+def create_mock_trainjob(name: str) -> TrainJob:
+    """Create a mock TrainJob object with the expected structure for testing."""
+    trainer = RuntimeTrainer(
+        trainer_type=TrainerType.CUSTOM_TRAINER,
+        framework="torch",
+        num_nodes=1,
+        device="gpu",
+        device_count="1",
+        image="trainer:latest",
+    )
+    trainer.set_command(trainer_constants.TORCH_COMMAND)
+    return TrainJob(
+        name=name,
+        creation_timestamp=datetime.datetime(2025, 6, 1, 10, 30, 0),
+        runtime=Runtime(
+            name="torch",
+            trainer=trainer,
+            kind=trainer_types.RuntimeKind.TRAINING_RUNTIME,
+        ),
+        steps=[
+            Step(
+                name="node-0",
+                status="Running",
+                pod_name=f"{name}-node-0-pod",
+                device="gpu",
+                device_count="1",
+            ),
+        ],
+        num_nodes=1,
+        status=trainer_constants.TRAINJOB_COMPLETE,
+    )
+
+
+def get_optimization_job_data_type(
+    name: str = BASIC_OPTIMIZATION_JOB_NAME,
+    status: str = constants.OPTIMIZATION_JOB_CREATED,
+) -> OptimizationJob:
+    """Create the expected OptimizationJob output for assertion comparison."""
+    return OptimizationJob(
+        name=name,
+        search_space={
+            "lr": ContinuousSearchSpace(
+                min=0.001,
+                max=0.1,
+                distribution=Distribution.UNIFORM,
+            ),
+        },
+        objectives=[Objective(metric="loss")],
+        algorithm=RandomSearch(),
+        trial_config=TrialConfig(
+            num_trials=10,
+            parallel_trials=1,
+            max_failed_trials=None,
+        ),
+        trials=[],
+        creation_timestamp=datetime.datetime(2025, 6, 1, 10, 30, 0, tzinfo=datetime.timezone.utc),
+        status=status,
+    )
+
+
+# --------------------------
+# Tests
+# --------------------------
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="single search space parameter",
+            expected_status=SUCCESS,
+            config={
+                "search_space": {
+                    "lr": Search.uniform(min=0.001, max=0.1),
+                },
+                "expected_parameters": [
+                    {
+                        "name": "lr",
+                        "searchSpace": {
+                            "uniform": {"min": "0.001", "max": "0.1", "type": "Float"},
+                        },
+                    },
+                ],
+            },
+        ),
+        TestCase(
+            name="multiple search space parameters",
+            expected_status=SUCCESS,
+            config={
+                "search_space": {
+                    "lr": Search.loguniform(min=0.001, max=0.1),
+                    "epochs": Search.choice([10, 20, 30]),
+                },
+                "expected_parameters": [
+                    {
+                        "name": "lr",
+                        "searchSpace": {
+                            "logUniform": {"min": "0.001", "max": "0.1", "type": "Float"},
+                        },
+                    },
+                    {
+                        "name": "epochs",
+                        "searchSpace": {
+                            "categorical": {"choices": ["10", "20", "30"]},
+                        },
+                    },
+                ],
+            },
+        ),
+        TestCase(
+            name="random search algorithm with seed",
+            expected_status=SUCCESS,
+            config={
+                "search_space": {
+                    "lr": Search.uniform(min=0.001, max=0.1),
+                },
+                "algorithm": RandomSearch(random_state=42),
+                "expected_search_algorithm": {"random": {"seed": 42}},
+            },
+        ),
+        TestCase(
+            name="grid search algorithm",
+            expected_status=SUCCESS,
+            config={
+                "search_space": {
+                    "lr": Search.uniform(min=0.001, max=0.1),
+                },
+                "algorithm": GridSearch(),
+                "expected_search_algorithm": {"grid": {}},
+            },
+        ),
+        TestCase(
+            name="maximize objective direction",
+            expected_status=SUCCESS,
+            config={
+                "search_space": {
+                    "lr": Search.uniform(min=0.001, max=0.1),
+                },
+                "objectives": [Objective(metric="accuracy", direction="maximize")],
+                "expected_objectives": [{"metric": "accuracy", "direction": "Maximize"}],
+            },
+        ),
+        TestCase(
+            name="custom trial config",
+            expected_status=SUCCESS,
+            config={
+                "search_space": {
+                    "lr": Search.uniform(min=0.001, max=0.1),
+                },
+                "trial_config": TrialConfig(num_trials=20, parallel_trials=4),
+                "expected_num_trials": 20,
+                "expected_parallel_trials": 4,
+            },
+        ),
+        TestCase(
+            name="empty search space raises ValueError",
+            expected_status=FAILED,
+            config={
+                "search_space": {},
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="multiple objectives raise ValueError",
+            expected_status=FAILED,
+            config={
+                "search_space": {
+                    "lr": Search.uniform(min=0.001, max=0.1),
+                },
+                "objectives": [Objective(metric="loss"), Objective(metric="accuracy")],
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="max_failed_trials raises ValueError",
+            expected_status=FAILED,
+            config={
+                "search_space": {
+                    "lr": Search.uniform(min=0.001, max=0.1),
+                },
+                "trial_config": TrialConfig(max_failed_trials=3),
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="timeout error when creating job",
+            expected_status=FAILED,
+            config={
+                "namespace": TIMEOUT,
+                "search_space": {
+                    "lr": Search.uniform(min=0.001, max=0.1),
+                },
+            },
+            expected_error=TimeoutError,
+        ),
+        TestCase(
+            name="runtime error when creating job",
+            expected_status=FAILED,
+            config={
+                "namespace": RUNTIME,
+                "search_space": {
+                    "lr": Search.uniform(min=0.001, max=0.1),
+                },
+            },
+            expected_error=RuntimeError,
+        ),
+    ],
+)
+def test_optimize(trainer_native_backend, test_case):
+    """Test TrainerNativeBackend.optimize with success and error paths."""
+    print("Executing test:", test_case.name)
+
+    search_space = test_case.config["search_space"]
+
+    trial_template = TrainJobTemplate(
+        trainer=CustomTrainer(
+            func=lambda: None,
+            func_args={"existing_arg": "original_value"},
+            num_nodes=1,
+        ),
+    )
+    original_func_args = dict(trial_template.trainer.func_args)
+
+    try:
+        trainer_native_backend.namespace = test_case.config.get("namespace", DEFAULT_NAMESPACE)
+        job_name = trainer_native_backend.optimize(
+            trial_template=trial_template,
+            search_space=search_space,
+            trial_config=test_case.config.get("trial_config"),
+            objectives=test_case.config.get("objectives"),
+            algorithm=test_case.config.get("algorithm"),
+        )
+
+        assert test_case.expected_status == SUCCESS
+        assert isinstance(job_name, str) and len(job_name) > 0
+
+        # The controller injects hyperparameters via environment variables, so
+        # trial_template.trainer.func_args must be unchanged.
+        assert trial_template.trainer.func_args == original_func_args
+
+        # Verify the OptimizationJob CR was created with the expected payload.
+        trainer_native_backend.custom_api.create_namespaced_custom_object.assert_called_once()
+        call_args = trainer_native_backend.custom_api.create_namespaced_custom_object.call_args
+        assert call_args[0][0] == trainer_constants.GROUP
+        assert call_args[0][1] == trainer_constants.VERSION
+        assert call_args[0][3] == constants.OPTIMIZATION_JOB_PLURAL
+
+        payload = call_args[0][4]
+        assert payload["apiVersion"] == trainer_constants.API_VERSION
+        assert payload["kind"] == constants.OPTIMIZATION_JOB_KIND
+        assert payload["spec"]["trainJobTemplate"] == {"spec": {}}
+        assert payload["spec"]["numTrials"] == test_case.config.get("expected_num_trials", 10)
+        assert payload["spec"]["parallelTrials"] == test_case.config.get(
+            "expected_parallel_trials", 1
+        )
+        assert payload["spec"]["objectives"] == test_case.config.get(
+            "expected_objectives", [{"metric": "loss", "direction": "Minimize"}]
+        )
+        assert payload["spec"]["searchAlgorithm"] == test_case.config.get(
+            "expected_search_algorithm", {"random": {}}
+        )
+        if "expected_parameters" in test_case.config:
+            assert payload["spec"]["parameters"] == test_case.config["expected_parameters"]
+
+    except Exception as e:
+        assert test_case.expected_status != SUCCESS
+        assert type(e) is test_case.expected_error
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid flow with all defaults",
+            expected_status=SUCCESS,
+            config={"name": BASIC_OPTIMIZATION_JOB_NAME},
+            expected_output=get_optimization_job_data_type(
+                name=BASIC_OPTIMIZATION_JOB_NAME,
+            ),
+        ),
+        TestCase(
+            name="timeout error when getting job",
+            expected_status=FAILED,
+            config={"name": TIMEOUT},
+            expected_error=TimeoutError,
+        ),
+        TestCase(
+            name="runtime error when getting job",
+            expected_status=FAILED,
+            config={"name": RUNTIME},
+            expected_error=RuntimeError,
+        ),
+    ],
+)
+def test_get_job(trainer_native_backend, test_case):
+    """Test TrainerNativeBackend.get_job with success and error paths."""
+    print("Executing test:", test_case.name)
+    try:
+        job = trainer_native_backend.get_job(**test_case.config)
+
+        assert test_case.expected_status == SUCCESS
+        assert asdict(job) == asdict(test_case.expected_output)
+
+    except Exception as e:
+        assert test_case.expected_status != SUCCESS
+        assert type(e) is test_case.expected_error
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="complete condition maps to OPTIMIZATION_JOB_COMPLETE",
+            expected_status=SUCCESS,
+            config={
+                "name": "succeeded-job",
+                "conditions": [
+                    {"type": constants.OPTIMIZATION_JOB_COMPLETE, "status": "True"},
+                ],
+            },
+            expected_output=get_optimization_job_data_type(
+                name="succeeded-job",
+                status=constants.OPTIMIZATION_JOB_COMPLETE,
+            ),
+        ),
+        TestCase(
+            name="failed condition maps to OPTIMIZATION_JOB_FAILED",
+            expected_status=SUCCESS,
+            config={
+                "name": "failed-job",
+                "conditions": [
+                    {"type": constants.OPTIMIZATION_JOB_FAILED, "status": "True"},
+                ],
+            },
+            expected_output=get_optimization_job_data_type(
+                name="failed-job",
+                status=constants.OPTIMIZATION_JOB_FAILED,
+            ),
+        ),
+        TestCase(
+            name="created condition maps to OPTIMIZATION_JOB_CREATED",
+            expected_status=SUCCESS,
+            config={
+                "name": "created-job",
+                "conditions": [
+                    {"type": constants.OPTIMIZATION_JOB_CREATED, "status": "True"},
+                ],
+            },
+            expected_output=get_optimization_job_data_type(
+                name="created-job",
+                status=constants.OPTIMIZATION_JOB_CREATED,
+            ),
+        ),
+        TestCase(
+            name="condition with False status is ignored",
+            expected_status=SUCCESS,
+            config={
+                "name": "pending-job",
+                "conditions": [
+                    {"type": constants.OPTIMIZATION_JOB_COMPLETE, "status": "False"},
+                ],
+            },
+            expected_output=get_optimization_job_data_type(
+                name="pending-job",
+                status=constants.OPTIMIZATION_JOB_CREATED,
+            ),
+        ),
+        TestCase(
+            name="no conditions maps to OPTIMIZATION_JOB_CREATED",
+            expected_status=SUCCESS,
+            config={
+                "name": "created-job",
+                "conditions": None,
+            },
+            expected_output=get_optimization_job_data_type(
+                name="created-job",
+                status=constants.OPTIMIZATION_JOB_CREATED,
+            ),
+        ),
+    ],
+)
+def test_get_job_status_conditions(trainer_native_backend, test_case):
+    """Test status-mapping logic in __get_optimization_job_from_cr."""
+    print("Executing test:", test_case.name)
+
+    job_name = test_case.config["name"]
+    conditions = test_case.config.get("conditions")
+
+    optimization_job_cr = create_optimization_job_cr(name=job_name, status_conditions=conditions)
+
+    def patched_get(*args, **kwargs):
+        mock_thread = Mock()
+        if args[3] == constants.OPTIMIZATION_JOB_PLURAL and args[4] == job_name:
+            mock_thread.get.return_value = optimization_job_cr
+        return mock_thread
+
+    trainer_native_backend.custom_api.get_namespaced_custom_object.side_effect = patched_get
+
+    job = trainer_native_backend.get_job(name=job_name)
+    assert job.status == test_case.expected_output.status
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid flow with all defaults",
+            expected_status=SUCCESS,
+            config={},
+            expected_output=[
+                get_optimization_job_data_type(name="opt-job-1"),
+                get_optimization_job_data_type(name="opt-job-2"),
+            ],
+        ),
+        TestCase(
+            name="timeout error when listing jobs",
+            expected_status=FAILED,
+            config={"namespace": TIMEOUT},
+            expected_error=TimeoutError,
+        ),
+        TestCase(
+            name="runtime error when listing jobs",
+            expected_status=FAILED,
+            config={"namespace": RUNTIME},
+            expected_error=RuntimeError,
+        ),
+    ],
+)
+def test_list_jobs(trainer_native_backend, test_case):
+    """Test TrainerNativeBackend.list_jobs with success and error paths."""
+    print("Executing test:", test_case.name)
+    try:
+        trainer_native_backend.namespace = test_case.config.get("namespace", DEFAULT_NAMESPACE)
+        jobs = trainer_native_backend.list_jobs()
+
+        assert test_case.expected_status == SUCCESS
+        assert isinstance(jobs, list)
+        assert len(jobs) == 2
+        assert [asdict(j) for j in jobs] == [asdict(r) for r in test_case.expected_output]
+
+    except Exception as e:
+        assert test_case.expected_status != SUCCESS
+        assert type(e) is test_case.expected_error
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="best trial available in status result",
+            expected_status=SUCCESS,
+            config={"name": BASIC_OPTIMIZATION_JOB_NAME, "has_result": True},
+            expected_output=Result(
+                parameters={"lr": "0.01"},
+                metrics=[],
+            ),
+        ),
+        TestCase(
+            name="no best trial available",
+            expected_status=SUCCESS,
+            config={"name": BASIC_OPTIMIZATION_JOB_NAME, "has_result": False},
+            expected_output=None,
+        ),
+        TestCase(
+            name="timeout error when getting best results",
+            expected_status=FAILED,
+            config={"name": TIMEOUT, "has_result": False},
+            expected_error=TimeoutError,
+        ),
+        TestCase(
+            name="runtime error when getting best results",
+            expected_status=FAILED,
+            config={"name": RUNTIME, "has_result": False},
+            expected_error=RuntimeError,
+        ),
+    ],
+)
+def test_get_best_results(trainer_native_backend, test_case):
+    """Test TrainerNativeBackend.get_best_results with success and error paths."""
+    print("Executing test:", test_case.name)
+
+    if test_case.config.get("has_result"):
+        optimization_job_cr = create_optimization_job_cr(
+            name=BASIC_OPTIMIZATION_JOB_NAME,
+            result={
+                "trainJobName": BASIC_TRIAL_NAME,
+                "parameters": [{"name": "lr", "value": "0.01"}],
+            },
+        )
+        original_handler = (
+            trainer_native_backend.custom_api.get_namespaced_custom_object.side_effect
+        )
+
+        def patched_get(*args, **kwargs):
+            if args[3] == constants.OPTIMIZATION_JOB_PLURAL:
+                mock_thread = Mock()
+                mock_thread.get.return_value = optimization_job_cr
+                return mock_thread
+            return original_handler(*args, **kwargs)
+
+        trainer_native_backend.custom_api.get_namespaced_custom_object.side_effect = patched_get
+
+    try:
+        result = trainer_native_backend.get_best_results(name=test_case.config["name"])
+
+        assert test_case.expected_status == SUCCESS
+        if test_case.expected_output is None:
+            assert result is None
+        else:
+            assert asdict(result) == asdict(test_case.expected_output)
+
+    except Exception as e:
+        assert test_case.expected_status != SUCCESS
+        assert type(e) is test_case.expected_error
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="explicit trial_name delegates to trainer backend",
+            expected_status=SUCCESS,
+            config={"name": BASIC_OPTIMIZATION_JOB_NAME, "trial_name": BASIC_TRIAL_NAME},
+            expected_output=["test log content"],
+        ),
+        TestCase(
+            name="logs from the best trial when trial_name is not set",
+            expected_status=SUCCESS,
+            config={"name": BASIC_OPTIMIZATION_JOB_NAME, "has_result": True},
+            expected_output=["test log content"],
+        ),
+        TestCase(
+            name="no best trial returns no logs",
+            expected_status=SUCCESS,
+            config={"name": BASIC_OPTIMIZATION_JOB_NAME, "has_result": False},
+            expected_output=[],
+        ),
+        TestCase(
+            name="timeout error when getting job logs",
+            expected_status=FAILED,
+            config={"name": TIMEOUT},
+            expected_error=TimeoutError,
+        ),
+    ],
+)
+def test_get_job_logs(trainer_native_backend, test_case):
+    """Test TrainerNativeBackend.get_job_logs with success and error paths."""
+    print("Executing test:", test_case.name)
+
+    if test_case.config.get("has_result"):
+        optimization_job_cr = create_optimization_job_cr(
+            name=BASIC_OPTIMIZATION_JOB_NAME,
+            result={
+                "trainJobName": BASIC_TRIAL_NAME,
+                "parameters": [{"name": "lr", "value": "0.01"}],
+            },
+        )
+
+        def patched_get(*args, **kwargs):
+            mock_thread = Mock()
+            mock_thread.get.return_value = optimization_job_cr
+            return mock_thread
+
+        trainer_native_backend.custom_api.get_namespaced_custom_object.side_effect = patched_get
+
+    try:
+        logs = trainer_native_backend.get_job_logs(
+            test_case.config.get("name"),
+            trial_name=test_case.config.get("trial_name"),
+            follow=test_case.config.get("follow", False),
+        )
+        logs_list = list(logs)
+        assert test_case.expected_status == SUCCESS
+        assert logs_list == test_case.expected_output
+
+        if logs_list:
+            trainer_native_backend.trainer_backend.get_job_logs.assert_called_once_with(
+                name=BASIC_TRIAL_NAME,
+                follow=test_case.config.get("follow", False),
+            )
+
+    except Exception as e:
+        assert test_case.expected_status != SUCCESS
+        assert type(e) is test_case.expected_error
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="wait for complete status (default)",
+            expected_status=SUCCESS,
+            config={
+                "name": BASIC_OPTIMIZATION_JOB_NAME,
+                "_conditions": [
+                    {"type": constants.OPTIMIZATION_JOB_COMPLETE, "status": "True"},
+                ],
+            },
+            expected_output=get_optimization_job_data_type(
+                name=BASIC_OPTIMIZATION_JOB_NAME,
+                status=constants.OPTIMIZATION_JOB_COMPLETE,
+            ),
+        ),
+        TestCase(
+            name="wait for multiple statuses",
+            expected_status=SUCCESS,
+            config={
+                "name": BASIC_OPTIMIZATION_JOB_NAME,
+                "status": {
+                    constants.OPTIMIZATION_JOB_RUNNING,
+                    constants.OPTIMIZATION_JOB_COMPLETE,
+                },
+                "_conditions": [
+                    {"type": constants.OPTIMIZATION_JOB_COMPLETE, "status": "True"},
+                ],
+            },
+            expected_output=get_optimization_job_data_type(
+                name=BASIC_OPTIMIZATION_JOB_NAME,
+                status=constants.OPTIMIZATION_JOB_COMPLETE,
+            ),
+        ),
+        TestCase(
+            name="callback invoked on each poll iteration",
+            expected_status=SUCCESS,
+            config={
+                "name": BASIC_OPTIMIZATION_JOB_NAME,
+                "_conditions": [
+                    {"type": constants.OPTIMIZATION_JOB_COMPLETE, "status": "True"},
+                ],
+                "_has_callback": True,
+            },
+            expected_output=get_optimization_job_data_type(
+                name=BASIC_OPTIMIZATION_JOB_NAME,
+                status=constants.OPTIMIZATION_JOB_COMPLETE,
+            ),
+        ),
+        TestCase(
+            name="invalid status set error",
+            expected_status=FAILED,
+            config={
+                "name": BASIC_OPTIMIZATION_JOB_NAME,
+                "status": {"InvalidStatus"},
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="polling interval is more than timeout error",
+            expected_status=FAILED,
+            config={
+                "name": BASIC_OPTIMIZATION_JOB_NAME,
+                "timeout": 1,
+                "polling_interval": 2,
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="zero polling_interval raises ValueError",
+            expected_status=FAILED,
+            config={
+                "name": BASIC_OPTIMIZATION_JOB_NAME,
+                "timeout": 10,
+                "polling_interval": 0,
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="job failed when not expected",
+            expected_status=FAILED,
+            config={
+                "name": "failed-job",
+                "status": {constants.OPTIMIZATION_JOB_RUNNING},
+                "_conditions": [
+                    {"type": constants.OPTIMIZATION_JOB_FAILED, "status": "True"},
+                ],
+            },
+            expected_error=RuntimeError,
+        ),
+        TestCase(
+            name="timeout error to wait for failed status",
+            expected_status=FAILED,
+            config={
+                "name": BASIC_OPTIMIZATION_JOB_NAME,
+                "status": {constants.OPTIMIZATION_JOB_FAILED},
+                "polling_interval": 1,
+                "timeout": 2,
+                "_conditions": [
+                    {"type": constants.OPTIMIZATION_JOB_COMPLETE, "status": "True"},
+                ],
+            },
+            expected_error=TimeoutError,
+        ),
+    ],
+)
+def test_wait_for_job_status(trainer_native_backend, test_case):
+    """Test TrainerNativeBackend.wait_for_job_status with various scenarios."""
+    print("Executing test:", test_case.name)
+
+    job_name = test_case.config.get("name", BASIC_OPTIMIZATION_JOB_NAME)
+    status_conditions = test_case.config.get("_conditions")
+
+    optimization_job_cr = create_optimization_job_cr(
+        name=job_name, status_conditions=status_conditions
+    )
+
+    def patched_get(*args, **kwargs):
+        mock_thread = Mock()
+        if args[3] == constants.OPTIMIZATION_JOB_PLURAL:
+            mock_thread.get.return_value = optimization_job_cr
+        return mock_thread
+
+    trainer_native_backend.custom_api.get_namespaced_custom_object.side_effect = patched_get
+
+    mock_callback = Mock()
+
+    wait_kwargs = {k: v for k, v in test_case.config.items() if not k.startswith("_")}
+
+    if test_case.config.get("_has_callback"):
+        wait_kwargs["callbacks"] = [mock_callback]
+
+    try:
+        with patch("time.sleep", return_value=None):
+            job = trainer_native_backend.wait_for_job_status(**wait_kwargs)
+
+        assert test_case.expected_status == SUCCESS
+        assert isinstance(job, OptimizationJob)
+        assert job.status in test_case.config.get("status", {constants.OPTIMIZATION_JOB_COMPLETE})
+        assert asdict(job) == asdict(test_case.expected_output)
+
+        if test_case.config.get("_has_callback"):
+            mock_callback.assert_called()
+            for call_args in mock_callback.call_args_list:
+                assert isinstance(call_args[0][0], OptimizationJob)
+
+    except Exception as e:
+        assert test_case.expected_status != SUCCESS
+        assert type(e) is test_case.expected_error
+
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="valid flow with all defaults",
+            expected_status=SUCCESS,
+            config={"name": BASIC_OPTIMIZATION_JOB_NAME},
+            expected_output=None,
+        ),
+        TestCase(
+            name="timeout error when deleting job",
+            expected_status=FAILED,
+            config={"name": BASIC_OPTIMIZATION_JOB_NAME, "namespace": TIMEOUT},
+            expected_error=TimeoutError,
+        ),
+        TestCase(
+            name="runtime error when deleting job",
+            expected_status=FAILED,
+            config={"name": BASIC_OPTIMIZATION_JOB_NAME, "namespace": RUNTIME},
+            expected_error=RuntimeError,
+        ),
+    ],
+)
+def test_delete_job(trainer_native_backend, test_case):
+    """Test TrainerNativeBackend.delete_job with success and error paths."""
+    print("Executing test:", test_case.name)
+    try:
+        trainer_native_backend.namespace = test_case.config.get("namespace", DEFAULT_NAMESPACE)
+        trainer_native_backend.delete_job(test_case.config.get("name"))
+        assert test_case.expected_status == SUCCESS
+
+        call_args = trainer_native_backend.custom_api.delete_namespaced_custom_object.call_args
+        assert call_args[0][0] == trainer_constants.GROUP
+        assert call_args[0][3] == constants.OPTIMIZATION_JOB_PLURAL
+
+    except Exception as e:
+        assert test_case.expected_status != SUCCESS
+        assert type(e) is test_case.expected_error
+    print("test execution complete")
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="get job events with valid optimization job",
+            expected_status=SUCCESS,
+            config={"name": BASIC_OPTIMIZATION_JOB_NAME, "has_result": True},
+            expected_output=[
+                Event(
+                    involved_object_kind=constants.OPTIMIZATION_JOB_KIND,
+                    involved_object_name=BASIC_OPTIMIZATION_JOB_NAME,
+                    message="OptimizationJob created successfully",
+                    reason="Created",
+                    event_time=datetime.datetime(2025, 6, 1, 10, 30, 0),
+                ),
+                Event(
+                    involved_object_kind=trainer_constants.TRAINJOB_KIND,
+                    involved_object_name=BASIC_TRIAL_NAME,
+                    message="TrainJob started",
+                    reason="Running",
+                    event_time=datetime.datetime(2025, 6, 1, 10, 31, 0),
+                ),
+            ],
+        ),
+        TestCase(
+            name="events without best trial exclude TrainJob events",
+            expected_status=SUCCESS,
+            config={"name": BASIC_OPTIMIZATION_JOB_NAME, "has_result": False},
+            expected_output=[
+                Event(
+                    involved_object_kind=constants.OPTIMIZATION_JOB_KIND,
+                    involved_object_name=BASIC_OPTIMIZATION_JOB_NAME,
+                    message="OptimizationJob created successfully",
+                    reason="Created",
+                    event_time=datetime.datetime(2025, 6, 1, 10, 30, 0),
+                ),
+            ],
+        ),
+        TestCase(
+            name="timeout error when getting job events",
+            expected_status=FAILED,
+            config={"namespace": TIMEOUT, "name": BASIC_OPTIMIZATION_JOB_NAME},
+            expected_error=TimeoutError,
+        ),
+    ],
+)
+def test_get_job_events(trainer_native_backend, test_case):
+    """Test TrainerNativeBackend.get_job_events with various scenarios."""
+    print("Executing test:", test_case.name)
+
+    if test_case.config.get("has_result"):
+        optimization_job_cr = create_optimization_job_cr(
+            name=BASIC_OPTIMIZATION_JOB_NAME,
+            result={
+                "trainJobName": BASIC_TRIAL_NAME,
+                "parameters": [{"name": "lr", "value": "0.01"}],
+            },
+        )
+
+        def patched_get(*args, **kwargs):
+            mock_thread = Mock()
+            mock_thread.get.return_value = optimization_job_cr
+            return mock_thread
+
+        trainer_native_backend.custom_api.get_namespaced_custom_object.side_effect = patched_get
+
+    try:
+        trainer_native_backend.namespace = test_case.config.get("namespace", DEFAULT_NAMESPACE)
+        events = trainer_native_backend.get_job_events(test_case.config.get("name"))
+
+        assert test_case.expected_status == SUCCESS
+        assert isinstance(events, list)
+        assert len(events) == len(test_case.expected_output)
+        assert [asdict(e) for e in events] == [asdict(e) for e in test_case.expected_output]
+
+    except Exception as e:
+        assert test_case.expected_status != SUCCESS
+        assert type(e) is test_case.expected_error
+    print("test execution complete")

--- a/kubeflow/optimizer/backends/trainer_native/types.py
+++ b/kubeflow/optimizer/backends/trainer_native/types.py
@@ -1,0 +1,24 @@
+# Copyright 2026 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kubeflow.common.types import KubernetesBackendConfig
+
+
+class TrainerNativeBackendConfig(KubernetesBackendConfig):
+    """Configuration for the trainer-native OptimizationJob backend.
+
+    This backend creates OptimizationJob resources from the `trainer.kubeflow.org/v1alpha1`
+    API group (Kubeflow Trainer) instead of Katib Experiment resources.
+    It accepts the same Kubernetes connection options as `KubernetesBackendConfig`.
+    """

--- a/kubeflow/optimizer/backends/trainer_native/utils.py
+++ b/kubeflow/optimizer/backends/trainer_native/utils.py
@@ -1,0 +1,184 @@
+# Copyright 2026 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Converters between SDK types and the trainer-native OptimizationJob CRD.
+
+The trainer-native OptimizationJob (trainer.kubeflow.org/v1alpha1) has no released
+generated Python models yet, so specs are built and parsed as plain dictionaries.
+Source of truth: pkg/apis/trainer/v1alpha1/optimizationjob_types.go in kubeflow/trainer.
+"""
+
+from typing import Any
+
+from kubeflow_katib_api import models as katib_models
+
+from kubeflow.optimizer.constants import constants
+from kubeflow.optimizer.types.algorithm_types import BaseAlgorithm, GridSearch, RandomSearch
+from kubeflow.optimizer.types.optimization_types import Direction, Objective
+from kubeflow.optimizer.types.search_types import (
+    CategoricalSearchSpace,
+    ContinuousSearchSpace,
+    Distribution,
+)
+
+
+def get_crd_parameters(
+    search_space: dict[str, katib_models.V1beta1ParameterSpec],
+) -> list[dict[str, Any]]:
+    """Convert the SDK search space into OptimizationJob `spec.parameters`.
+
+    Args:
+        search_space: Dictionary mapping parameter names to `Search.uniform()`,
+            `Search.loguniform()`, or `Search.choice()` specifications.
+
+    Returns:
+        List of parameter dictionaries for the OptimizationJob spec.
+
+    Raises:
+        ValueError: The search space specification is invalid.
+    """
+    parameters = []
+    for param_name, param_spec in search_space.items():
+        feasible_space = param_spec.feasible_space
+        if param_spec.parameter_type == constants.CATEGORICAL_PARAMETERS:
+            if not (feasible_space and feasible_space.list):
+                raise ValueError(f"Categorical parameter '{param_name}' is invalid: {param_spec}")
+            crd_search_space = {
+                constants.SEARCH_SPACE_CATEGORICAL: {
+                    "choices": [str(v) for v in feasible_space.list],
+                },
+            }
+        else:
+            if not (feasible_space and feasible_space.min and feasible_space.max):
+                raise ValueError(f"Continuous parameter '{param_name}' is invalid: {param_spec}")
+            distribution_key = (
+                constants.SEARCH_SPACE_LOG_UNIFORM
+                if feasible_space.distribution == Distribution.LOG_UNIFORM.value
+                else constants.SEARCH_SPACE_UNIFORM
+            )
+            # The CRD validates min/max as decimal-pattern strings.
+            crd_search_space = {
+                distribution_key: {
+                    "min": str(feasible_space.min),
+                    "max": str(feasible_space.max),
+                    "type": constants.PARAMETER_TYPE_FLOAT,
+                },
+            }
+
+        parameters.append({"name": param_name, "searchSpace": crd_search_space})
+
+    return parameters
+
+
+def get_search_space_from_crd(
+    parameters: list[dict[str, Any]],
+) -> dict[str, ContinuousSearchSpace | CategoricalSearchSpace]:
+    """Convert OptimizationJob `spec.parameters` into SDK search space types."""
+    search_space: dict[str, ContinuousSearchSpace | CategoricalSearchSpace] = {}
+    for parameter in parameters:
+        name = parameter.get("name")
+        crd_search_space = parameter.get("searchSpace") or {}
+        if not name or not crd_search_space:
+            raise ValueError(f"OptimizationJob parameter is invalid: {parameter}")
+
+        if constants.SEARCH_SPACE_CATEGORICAL in crd_search_space:
+            categorical = crd_search_space[constants.SEARCH_SPACE_CATEGORICAL]
+            search_space[name] = CategoricalSearchSpace(
+                choices=[str(v) for v in categorical.get("choices", [])]
+            )
+        elif constants.SEARCH_SPACE_LOG_UNIFORM in crd_search_space:
+            log_uniform = crd_search_space[constants.SEARCH_SPACE_LOG_UNIFORM]
+            search_space[name] = ContinuousSearchSpace(
+                min=float(log_uniform["min"]),
+                max=float(log_uniform["max"]),
+                distribution=Distribution.LOG_UNIFORM,
+            )
+        elif constants.SEARCH_SPACE_UNIFORM in crd_search_space:
+            uniform = crd_search_space[constants.SEARCH_SPACE_UNIFORM]
+            search_space[name] = ContinuousSearchSpace(
+                min=float(uniform["min"]),
+                max=float(uniform["max"]),
+                distribution=Distribution.UNIFORM,
+            )
+        else:
+            raise ValueError(f"OptimizationJob search space is invalid: {crd_search_space}")
+
+    return search_space
+
+
+def get_crd_objectives(objectives: list[Objective]) -> list[dict[str, Any]]:
+    """Convert SDK objectives into OptimizationJob `spec.objectives`.
+
+    Raises:
+        ValueError: More than one objective is set. The trainer-native OptimizationJob
+            supports exactly one objective.
+    """
+    if len(objectives) != 1:
+        raise ValueError(
+            "The trainer-native OptimizationJob supports exactly one objective, "
+            f"got {len(objectives)}"
+        )
+
+    return [
+        {
+            "metric": objective.metric,
+            # SDK direction values are lowercase, the CRD enum is Maximize/Minimize.
+            "direction": objective.direction.value.capitalize(),
+        }
+        for objective in objectives
+    ]
+
+
+def get_objectives_from_crd(objectives: list[dict[str, Any]]) -> list[Objective]:
+    """Convert OptimizationJob `spec.objectives` into SDK objectives."""
+    result = []
+    for objective in objectives:
+        metric = objective.get("metric")
+        if not metric:
+            raise ValueError(f"OptimizationJob objective is invalid: {objective}")
+        result.append(
+            Objective(
+                metric=metric,
+                direction=Direction(objective.get("direction", "Minimize").lower()),
+            )
+        )
+    return result
+
+
+def get_crd_search_algorithm(algorithm: BaseAlgorithm) -> dict[str, Any]:
+    """Convert an SDK algorithm into OptimizationJob `spec.searchAlgorithm`.
+
+    Raises:
+        ValueError: The algorithm is not supported by the trainer-native OptimizationJob.
+    """
+    if isinstance(algorithm, RandomSearch):
+        random: dict[str, Any] = {}
+        if algorithm.random_state is not None:
+            random["seed"] = algorithm.random_state
+        return {"random": random}
+    if isinstance(algorithm, GridSearch):
+        return {"grid": {}}
+
+    raise ValueError(
+        f"The trainer-native OptimizationJob doesn't support {type(algorithm).__name__} algorithm"
+    )
+
+
+def get_algorithm_from_crd(search_algorithm: dict[str, Any]) -> GridSearch | RandomSearch:
+    """Convert OptimizationJob `spec.searchAlgorithm` into an SDK algorithm."""
+    if "grid" in search_algorithm:
+        return GridSearch()
+    # The CRD defaults to the random search algorithm.
+    random = search_algorithm.get("random") or {}
+    return RandomSearch(random_state=random.get("seed"))

--- a/kubeflow/optimizer/constants/constants.py
+++ b/kubeflow/optimizer/constants/constants.py
@@ -57,3 +57,14 @@ METRICS_COLLECTOR_CONTAINER = "metrics-logger-and-collector"
 # Katib search space parameter types.
 DOUBLE_PARAMETER = "double"
 CATEGORICAL_PARAMETERS = "categorical"
+
+# The plural for the trainer-native OptimizationJob (trainer.kubeflow.org/v1alpha1).
+OPTIMIZATION_JOB_PLURAL = "optimizationjobs"
+
+# Trainer-native OptimizationJob search space keys.
+SEARCH_SPACE_UNIFORM = "uniform"
+SEARCH_SPACE_LOG_UNIFORM = "logUniform"
+SEARCH_SPACE_CATEGORICAL = "categorical"
+
+# Trainer-native OptimizationJob parameter data type for continuous search spaces.
+PARAMETER_TYPE_FLOAT = "Float"


### PR DESCRIPTION
Part of kubeflow/trainer#3794 (KEP-3562).

Adds a trainer-native backend for OptimizerClient that creates OptimizationJob CRs (trainer.kubeflow.org/v1alpha1, KEP-2605) instead of Katib Experiments. Selected via `TrainerNativeBackendConfig`; the Katib backend is untouched.

**Blocked on trainer PRs** (hence draft): CRD kubeflow/trainer#3552, controller kubeflow/trainer#3828, trial history kubeflow/trainer#3856. Unit tests (44) run against a mocked Kubernetes API; E2E impossible until the controller merges.