### PR TITLE
feat(trainer): add job_exists() helper to TrainerClient

### DIFF
--- a/kubeflow/trainer/api/trainer_client.py
+++ b/kubeflow/trainer/api/trainer_client.py
@@ -232,6 +232,30 @@ class TrainerClient:
 
         return self.backend.get_job(name=name)
 
+    def job_exists(self, name: str) -> bool:
+        """Check whether a TrainJob with the given name exists.
+
+        Args:
+            name: Name of the TrainJob.
+
+        Returns:
+            True if the TrainJob exists, False otherwise.
+
+        Raises:
+            TimeoutError: Timeout occurred while getting the TrainJob.
+
+        Examples:
+            >>> from kubeflow.trainer import TrainerClient
+            >>> client = TrainerClient()
+            >>> if client.job_exists("s8d44aa4fb6d"):
+            ...     print("TrainJob exists")
+        """
+        try:
+            self.get_job(name=name)
+            return True
+        except (ValueError, RuntimeError):
+            return False
+
     def get_job_logs(
         self,
         name: str,

--- a/kubeflow/trainer/api/trainer_client_test.py
+++ b/kubeflow/trainer/api/trainer_client_test.py
@@ -70,3 +70,49 @@ def test_backend_selection(test_case):
         client = TrainerClient(backend_config=test_case["backend_config"])
         backend_name = client.backend.__class__.__name__
         assert backend_name == test_case["expected_backend"]
+
+
+@pytest.fixture
+def trainer_client():
+    """Create a TrainerClient with a mocked LocalProcessBackend."""
+    return TrainerClient(backend_config=LocalProcessBackendConfig())
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        {
+            "name": "job_exists_returns_true",
+            "get_job_side_effect": None,
+            "expected_result": True,
+        },
+        {
+            "name": "job_exists_returns_false_on_value_error",
+            "get_job_side_effect": ValueError("No TrainJob with name test-job"),
+            "expected_result": False,
+        },
+        {
+            "name": "job_exists_returns_false_on_runtime_error",
+            "get_job_side_effect": RuntimeError("Failed to get TrainJob"),
+            "expected_result": False,
+        },
+    ],
+)
+def test_job_exists(trainer_client, test_case):
+    """Test TrainerClient.job_exists() across found, not-found, and error cases."""
+    with patch.object(trainer_client.backend, "get_job") as mock_get_job:
+        if test_case["get_job_side_effect"] is not None:
+            mock_get_job.side_effect = test_case["get_job_side_effect"]
+        else:
+            mock_get_job.return_value = Mock()
+
+        assert trainer_client.job_exists("test-job") == test_case["expected_result"]
+
+
+def test_job_exists_propagates_timeout_error(trainer_client):
+    """Test TrainerClient.job_exists() lets a TimeoutError propagate instead of masking it."""
+    with patch.object(trainer_client.backend, "get_job") as mock_get_job:
+        mock_get_job.side_effect = TimeoutError("Timeout to get TrainJob")
+
+        with pytest.raises(TimeoutError):
+            trainer_client.job_exists("test-job")


### PR DESCRIPTION
## Summary

Closes #380. Checking whether a TrainJob exists currently means calling `get_job()` and handling an exception yourself. This adds a small `job_exists(name: str) -> bool` helper to `TrainerClient` that wraps that pattern.

## Implementation note

The issue's suggested implementation only catches `RuntimeError`. I checked all three backends' `get_job()` and that's not quite right:

- `KubernetesBackend.get_job()` raises `RuntimeError` for a missing job (and for other API failures too, wrapped generically).
- `LocalProcessBackend.get_job()` and `ContainerBackend.get_job()` both raise `ValueError` for a missing job.

So `except RuntimeError` alone would silently return `False` on Kubernetes but let a `ValueError` escape uncaught on the other two backends. `job_exists()` catches both `ValueError` and `RuntimeError`, and lets `TimeoutError` propagate rather than reporting a timeout as "job doesn't exist."

## Changes

- `kubeflow/trainer/api/trainer_client.py`: added `job_exists()`, docstring matches the style of `get_job()` right above it.

## Test plan

- Added `test_job_exists` covering the found case and both not-found exception shapes (`ValueError`, `RuntimeError`).
- Added `test_job_exists_propagates_timeout_error` to confirm a real timeout isn't masked as "not found."
- Verified against the issue's originally proposed `except RuntimeError` implementation: the `ValueError` test case fails with it, confirming the broader catch is necessary, not just extra caution.
- `make verify` (ruff check, ruff format, ty check) passes.
- Full `kubeflow/` unit test suite passes: 684 passed, no regressions.