### PR TITLE
fix: [KEP-107] reject Spark Connect URLs with missing hostname

### DIFF
--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -394,6 +394,8 @@ def validate_spark_connect_url(url: str) -> bool:
     parsed = urlparse(url)
     if parsed.scheme != "sc":
         raise ValueError(f"Invalid scheme '{parsed.scheme}'. Expected 'sc://'")
+    if not parsed.hostname:
+        raise ValueError("Hostname is required in Spark Connect URL")
     if not parsed.port:
         raise ValueError("Port is required in Spark Connect URL")
     return True

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -389,6 +389,13 @@ def test_validate_spark_conf(test_case: TestCase) -> None:
             expected_error=ValueError,
             expected_output="Port is required",
         ),
+        TestCase(
+            name="missing hostname",
+            expected_status=FAILED,
+            config={"url": "sc://:15002"},
+            expected_error=ValueError,
+            expected_output="Hostname is required",
+        ),
     ],
 )
 def test_validate_spark_connect_url(test_case: TestCase) -> None:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
   https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

`validate_spark_connect_url` only checked the URL scheme and port, so a URL with an empty hostname such as `sc://:15002` passed validation. Such a URL is not usable as a Spark Connect endpoint, and the failure surfaced later and less clearly at connection time.

This adds a hostname check between the existing scheme and port checks, so the error is raised at validation time with a message consistent with the surrounding checks. A `missing hostname` test case was added to `test_validate_spark_connect_url`.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #598