### PR TITLE
feat(docs): Spark SDK docs for batch job submission and lifecycle APIs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -136,6 +136,9 @@ html_title = "Kubeflow SDK"
 html_static_path = ["_static"]
 html_css_files = ["custom.css"]
 
+# Don't let every autodoc'd class/function bloat the sidebar's local TOC
+toc_object_entries = False
+
 # Furo theme options with top navigation
 html_theme_options = {
     "sidebar_hide_name": False,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -181,6 +181,10 @@ Getting Involved
    :caption: Spark
 
    spark/index
+   spark/sessions
+   spark/batch-jobs
+   spark/lifecycle
+   spark/options
    spark/api
 
 .. toctree::

--- a/docs/source/spark/api.rst
+++ b/docs/source/spark/api.rst
@@ -10,3 +10,19 @@ Spark Client
    :members:
    :undoc-members:
    :show-inheritance:
+
+Types
+-----
+
+.. automodule:: kubeflow.spark.types.types
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Kubernetes Options
+-------------------
+
+.. automodule:: kubeflow.spark.options.kubernetes
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/spark/batch-jobs.rst
+++ b/docs/source/spark/batch-jobs.rst
@@ -104,7 +104,7 @@ This is passed through as ``spec.mainApplicationFile`` on the generated
 ``SparkApplication``:
 
 .. code-block:: yaml
-  
+
    mainApplicationFile: local:///opt/spark/app/etl.py
 
 Additional dependencies (Python packages, JARs, archives) are not configurable
@@ -124,7 +124,7 @@ through ``submit_job()`` yet — the SDK never sets ``spec.deps`` on the
      - ``str``
      - Local or remote path to the Spark application file (required)
    * - ``args``
-     - ``List[str]``
+     - ``list[str] | None``
      - Command-line arguments passed to the application
 
 Function Mode

--- a/docs/source/spark/batch-jobs.rst
+++ b/docs/source/spark/batch-jobs.rst
@@ -1,0 +1,260 @@
+Batch Jobs
+==========
+
+Submit existing Spark applications as managed, long-running Kubernetes workloads.
+
+Overview
+--------
+
+Batch jobs are built for production workflows — scheduled ETL, CI/CD pipelines, and
+anything that should run to completion without an interactive session attached.
+``submit_job()`` translates a job definition into a ``SparkApplication`` resource
+managed by the Spark Operator.
+
+.. code-block:: python
+
+   from kubeflow.spark import FileJob, SparkClient
+
+   client = SparkClient()
+
+   job_name = client.submit_job(
+       job=FileJob(
+           file_source="https://raw.githubusercontent.com/<repo>/<branch>/daily_pipeline.py",
+           args=["--date", "2024-01-15", "--output", "s3a://bucket/output/"],
+       ),
+       spark_conf={"spark.sql.adaptive.enabled": "true"},
+   )
+
+.. note::
+   The job script itself is fetched from ``https://raw.githubusercontent.com/...``
+   here — that's the URI scheme with a working, tested example today. The job's
+   *output* can still go anywhere Spark can write, including ``s3a://`` — see the
+   note on remote sources below for why the script source and the data paths are
+   different concerns.
+
+Once submitted, use the :doc:`lifecycle` APIs to monitor, wait on, and clean up the
+job.
+
+Two Submission Modes
+---------------------
+
+``submit_job()`` uses function overloading — the type of ``job`` you pass determines
+the mode:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Job Type
+     - Mode
+     - Use Case
+   * - ``job=FileJob(...)``
+     - File mode
+     - Existing scripts, CI/CD pipelines
+   * - ``job=FuncJob(...)``
+     - Function mode
+     - Inline transformations, notebooks
+
+File Mode
+---------
+
+``FileJob`` submits an existing Spark application, referenced by a local or remote
+file source.
+
+.. code-block:: python
+
+   from kubeflow.spark import FileJob
+
+   job_name = client.submit_job(
+       job=FileJob(
+           file_source="https://raw.githubusercontent.com/<repo>/<branch>/daily_pipeline.py",
+           args=["--date", "2024-01-15"],
+       )
+   )
+
+**Remote sources** — ``file_source`` can point at ``s3a://``, ``gs://``,
+``hdfs://``, or ``https://``. The SDK doesn't validate or fetch the file itself —
+The SDK passes the URI through to the Spark runtime, which is responsible for resolving and accessing it:
+
+.. code-block:: python
+
+   client.submit_job(job=FileJob(file_source="https://raw.githubusercontent.com/<repo>/<branch>/etl.py"))
+
+.. note::
+   ``https://`` is the scheme with a working, tested example today (see
+   ``examples/spark`` in the ``kubeflow/sdk`` repo). ``s3a://``, ``gs://``, and
+   ``hdfs://`` are supported the same way in principle — the SDK just passes the
+   URI to Spark — but they haven't been verified end-to-end and may need
+   additional filesystem connector packages that aren't guaranteed to be
+   preinstalled in every Spark image. Until there's an example notebook
+   covering that setup, start with ``https://`` if you want something that's
+   known to work.
+
+**Local sources** — when ``file_source`` uses a local URI
+(``local:///opt/spark/app/etl.py``), the file must already be available to the
+``SparkApplication`` — for example through a mounted PersistentVolumeClaim (PVC) or
+a pre-built container image. SparkClient does not package or upload local files
+automatically:
+
+.. code-block:: python
+
+   client.submit_job(job=FileJob(file_source="local:///opt/spark/app/etl.py"))
+
+.. code-block:: yaml
+
+   mainApplicationFile: local:///opt/spark/app/etl.py
+
+Additional dependencies (Python packages, JARs, archives, and other resources) are
+managed using the Spark Operator's native dependency mechanisms (``deps.files``,
+``deps.pyFiles``, ``deps.jars``, etc.).
+
+``FileJob`` fields:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Field
+     - Type
+     - Description
+   * - ``file_source``
+     - ``str``
+     - Local or remote path to the Spark application file (required)
+   * - ``args``
+     - ``List[str]``
+     - Command-line arguments passed to the application
+   * - ``main_class``
+     - ``str``
+     - Main class for JVM-based (Java/Scala) applications
+
+Function Mode
+-------------
+
+``FuncJob`` lets you submit a Python function directly, without authoring a
+standalone application file yourself.
+
+**In short:** write a normal Python function, put any imports it needs
+*inside* the function body, and pass it to ``FuncJob``. The SDK turns it into
+a runnable script for you. The details below explain exactly which functions
+qualify and why.
+
+.. code-block:: python
+
+   from kubeflow.spark import FuncJob
+
+   def etl_pipeline(date: str, output_path: str):
+       from pyspark.sql import SparkSession
+       import pyspark.sql.functions as F
+
+       spark = SparkSession.builder.getOrCreate()
+       df = spark.read.parquet(f"s3a://data/raw/{date}/")
+
+       result = (
+           df.filter(df.status == "valid")
+           .groupBy("category")
+           .agg(F.sum("amount").alias("total"))
+       )
+
+       result.write.parquet(output_path)
+
+   job_name = client.submit_job(
+       job=FuncJob(
+           func=etl_pipeline,
+           func_args={"date": "2024-01-15", "output_path": "s3a://data/processed/"},
+       )
+   )
+
+**Function requirements.** The SDK reads the function's source directly via
+``inspect.getsource()`` and serializes it — so ``func`` must be a plain,
+top-level function defined in an importable ``.py`` module. Lambdas, decorated
+functions, async functions, and anything defined interactively (a REPL or
+notebook cell) aren't supported — the SDK validates this at submit time and
+raises a ``ValueError`` with a specific reason if ``func`` doesn't qualify. If
+you're prototyping in a notebook, the function still needs to live in a module
+you import from, not be defined inline in a cell.
+
+**func_args must be simple, JSON-like values.** Keys must be strings, and
+values are limited to ``None``, ``str``, ``int``, ``bool``, finite floats, and
+lists/dicts built from those — no arbitrary Python objects (DataFrames,
+custom classes, open file handles, etc.), since ``func_args`` has to be
+serialized alongside the function. The SDK also checks that ``func_args``
+actually matches your function's signature before submitting, so a typo'd
+keyword argument fails fast locally instead of surfacing as a cryptic error
+inside the driver pod.
+
+**Imports must live inside the function body.** Only the function's source is
+serialized, not its surrounding module — so the function needs to be
+self-contained. Any imports it needs (``pyspark.sql``, ``pyspark.sql.functions``,
+etc.) have to be placed inside the function itself, as in the example above,
+so they're available when the generated script runs:
+
+.. code-block:: python
+
+   def transform():
+       from pyspark.sql import SparkSession  # required: import inside the function
+
+       spark = SparkSession.builder.getOrCreate()
+       # ...
+
+Under the hood, the SDK serializes the function into a generated script, writes
+it to a shared ``emptyDir`` volume through an init container, and points the
+driver at the generated file — this is the one case where the SDK does the
+packaging step for you. Once submitted, a ``FuncJob`` converges on the same
+``SparkJob`` shape as a ``FileJob``, so every :doc:`lifecycle` call treats them
+identically.
+
+``FuncJob`` fields:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Field
+     - Type
+     - Description
+   * - ``func``
+     - ``Callable``
+     - Top-level, importable Python function (no lambdas, decorators, or
+       ``async def``) to run as the Spark application
+   * - ``func_args``
+     - ``dict``
+     - Keyword arguments passed to ``func``. String keys; values limited to
+       JSON-like primitives (``None``, ``str``, ``int``, ``bool``, finite
+       ``float``, or lists/dicts of the same) — must match ``func``'s
+       signature
+
+Resource and Spark Configuration
+----------------------------------
+
+Batch jobs use the same resource and Spark configuration model as interactive
+sessions:
+
+.. code-block:: python
+
+   client.submit_job(
+       job=FileJob(file_source="https://raw.githubusercontent.com/<repo>/<branch>/etl.py"),
+       num_executors=10,
+       resources_per_executor={"cpu": "4", "memory": "16Gi"},
+       spark_conf={"spark.sql.adaptive.enabled": "true"},
+   )
+
+For Kubernetes-native customization — labels, annotations, node selection,
+tolerations, and custom job names — see :doc:`options`.
+
+.. code-block:: python
+
+   from kubeflow.spark import Labels, Name
+
+   client.submit_job(
+       job=FileJob(file_source="https://raw.githubusercontent.com/<repo>/<branch>/etl.py"),
+       options=[
+           Name("daily-etl-2026-06-18"),
+           Labels({"team": "data-engineering"}),
+       ],
+   )
+
+Next Steps
+----------
+
+Once a job is submitted, head to :doc:`lifecycle` to monitor its status, stream
+logs, wait for completion, and clean it up.

--- a/docs/source/spark/batch-jobs.rst
+++ b/docs/source/spark/batch-jobs.rst
@@ -107,9 +107,6 @@ This is passed through as ``spec.mainApplicationFile`` on the generated
 
    mainApplicationFile: local:///opt/spark/app/etl.py
 
-Additional dependencies (Python packages, JARs, archives) are not configurable
-through ``submit_job()`` yet — the SDK never sets ``spec.deps`` on the
-``SparkApplication``. Bake them into the Spark image or mount them via a PVC.
 
 ``FileJob`` fields:
 

--- a/docs/source/spark/batch-jobs.rst
+++ b/docs/source/spark/batch-jobs.rst
@@ -38,8 +38,8 @@ job.
 Two Submission Modes
 ---------------------
 
-``submit_job()`` uses function overloading — the type of ``job`` you pass determines
-the mode:
+``submit_job()`` dispatches on the type of ``job`` you pass — anything other than
+``FileJob`` or ``FuncJob`` raises ``TypeError``:
 
 .. list-table::
    :header-rows: 1
@@ -53,7 +53,7 @@ the mode:
      - Existing scripts, CI/CD pipelines
    * - ``job=FuncJob(...)``
      - Function mode
-     - Inline transformations, notebooks
+     - Python functions kept in an importable module
 
 File Mode
 ---------
@@ -100,13 +100,16 @@ automatically:
 
    client.submit_job(job=FileJob(file_source="local:///opt/spark/app/etl.py"))
 
-.. code-block:: yaml
+This is passed through as ``spec.mainApplicationFile`` on the generated
+``SparkApplication``:
 
+.. code-block:: yaml
+  
    mainApplicationFile: local:///opt/spark/app/etl.py
 
-Additional dependencies (Python packages, JARs, archives, and other resources) are
-managed using the Spark Operator's native dependency mechanisms (``deps.files``,
-``deps.pyFiles``, ``deps.jars``, etc.).
+Additional dependencies (Python packages, JARs, archives) are not configurable
+through ``submit_job()`` yet — the SDK never sets ``spec.deps`` on the
+``SparkApplication``. Bake them into the Spark image or mount them via a PVC.
 
 ``FileJob`` fields:
 
@@ -123,9 +126,6 @@ managed using the Spark Operator's native dependency mechanisms (``deps.files``,
    * - ``args``
      - ``List[str]``
      - Command-line arguments passed to the application
-   * - ``main_class``
-     - ``str``
-     - Main class for JVM-based (Java/Scala) applications
 
 Function Mode
 -------------

--- a/docs/source/spark/index.rst
+++ b/docs/source/spark/index.rst
@@ -46,6 +46,20 @@ How It Works
 3. The Spark Operator schedules the driver and executor pods on the cluster
 4. You monitor progress and retrieve logs or results
 
+By default, SparkClient provisions **1 CPU** and **512Mi** of memory per
+executor. You can customize the number of executors and their resource requests
+using ``num_executors`` and ``resources_per_executor``.
+
+.. note::
+
+   Batch job submission requires the ``spark-operator-spark`` ServiceAccount to
+   exist in the target namespace, with the required SparkApplication RBAC
+   permissions bound to it. Otherwise, ``submit_job()`` requests will fail.
+
+   This is a current Spark Operator requirement and is expected to be simplified
+   once `kubeflow/spark-operator#3049 <https://github.com/kubeflow/spark-operator/issues/3049>`_
+   is resolved.
+
 Two Ways to Run Spark
 -----------------------
 

--- a/docs/source/spark/index.rst
+++ b/docs/source/spark/index.rst
@@ -93,6 +93,23 @@ Common Patterns
        },
    )
 
+**Set Spark configuration properties:**
+
+.. code-block:: python
+
+   spark = client.connect(
+       num_executors=3,
+       resources_per_executor={"cpu": "4", "memory": "4Gi"},
+       spark_conf={
+           "spark.sql.adaptive.enabled": "true",
+           "spark.sql.shuffle.partitions": "200",
+           "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
+       },
+   )
+
+``spark_conf`` maps directly to Spark configuration properties and is applied when
+the session is created.
+
 **Create a DataFrame from a range:**
 
 .. code-block:: python
@@ -126,6 +143,131 @@ Common Patterns
 
    result = df.groupBy().count()
    result.show()
+
+Advanced Options
+-----------------
+
+Beyond ``num_executors``, ``resources_per_executor``, and ``spark_conf``, ``connect()``
+accepts an ``options`` list for Kubernetes-native configuration — labels, annotations,
+node placement, tolerations, pod template overrides, and session naming. The options
+pattern is designed for extensibility: new option types can be added in future SDK
+versions without changing the core ``connect()`` signature.
+
+**Labels and annotations**, for resource organization and tooling metadata:
+
+.. code-block:: python
+
+   from kubeflow.spark import Annotations, Labels, SparkClient
+
+   client = SparkClient()
+
+   spark = client.connect(
+       num_executors=3,
+       resources_per_executor={"cpu": "2", "memory": "4Gi"},
+       options=[
+           Labels(
+               {
+                   "app": "spark",
+                   "team": "data-engineering",
+                   "environment": "production",
+               }
+           ),
+           Annotations(
+               {
+                   "description": "Daily ETL pipeline for customer data",
+                   "owner": "data-team@company.com",
+               }
+           ),
+       ],
+   )
+
+**Node selection**, to constrain pods to nodes with matching labels — useful for
+dedicated Spark infrastructure or GPU nodes:
+
+.. code-block:: python
+
+   from kubeflow.spark import NodeSelector, SparkClient
+
+   client = SparkClient()
+
+   spark = client.connect(
+       num_executors=5,
+       resources_per_executor={"cpu": "4", "memory": "16Gi", "nvidia.com/gpu": "1"},
+       options=[
+           NodeSelector({"node-type": "spark-gpu", "workload": "ml"}),
+       ],
+   )
+
+**Tolerations**, to allow scheduling on tainted nodes — for example, dedicated Spark
+nodes or spot instances:
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient, Toleration
+
+   client = SparkClient()
+
+   spark = client.connect(
+       num_executors=10,
+       resources_per_executor={"cpu": "8", "memory": "32Gi"},
+       options=[
+           Toleration(
+               key="spot-instance",
+               operator="Exists",
+               effect="NoSchedule",
+           ),
+       ],
+   )
+
+**Custom session name**, via the ``Name`` option. If not specified, a name is
+auto-generated in the form ``spark-connect-{uuid}``:
+
+.. code-block:: python
+
+   from kubeflow.spark import Name, SparkClient
+
+   client = SparkClient()
+
+   spark = client.connect(
+       num_executors=3,
+       resources_per_executor={"cpu": "2", "memory": "4Gi"},
+       options=[Name("custom-session-name")],
+   )
+
+**Pod template overrides**, for full control over pod specifications — for example,
+security contexts, volumes, or sidecars. Use with caution, since overrides can
+conflict with SDK-managed settings:
+
+.. code-block:: python
+
+   from kubeflow.spark import Driver, Executor, PodTemplateOverride, SparkClient
+
+   client = SparkClient()
+
+   spark = client.connect(
+       driver=Driver(resources={"cpu": "2", "memory": "4Gi"}),
+       executor=Executor(
+           num_instances=5,
+           resources_per_executor={"cpu": "4", "memory": "8Gi"},
+       ),
+       options=[
+           PodTemplateOverride(
+               role="executor",
+               template={
+                   "spec": {
+                       "securityContext": {
+                           "runAsUser": 1000,
+                           "runAsNonRoot": True,
+                       },
+                   }
+               },
+           ),
+       ],
+   )
+
+Options are composable — production setups typically combine several at once (name,
+labels, annotations, node selection, and tolerations together) to fully describe how
+a session should run and be scheduled.
 
 Connecting to Existing Spark Connect Servers
 --------------------------------------------

--- a/docs/source/spark/index.rst
+++ b/docs/source/spark/index.rst
@@ -6,14 +6,18 @@ Run distributed data processing workloads using Apache Spark.
 Overview
 --------
 
-Kubeflow provides integration with Apache Spark to run scalable data processing jobs on Kubernetes. Using the Spark SDK, you can:
+Kubeflow provides integration with Apache Spark to run scalable data processing jobs
+on Kubernetes. Using the Spark SDK, you can:
 
-- **Create Spark sessions** - Connect to a Spark cluster from Python
-- **Run distributed workloads** - Execute Spark DataFrame and SQL operations
+- **Run interactive sessions** - Connect to a Spark cluster from a notebook or script
+- **Submit batch jobs** - Run existing Spark applications as managed Kubernetes workloads
 - **Scale compute resources** - Configure executor counts and resources
 - **Process large datasets** - Perform transformations and aggregations across a cluster
+- **Track progress** - Monitor logs and job status in real-time
 
-Spark jobs are executed on Kubernetes using the Spark Operator. The operator manages the lifecycle of Spark driver and executor pods, allowing Spark workloads to run alongside machine learning pipelines.
+Spark jobs are executed on Kubernetes using the Spark Operator. The operator manages
+the lifecycle of Spark driver and executor pods, allowing Spark workloads to run
+alongside machine learning pipelines.
 
 Spark is commonly used for:
 
@@ -33,318 +37,114 @@ To use Spark with the Kubeflow SDK, install the Spark dependencies:
 
 For full setup instructions, see `the Spark installation guide <https://www.kubeflow.org/docs/components/spark-operator/getting-started/>`_.
 
-Quick Example
--------------
-
-.. code-block:: python
-
-   from kubeflow.spark import SparkClient
-
-   # Connect to a Spark cluster
-   client = SparkClient()
-
-   spark = client.connect(
-       num_executors=5,
-       resources_per_executor={
-           "cpu": "2",
-           "memory": "2Gi",
-       },
-   )
-
-   # Create a distributed DataFrame
-   df = spark.range(10)
-
-   # Run a distributed computation
-   df.show()
-
 How It Works
 ------------
 
-1. **Connect** - Create a Spark client and establish a Spark session
-2. **Configure resources** - Specify executor count and resource allocation
-3. **Submit operations** - Execute DataFrame or SQL transformations
-4. **Execute on cluster** - Spark driver coordinates tasks across executor pods
+1. You create a ``SparkClient``, optionally pointed at a specific namespace via
+   ``KubernetesBackendConfig`` (the only backend supported today)
+2. You either connect interactively or submit a batch job
+3. The Spark Operator schedules the driver and executor pods on the cluster
+4. You monitor progress and retrieve logs or results
 
-When a Spark session is created, a Spark application is started on the Kubernetes cluster. The Spark driver schedules tasks across executor pods, which perform distributed computation on the data.
+Two Ways to Run Spark
+-----------------------
 
-Key Concepts
+Choose the approach that fits your workflow:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 40 35
+
+   * - Approach
+     - Best For
+     - Example
+   * - **Interactive Sessions**
+     - Notebooks, ad-hoc exploration, iterative development
+     - ``client.connect(num_executors=5, ...)``
+   * - **Batch Jobs**
+     - Scheduled ETL, CI/CD pipelines, production workflows
+     - ``client.submit_job(job=FileJob(...))``
+
+Both approaches share the same ``SparkClient`` and the same resource and Spark
+configuration model. Everything below applies across both.
+
+Capabilities
 ------------
 
-**Spark Driver**: The central coordinator that schedules tasks and manages the execution of a Spark application.
+SparkClient is organized around what you're trying to do, not just how you launch
+a job. As new capabilities land, they get their own guide here rather than being
+folded into Sessions or Batch Jobs.
 
-**Executor**: Worker processes that execute Spark tasks and store data partitions.
+**Run Spark**
 
-**Spark Session**: The entry point for interacting with Spark using the DataFrame and SQL APIs.
+.. grid:: 2
+   :gutter: 3
 
-**Spark Operator**: A Kubernetes controller that manages the lifecycle of Spark applications.
+   .. grid-item-card:: Interactive Sessions
+      :link: sessions
+      :link-type: doc
 
-Common Patterns
----------------
+      Connect to Spark from a notebook or script using Spark Connect.
 
-**Configure executor resources:**
+   .. grid-item-card:: Batch Jobs
+      :link: batch-jobs
+      :link-type: doc
 
-.. code-block:: python
+      Submit existing Spark applications as SparkApplication jobs.
 
-   spark = client.connect(
-       num_executors=3,
-       resources_per_executor={
-           "cpu": "4",
-           "memory": "4Gi",
-       },
-   )
+**Monitor**
 
-**Set Spark configuration properties:**
+.. grid:: 2
+   :gutter: 3
 
-.. code-block:: python
+   .. grid-item-card:: Job Lifecycle
+      :link: lifecycle
+      :link-type: doc
 
-   spark = client.connect(
-       num_executors=3,
-       resources_per_executor={"cpu": "4", "memory": "4Gi"},
-       spark_conf={
-           "spark.sql.adaptive.enabled": "true",
-           "spark.sql.shuffle.partitions": "200",
-           "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
-       },
-   )
+      Status model, list/get/wait/logs/delete, and common monitoring patterns.
 
-``spark_conf`` maps directly to Spark configuration properties and is applied when
-the session is created.
+**Configure**
 
-**Create a DataFrame from a range:**
+.. grid:: 2
+   :gutter: 3
 
-.. code-block:: python
+   .. grid-item-card:: Options Reference
+      :link: options
+      :link-type: doc
 
-   df = spark.range(100)
-   df.show()
+      Labels, annotations, node selection, and tolerations. Shared by both
+      Sessions and Batch Jobs.
 
-**Perform transformations:**
+Quick Examples
+--------------
 
-.. code-block:: python
-
-   df = spark.range(10)
-   result = df.withColumn("value_squared", df.id * df.id)
-   result.show()
-
-**Run SQL queries:**
+**Interactive session:**
 
 .. code-block:: python
 
-   df = spark.range(10)
-   df.createOrReplaceTempView("numbers")
-
-   result = spark.sql("SELECT id, id * id AS square FROM numbers")
-   result.show()
-
-**Aggregate data:**
-
-.. code-block:: python
-
-   df = spark.range(100)
-
-   result = df.groupBy().count()
-   result.show()
-
-Advanced Options
------------------
-
-Beyond ``num_executors``, ``resources_per_executor``, and ``spark_conf``, ``connect()``
-accepts an ``options`` list for Kubernetes-native configuration — labels, annotations,
-node placement, tolerations, pod template overrides, and session naming. The options
-pattern is designed for extensibility: new option types can be added in future SDK
-versions without changing the core ``connect()`` signature.
-
-**Labels and annotations**, for resource organization and tooling metadata:
-
-.. code-block:: python
-
-   from kubeflow.spark import Annotations, Labels, SparkClient
+   from kubeflow.spark import SparkClient
 
    client = SparkClient()
-
-   spark = client.connect(
-       num_executors=3,
-       resources_per_executor={"cpu": "2", "memory": "4Gi"},
-       options=[
-           Labels(
-               {
-                   "app": "spark",
-                   "team": "data-engineering",
-                   "environment": "production",
-               }
-           ),
-           Annotations(
-               {
-                   "description": "Daily ETL pipeline for customer data",
-                   "owner": "data-team@company.com",
-               }
-           ),
-       ],
-   )
-
-**Node selection**, to constrain pods to nodes with matching labels — useful for
-dedicated Spark infrastructure or GPU nodes:
-
-.. code-block:: python
-
-   from kubeflow.spark import NodeSelector, SparkClient
-
-   client = SparkClient()
-
    spark = client.connect(
        num_executors=5,
-       resources_per_executor={"cpu": "4", "memory": "16Gi", "nvidia.com/gpu": "1"},
-       options=[
-           NodeSelector({"node-type": "spark-gpu", "workload": "ml"}),
-       ],
+       resources_per_executor={"cpu": "2", "memory": "2Gi"},
    )
 
-**Tolerations**, to allow scheduling on tainted nodes — for example, dedicated Spark
-nodes or spot instances:
+   df = spark.range(10)
+   df.show()
+
+**Batch job:**
 
 .. code-block:: python
 
-   from kubeflow.spark import SparkClient, Toleration
+   from kubeflow.spark import FileJob, SparkClient
 
    client = SparkClient()
-
-   spark = client.connect(
-       num_executors=10,
-       resources_per_executor={"cpu": "8", "memory": "32Gi"},
-       options=[
-           Toleration(
-               key="spot-instance",
-               operator="Exists",
-               effect="NoSchedule",
-           ),
-       ],
+   job_name = client.submit_job(
+       job=FileJob(
+           file_source="https://raw.githubusercontent.com/<repo>/<branch>/daily_pipeline.py",
+           args=["--date", "2026-06-18"],
+       )
    )
 
-**Custom session name**, via the ``Name`` option. If not specified, a name is
-auto-generated in the form ``spark-connect-{uuid}``:
-
-.. code-block:: python
-
-   from kubeflow.spark import Name, SparkClient
-
-   client = SparkClient()
-
-   spark = client.connect(
-       num_executors=3,
-       resources_per_executor={"cpu": "2", "memory": "4Gi"},
-       options=[Name("custom-session-name")],
-   )
-
-**Pod template overrides**, for full control over pod specifications — for example,
-security contexts, volumes, or sidecars. Use with caution, since overrides can
-conflict with SDK-managed settings:
-
-.. code-block:: python
-
-   from kubeflow.spark import Driver, Executor, PodTemplateOverride, SparkClient
-
-   client = SparkClient()
-
-   spark = client.connect(
-       driver=Driver(resources={"cpu": "2", "memory": "4Gi"}),
-       executor=Executor(
-           num_instances=5,
-           resources_per_executor={"cpu": "4", "memory": "8Gi"},
-       ),
-       options=[
-           PodTemplateOverride(
-               role="executor",
-               template={
-                   "spec": {
-                       "securityContext": {
-                           "runAsUser": 1000,
-                           "runAsNonRoot": True,
-                       },
-                   }
-               },
-           ),
-       ],
-   )
-
-Options are composable — production setups typically combine several at once (name,
-labels, annotations, node selection, and tolerations together) to fully describe how
-a session should run and be scheduled.
-
-Connecting to Existing Spark Connect Servers
---------------------------------------------
-
-You can connect to an existing Spark Connect server instead of creating a new Spark session.
-
-.. code-block:: python
-
-   from kubeflow.spark import SparkClient
-
-   client = SparkClient()
-
-   spark = client.connect(
-       base_url="sc://localhost:15002"
-   )
-
-   spark.range(10).show()
-
-This pattern is useful when Spark Connect is already running and managed independently of your application.
-
-Session Management
-------------------
-
-Use the Spark SDK to inspect and manage Spark Connect sessions in the configured Kubernetes namespace (defaults to ``default``).
-
-**List active sessions:**
-
-.. code-block:: python
-
-   from kubeflow.spark import SparkClient
-
-   client = SparkClient()
-
-   sessions = client.list_sessions()
-
-   for session in sessions:
-       print(session.name)
-       print(session.state.value)
-
-**Get session information:**
-
-.. code-block:: python
-
-   session = client.get_session(
-       "spark-connect-example"
-   )
-
-   print(f"Name: {session.name}")
-   print(f"State: {session.state.value}")
-   print(f"Namespace: {session.namespace}")
-
-**View session logs:**
-
-.. code-block:: python
-
-   for line in client.get_session_logs(
-       "spark-connect-example"
-   ):
-       print(line)
-
-**Delete a session:**
-
-.. code-block:: python
-
-   client.delete_session(
-       "spark-connect-example"
-   )
-
-When Things Go Wrong
---------------------
-
-**Common issues:**
-
-- **Connection timeout:** Verify that the Spark Connect server is running and reachable.
-
-- **Session creation failure:** Check Spark Connect logs and available cluster resources.
-
-- **Port-forward errors:** When connecting from outside the cluster, ensure the Spark Connect server is running and reachable. You can also connect directly to an existing Spark Connect endpoint using ``base_url``.
-
-- **Spark application startup issues:** Inspect the Spark Connect server logs and verify the Spark Operator is running correctly.
+   client.wait_for_job_status(job_name)

--- a/docs/source/spark/lifecycle.rst
+++ b/docs/source/spark/lifecycle.rst
@@ -51,7 +51,7 @@ simplified into four SDK-level states:
    * - SDK Status
      - SparkApplication States
    * - ``CREATED``
-     - SUBMITTED
+     - SUBMITTED, or no state reported yet
    * - ``RUNNING``
      - RUNNING, SUCCEEDING, SUSPENDING, SUSPENDED, RESUMING
    * - ``COMPLETED``
@@ -59,7 +59,8 @@ simplified into four SDK-level states:
    * - ``FAILED``
      - FAILED, SUBMISSION_FAILED, FAILING, PENDING_RERUN, INVALIDATING, UNKNOWN
 
-Additional status categories may be introduced in future releases.
+Any SparkApplication state the SDK doesn't recognize maps to ``FAILED`` and logs a
+warning, so newly introduced operator states are handled conservatively.
 
 The ``SparkJob`` Model
 ------------------------

--- a/docs/source/spark/lifecycle.rst
+++ b/docs/source/spark/lifecycle.rst
@@ -1,0 +1,187 @@
+Job Lifecycle
+=============
+
+Monitor, list, wait on, and clean up batch Spark jobs.
+
+Overview
+--------
+
+Once a job is submitted with ``submit_job()`` (see :doc:`batch-jobs`), SparkClient
+provides lifecycle management APIs for tracking it through to completion. These
+APIs follow the same pattern as ``TrainerClient``, so if you've used Kubeflow
+Trainer, this will look familiar:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 50 50
+
+   * - TrainerClient
+     - SparkClient
+   * - ``train()``
+     - ``submit_job()``
+   * - ``list_jobs()``
+     - ``list_jobs()``
+   * - ``get_job()``
+     - ``get_job()``
+   * - ``get_job_logs()``
+     - ``get_job_logs()``
+   * - ``wait_for_job_status()``
+     - ``wait_for_job_status()``
+   * - ``delete_job()``
+     - ``delete_job()``
+
+Status Model
+------------
+
+Job state is derived from the underlying ``SparkApplication`` resource and
+simplified into four SDK-level states:
+
+.. code-block:: python
+
+   class SparkJobStatus(str, Enum):
+       CREATED = "Created"
+       RUNNING = "Running"
+       COMPLETED = "Completed"
+       FAILED = "Failed"
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - SDK Status
+     - SparkApplication States
+   * - ``CREATED``
+     - SUBMITTED
+   * - ``RUNNING``
+     - RUNNING, SUCCEEDING, SUSPENDING, SUSPENDED, RESUMING
+   * - ``COMPLETED``
+     - COMPLETED
+   * - ``FAILED``
+     - FAILED, SUBMISSION_FAILED, FAILING, PENDING_RERUN, INVALIDATING, UNKNOWN
+
+Additional status categories may be introduced in future releases.
+
+The ``SparkJob`` Model
+------------------------
+
+.. code-block:: python
+
+   @dataclass
+   class SparkJob:
+       name: str
+       namespace: str
+       status: SparkJobStatus | None = None
+       creation_timestamp: datetime | None = None
+       num_executors: int | None = None
+       driver_pod_name: str | None = None
+
+Lifecycle APIs
+--------------
+
+**Get a job:**
+
+.. code-block:: python
+
+   job = client.get_job(job_name)
+   print(f"Status: {job.status}")
+
+**List jobs, optionally filtered by status:**
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkJobStatus
+
+   jobs = client.list_jobs()
+   for job in jobs:
+       print(f"{job.name}: {job.status}")
+
+   running = client.list_jobs(status={SparkJobStatus.RUNNING})
+
+**Wait for a job to reach a desired status:**
+
+.. code-block:: python
+
+   completed_job = client.wait_for_job_status(job_name, timeout=3600)
+   print(f"Final status: {completed_job.status}")
+
+.. important::
+   By default, ``wait_for_job_status()`` waits for ``COMPLETED``. If the job
+   instead reaches ``FAILED`` — and ``FAILED`` isn't in the ``status`` set
+   you're waiting for — it raises a ``RuntimeError`` immediately rather than
+   waiting out the timeout. If you want to handle both outcomes yourself
+   without an exception, wait on both explicitly:
+
+   .. code-block:: python
+
+      job = client.wait_for_job_status(
+          job_name,
+          status={SparkJobStatus.COMPLETED, SparkJobStatus.FAILED},
+          timeout=3600,
+      )
+      if job.status == SparkJobStatus.FAILED:
+          ...  # handle failure
+
+   ``timeout`` and ``polling_interval`` must both be positive — a zero or
+   negative value raises ``ValueError`` before any polling starts.
+
+**Stream logs:**
+
+.. code-block:: python
+
+   for line in client.get_job_logs(job_name, follow=True):
+       print(line)
+
+.. note::
+   ``get_job_logs()`` reads from the **driver pod only**, via the Kubernetes API.
+   Executor-level log access isn't wired in yet — the driver is where Spark
+   surfaces stage failures, exceptions, and final job status, so it covers the
+   common debugging path. Log retrieval is only available while the driver pod
+   exists — if it has been deleted (for example, due to TTL-based cleanup),
+   logs may no longer be available.
+
+**Delete a job:**
+
+.. code-block:: python
+
+   client.delete_job(job_name)
+
+.. note::
+   ``get_job_logs()`` above covers raw pod logs. Structured metrics, job health,
+   event streaming, and Spark UI access are planned as a dedicated
+   **Observability** guide that builds on the job model defined here — watch
+   this page's "See also" once that lands.
+
+Common Patterns
+----------------
+
+**Submit and wait for completion:**
+
+.. code-block:: python
+
+   job_name = client.submit_job(job=FileJob(file_source="https://raw.githubusercontent.com/<repo>/<branch>/etl.py"))
+   completed_job = client.wait_for_job_status(job_name, timeout=3600)
+
+**Wait for completion with a timeout:**
+
+.. code-block:: python
+
+   client.wait_for_job_status(job_name, timeout=3600)  # 1 hour max
+
+**List all your running jobs:**
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkJobStatus
+
+   jobs = client.list_jobs(status={SparkJobStatus.RUNNING})
+   for job in jobs:
+       print(f"{job.name}: {job.status}")
+
+**Clean up after inspecting logs:**
+
+.. code-block:: python
+
+   for line in client.get_job_logs(job_name):
+       print(line)
+
+   client.delete_job(job_name)

--- a/docs/source/spark/options.rst
+++ b/docs/source/spark/options.rst
@@ -60,7 +60,7 @@ infrastructure or GPU nodes:
        num_executors=5,
        resources_per_executor={"cpu": "4", "memory": "16Gi", "nvidia.com/gpu": "1"},
        options=[
-           NodeSelector({"node-type": "spark-gpu", "workload": "ml"}),
+           NodeSelector({"kubernetes.io/os": "linux", "node-pool": "batch",}),
        ],
    )
 

--- a/docs/source/spark/options.rst
+++ b/docs/source/spark/options.rst
@@ -47,22 +47,27 @@ For resource organization and tooling metadata:
 Node Selection
 --------------
 
-Constrain pods to nodes with matching labels — useful for dedicated Spark
-infrastructure or GPU nodes:
+Constrain Spark pods to nodes with matching Kubernetes labels:
 
 .. code-block:: python
 
    from kubeflow.spark import NodeSelector, SparkClient
 
-   client = SparkClient()
-
    spark = client.connect(
-       num_executors=5,
-       resources_per_executor={"cpu": "4", "memory": "16Gi", "nvidia.com/gpu": "1"},
-       options=[
-           NodeSelector({"kubernetes.io/os": "linux", "node-pool": "batch",}),
-       ],
-   )
+        num_executors=5,
+        resources_per_executor={
+            "cpu": "4",
+            "memory": "16Gi",
+        },
+        options=[
+            NodeSelector(
+                {
+                    "kubernetes.io/os": "linux",
+                    "node-pool": "batch",
+                }
+            ),
+        ],
+    )
 
 Tolerations
 -----------

--- a/docs/source/spark/options.rst
+++ b/docs/source/spark/options.rst
@@ -88,7 +88,8 @@ Custom Name
 -----------
 
 Set a custom session or job name via the ``Name`` option. If not specified, a name
-is auto-generated (``spark-connect-{uuid}`` for sessions):
+is auto-generated (``spark-connect-{uuid}`` for sessions, ``spark-job-{uuid}`` for
+batch jobs):
 
 .. code-block:: python
 

--- a/docs/source/spark/options.rst
+++ b/docs/source/spark/options.rst
@@ -1,0 +1,119 @@
+Options Reference
+==================
+
+Kubernetes-native customization shared by interactive sessions (:doc:`sessions`)
+and batch jobs (:doc:`batch-jobs`).
+
+Overview
+--------
+
+Beyond ``num_executors``, ``resources_per_executor``, and ``spark_conf``, both
+``connect()`` and ``submit_job()`` accept an ``options`` list for Kubernetes-native
+configuration — labels, annotations, node placement, tolerations, and naming. The options pattern is designed for extensibility: new
+option types can be added in future SDK versions without changing the core method
+signatures.
+
+Labels and Annotations
+------------------------
+
+For resource organization and tooling metadata:
+
+.. code-block:: python
+
+   from kubeflow.spark import Annotations, Labels, SparkClient
+
+   client = SparkClient()
+
+   spark = client.connect(
+       num_executors=3,
+       resources_per_executor={"cpu": "2", "memory": "4Gi"},
+       options=[
+           Labels(
+               {
+                   "app": "spark",
+                   "team": "data-engineering",
+                   "environment": "production",
+               }
+           ),
+           Annotations(
+               {
+                   "description": "Daily ETL pipeline for customer data",
+                   "owner": "data-team@company.com",
+               }
+           ),
+       ],
+   )
+
+Node Selection
+--------------
+
+Constrain pods to nodes with matching labels — useful for dedicated Spark
+infrastructure or GPU nodes:
+
+.. code-block:: python
+
+   from kubeflow.spark import NodeSelector, SparkClient
+
+   client = SparkClient()
+
+   spark = client.connect(
+       num_executors=5,
+       resources_per_executor={"cpu": "4", "memory": "16Gi", "nvidia.com/gpu": "1"},
+       options=[
+           NodeSelector({"node-type": "spark-gpu", "workload": "ml"}),
+       ],
+   )
+
+Tolerations
+-----------
+
+Allow scheduling on tainted nodes — for example, dedicated Spark nodes or spot
+instances:
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient, Toleration
+
+   client = SparkClient()
+
+   spark = client.connect(
+       num_executors=10,
+       resources_per_executor={"cpu": "8", "memory": "32Gi"},
+       options=[
+           Toleration(key="spot-instance", operator="Exists", effect="NoSchedule"),
+       ],
+   )
+
+Custom Name
+-----------
+
+Set a custom session or job name via the ``Name`` option. If not specified, a name
+is auto-generated (``spark-connect-{uuid}`` for sessions):
+
+.. code-block:: python
+
+   from kubeflow.spark import Name, SparkClient
+
+   client = SparkClient()
+
+   spark = client.connect(
+       num_executors=3,
+       resources_per_executor={"cpu": "2", "memory": "4Gi"},
+       options=[Name("custom-session-name")],
+   )
+
+For batch jobs:
+
+.. code-block:: python
+
+   client.submit_job(
+       job=FileJob(file_source="https://raw.githubusercontent.com/<repo>/<branch>/etl.py"),
+       options=[Name("daily-etl-2026-06-18")],
+   )
+
+Composing Options
+------------------
+
+Options are composable — production setups typically combine several at once
+(name, labels, annotations, node selection, and tolerations together) to fully
+describe how a session or job should run and be scheduled.

--- a/docs/source/spark/options.rst
+++ b/docs/source/spark/options.rst
@@ -53,6 +53,8 @@ Constrain Spark pods to nodes with matching Kubernetes labels:
 
    from kubeflow.spark import NodeSelector, SparkClient
 
+   client = SparkClient()
+
    spark = client.connect(
         num_executors=5,
         resources_per_executor={

--- a/docs/source/spark/sessions.rst
+++ b/docs/source/spark/sessions.rst
@@ -6,10 +6,10 @@ Connect to Spark interactively from a notebook or script using Spark Connect.
 Overview
 --------
 
-An interactive session gives you a standard PySpark ``SparkSession`` backed by a
-Spark Connect server running on Kubernetes. Sessions are self-managing: the SDK
-provisions the server and executors for you, and cleans them up when you call
-``spark.stop()`` or the client exits.
+Spark Connect server running on Kubernetes. The SDK provisions the server and
+executors for you, but does not delete them automatically — call
+``client.delete_session(name)`` when you are done, otherwise the ``SparkConnect``
+resource keeps running after your script exits.
 
 Quick Example
 -------------

--- a/docs/source/spark/sessions.rst
+++ b/docs/source/spark/sessions.rst
@@ -6,6 +6,7 @@ Connect to Spark interactively from a notebook or script using Spark Connect.
 Overview
 --------
 
+An interactive session gives you a standard PySpark ``SparkSession`` backed by a
 Spark Connect server running on Kubernetes. The SDK provisions the server and
 executors for you, but does not delete them automatically — call
 ``client.delete_session(name)`` when you are done, otherwise the ``SparkConnect``

--- a/docs/source/spark/sessions.rst
+++ b/docs/source/spark/sessions.rst
@@ -1,0 +1,236 @@
+Interactive Sessions
+=====================
+
+Connect to Spark interactively from a notebook or script using Spark Connect.
+
+Overview
+--------
+
+An interactive session gives you a standard PySpark ``SparkSession`` backed by a
+Spark Connect server running on Kubernetes. Sessions are self-managing: the SDK
+provisions the server and executors for you, and cleans them up when you call
+``spark.stop()`` or the client exits.
+
+Quick Example
+-------------
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+
+   # Connect to a Spark cluster
+   client = SparkClient()
+
+   spark = client.connect(
+       num_executors=5,
+       resources_per_executor={
+           "cpu": "2",
+           "memory": "2Gi",
+       },
+   )
+
+   # Create a distributed DataFrame
+   df = spark.range(10)
+
+   # Run a distributed computation
+   df.show()
+
+Key Concepts
+------------
+
+**Spark Driver**: The central coordinator that schedules tasks and manages the
+execution of a Spark application.
+
+**Executor**: Worker processes that execute Spark tasks and store data partitions.
+
+**Spark Session**: The entry point for interacting with Spark using the DataFrame
+and SQL APIs.
+
+**Spark Operator**: A Kubernetes controller that manages the lifecycle of Spark
+applications.
+
+The Unified ``connect()`` API
+------------------------------
+
+``connect()`` automatically determines the mode based on the parameters you pass:
+
+- **Create mode** - when ``base_url`` is not provided, creates a new Spark Connect
+  session with the specified configuration
+- **Connect mode** - when ``base_url`` is provided, connects to an existing Spark
+  Connect server
+
+.. code-block:: python
+
+   # Create a new session
+   spark = client.connect(
+       num_executors=5,
+       resources_per_executor={"cpu": "5", "memory": "10Gi"},
+       spark_conf={"spark.sql.adaptive.enabled": "true"},
+   )
+
+   # Connect to an existing server
+   spark = client.connect(base_url="sc://server:15002", token="team-token")
+
+   # Minimal usage - default configuration
+   spark = client.connect()
+
+.. important::
+   In **create mode**, if you're running outside the cluster — a laptop, a CI
+   runner, anywhere without ``KUBERNETES_SERVICE_HOST`` set — the SDK
+   automatically opens a ``kubectl port-forward`` to the new session's driver
+   pod so ``connect()`` can reach it, and keeps that process alive for the
+   life of the session. This means:
+
+   - ``kubectl`` must be installed and already configured to reach your
+     cluster (same context/credentials ``kubectl get pods`` would use).
+   - The first call to ``connect()`` in create mode can take a few seconds
+     longer than you might expect — it's waiting for the session to become
+     ready, then for the port-forward and the gRPC server behind it to come up.
+   - Running from inside the cluster (for example, a Kubeflow Notebook) skips
+     this entirely and connects directly via the in-cluster Service.
+
+   **Connect mode** (``base_url=...``) never does this — you're responsible for
+   making sure the URL you pass is already reachable.
+
+Common Patterns
+----------------
+
+**Configure executor resources:**
+
+.. code-block:: python
+
+   spark = client.connect(
+       num_executors=3,
+       resources_per_executor={
+           "cpu": "4",
+           "memory": "4Gi",
+       },
+   )
+
+**Set Spark configuration properties:**
+
+.. code-block:: python
+
+   spark = client.connect(
+       num_executors=3,
+       resources_per_executor={"cpu": "4", "memory": "4Gi"},
+       spark_conf={
+           "spark.sql.adaptive.enabled": "true",
+           "spark.sql.shuffle.partitions": "200",
+           "spark.serializer": "org.apache.spark.serializer.KryoSerializer",
+       },
+   )
+
+``spark_conf`` maps directly to Spark configuration properties and is applied when
+the session is created.
+
+**Per-role driver/executor overrides:** ``connect()`` also accepts ``driver``
+and ``executor`` objects for settings that apply specifically to the driver or
+to executors (rather than to the session as a whole). These are for advanced
+cases — most sessions only need ``num_executors``, ``resources_per_executor``,
+and ``spark_conf`` above. See :doc:`api` for the current field list.
+
+**Create a DataFrame from a range:**
+
+.. code-block:: python
+
+   df = spark.range(100)
+   df.show()
+
+**Perform transformations:**
+
+.. code-block:: python
+
+   df = spark.range(10)
+   result = df.withColumn("value_squared", df.id * df.id)
+   result.show()
+
+**Run SQL queries:**
+
+.. code-block:: python
+
+   df = spark.range(10)
+   df.createOrReplaceTempView("numbers")
+
+   result = spark.sql("SELECT id, id * id AS square FROM numbers")
+   result.show()
+
+**Aggregate data:**
+
+.. code-block:: python
+
+   df = spark.range(100)
+
+   result = df.groupBy().count()
+   result.show()
+
+Connecting to an Existing Spark Connect Server
+------------------------------------------------
+
+.. code-block:: python
+
+   from kubeflow.spark import SparkClient
+
+   client = SparkClient()
+
+   spark = client.connect(base_url="sc://localhost:15002")
+
+   spark.range(10).show()
+
+This pattern is useful when Spark Connect is already running and managed
+independently of your application.
+
+For Kubernetes-native customization of sessions — labels, annotations, node
+selection, tolerations, and custom session names — see :doc:`options`.
+
+Session Management
+-------------------
+
+Use the Spark SDK to inspect and manage Spark Connect sessions in the configured
+Kubernetes namespace (defaults to ``default``).
+
+**List active sessions:**
+
+.. code-block:: python
+
+   sessions = client.list_sessions()
+
+   for session in sessions:
+       print(session.name)
+       print(session.state.value)
+
+**Get session information:**
+
+.. code-block:: python
+
+   session = client.get_session("spark-connect-example")
+
+   print(f"Name: {session.name}")
+   print(f"State: {session.state.value}")
+   print(f"Namespace: {session.namespace}")
+
+**View session logs:**
+
+.. code-block:: python
+
+   for line in client.get_session_logs("spark-connect-example"):
+       print(line)
+
+**Delete a session:**
+
+.. code-block:: python
+
+   client.delete_session("spark-connect-example")
+
+When Things Go Wrong
+----------------------
+
+- **Connection timeout** - Verify that the Spark Connect server is running and
+  reachable.
+- **Session creation failure** - Check Spark Connect logs and available cluster
+  resources.
+- **Port-forward errors** - When connecting from outside the cluster, ensure the
+  Spark Connect server is running and reachable. You can also connect directly to
+  an existing Spark Connect endpoint using ``base_url``.
+- **Spark application startup issues** - Inspect the Spark Connect server logs and
+  verify the Spark Operator is running correctly.


### PR DESCRIPTION
## What this PR does

`docs/source/spark/index.rst` covered interactive sessions well, but batch job submission and lifecycle management (submit_job(), FileJob, FuncJob, list_jobs/get_job/wait_for_job_status/get_job_logs/delete_job) are now implemented and had nowhere to go without turning index.rst into an unmaintainable wall of text.

This PR splits the Spark docs the same way `docs/source/train/` already splits Trainer's docs — a slim landing page plus one guide per capability — instead of cramming everything into a single file.

## New structure

spark/
├── index.rst # landing page: overview, "Two Ways to Run Spark", guide cards
├── sessions.rst # connect(), session management (moved out of index.rst, content unchanged)
├── batch-jobs.rst # submit_job(), FileJob, FuncJob
├── lifecycle.rst # SparkJobStatus, list/get/wait/logs/delete, common patterns
├── options.rst # Labels/Annotations/NodeSelector/Toleration/Name (shared by sessions + batch jobs)
└── api.rst # unchanged

## Notes on content

- `PodTemplateOverride` has been removed everywhere — it's no longer part of either `connect()` or `submit_job()`.
- Batch job examples use `https://` as the flagship `file_source` scheme (matches `examples/spark` and the batch-jobs blog post). `s3a://`, `gs://`, and `hdfs://` are documented as supported but not yet covered by a working example/notebook.
- `batch-jobs.rst` documents the real `FuncJob` constraints from `_validate_func_job`: top-level importable functions only (no lambdas, decorators, `async def`, or interactively-defined functions), imports must live inside the function body, and `func_args` is limited to JSON-like primitive values that must bind to the function's signature.
- `lifecycle.rst` calls out that `wait_for_job_status()` raises `RuntimeError` immediately if a job reaches `FAILED` and `FAILED` isn't in the target `status` set, and that `get_job_logs()` reads from the driver pod only (executor logs aren't wired in yet).
- `sessions.rst` documents the automatic `kubectl port-forward` behavior when `connect()` creates a session from outside the cluster.
- This PR also sets `toc_object_entries = False` in the Sphinx configuration. This is an intentional site-wide documentation change that disables per-object entries in the local table of contents for autodoc pages (Trainer, Spark, Pipelines, Hub, etc.). The goal is to keep API reference sidebars focused on the documentation structure instead of expanding every documented class and function.

## Testing

- [x] `make html` (or equivalent Sphinx build) — no broken `:doc:` references
- [x] Spot-checked code examples against `kubeflow/spark/client.py` and the
      Kubernetes backend implementation

 ### Blocker #720 