### PR TITLE
chore(spark): update Spark examples README for batch jobs

### DIFF
--- a/examples/spark/README.md
+++ b/examples/spark/README.md
@@ -5,9 +5,9 @@ This directory contains examples for using the Kubeflow Spark SDK.
 The Spark SDK supports two ways to run Spark, matching the [Spark SDK documentation](https://sdk.kubeflow.org/en/latest/spark/index.html):
 
 - **Interactive Sessions** - Connect to Spark from a notebook or script using Spark Connect.
-- **Batch Jobs** - Submit existing Spark applications as managed Kubernetes workloads.
+- **Batch Jobs** - Submit Spark applications as managed Kubernetes workloads.
 
-For the full batch job documentation, see [Batch Jobs](https://sdk.kubeflow.org/en/latest/spark/batch-jobs.html) and [Job Lifecycle](https://sdk.kubeflow.org/en/latest/spark/lifecycle.html).
+For the full documentation, see [Interactive Sessions](https://sdk.kubeflow.org/en/latest/spark/sessions.html), [Batch Jobs](https://sdk.kubeflow.org/en/latest/spark/batch-jobs.html), and [Job Lifecycle](https://sdk.kubeflow.org/en/latest/spark/lifecycle.html).
 
 ## Examples
 
@@ -35,17 +35,29 @@ Install spark dependencies:
 uv pip install kubeflow[spark]
 ```
 
-Batch job examples run against a Kubernetes cluster with the Spark Operator installed. Batch job submission requires a `spark-operator-spark` ServiceAccount in the target namespace with the required SparkApplication RBAC permissions. See the [Spark SDK docs](https://sdk.kubeflow.org/en/latest/spark/index.html) for prerequisites.
+The Spark examples run against a Kubernetes cluster with the Spark Operator installed. Batch job submission requires a `spark-operator-spark` ServiceAccount in the target namespace with the required SparkApplication RBAC permissions. See the [Spark SDK docs](https://sdk.kubeflow.org/en/latest/spark/index.html) for prerequisites.
 
 ## Running Examples
 
 ```bash
 # Run from repository root
+
+# Run an interactive session example
 uv run python examples/spark/spark_connect_simple.py
 
 # Run a batch job lifecycle example
 uv run python examples/spark/batch_job_lifecycle.py
 ```
+
+## Interactive Session APIs
+
+Interactive session examples use `SparkClient` and `connect()`:
+
+- `SparkClient()` - Create a client for the Kubernetes cluster
+- `connect()` - Create a new Spark Connect session, or connect to an existing server when `base_url` is provided
+- `delete_session()` - Delete a Spark Connect session when you are done with it
+
+See the [Spark SDK API reference](https://sdk.kubeflow.org/en/latest/spark/api.html) for the current API surface.
 
 ## Batch Job APIs
 

--- a/examples/spark/README.md
+++ b/examples/spark/README.md
@@ -55,6 +55,8 @@ Interactive session examples use `SparkClient` and `connect()`:
 
 - `SparkClient()` - Create a client for the Kubernetes cluster
 - `connect()` - Create a new Spark Connect session, or connect to an existing server when `base_url` is provided
+- `list_sessions()` / `get_session()` - Inspect Spark Connect sessions
+- `get_session_logs()` - Read session logs
 - `delete_session()` - Delete a Spark Connect session when you are done with it
 
 See the [Spark SDK API reference](https://sdk.kubeflow.org/en/latest/spark/api.html) for the current API surface.
@@ -66,7 +68,7 @@ Batch job examples use `submit_job()` with either `FileJob` or `FuncJob`, then m
 - `submit_job()` - Submit a Spark application as a managed Kubernetes workload
 - `get_job()` / `list_jobs()` - Inspect batch jobs
 - `wait_for_job_status()` - Wait for a job to reach a target `SparkJobStatus`
-- `get_job_logs()` - Stream driver pod logs
+- `get_job_logs()` - Read driver pod logs
 - `delete_job()` - Delete a batch job
 
 See the [Spark SDK API reference](https://sdk.kubeflow.org/en/latest/spark/api.html) for the current API surface.

--- a/examples/spark/README.md
+++ b/examples/spark/README.md
@@ -2,12 +2,12 @@
 
 This directory contains examples for using the Kubeflow Spark SDK.
 
-The Spark SDK supports two ways to run Spark, matching the [Spark SDK documentation](../../docs/source/spark/index.rst):
+The Spark SDK supports two ways to run Spark, matching the [Spark SDK documentation](https://sdk.kubeflow.org/en/latest/spark/index.html):
 
 - **Interactive Sessions** - Connect to Spark from a notebook or script using Spark Connect.
 - **Batch Jobs** - Submit existing Spark applications as managed Kubernetes workloads.
 
-For the full batch job documentation, see [Batch Jobs](../../docs/source/spark/batch-jobs.rst) and [Job Lifecycle](../../docs/source/spark/lifecycle.rst).
+For the full batch job documentation, see [Batch Jobs](https://sdk.kubeflow.org/en/latest/spark/batch-jobs.html) and [Job Lifecycle](https://sdk.kubeflow.org/en/latest/spark/lifecycle.html).
 
 ## Examples
 
@@ -25,6 +25,7 @@ For the full batch job documentation, see [Batch Jobs](../../docs/source/spark/b
 - **batch_func_job_lifecycle.py** - Submit a `FuncJob` and exercise the batch job lifecycle
 - **batch_failed_job.py** - Submit a `FileJob` expected to fail and inspect the `FAILED` state
 - **batch_job_options.py** - Submit a batch job with Kubernetes options (labels, annotations, node selector, tolerations, custom name)
+  See the [Options Reference](https://sdk.kubeflow.org/en/latest/spark/options.html) for details on Kubernetes options.
 - **spark_job.py** - A simple Spark application used as the remote `file_source` for the batch job examples
 
 ## Prerequisites
@@ -34,7 +35,7 @@ Install spark dependencies:
 uv pip install kubeflow[spark]
 ```
 
-Batch job examples run against a Kubernetes cluster with the Spark Operator installed. Batch job submission requires a `spark-operator-spark` ServiceAccount in the target namespace with the required SparkApplication RBAC permissions. See the [Spark SDK docs](../../docs/source/spark/index.rst) for prerequisites.
+Batch job examples run against a Kubernetes cluster with the Spark Operator installed. Batch job submission requires a `spark-operator-spark` ServiceAccount in the target namespace with the required SparkApplication RBAC permissions. See the [Spark SDK docs](https://sdk.kubeflow.org/en/latest/spark/index.html) for prerequisites.
 
 ## Running Examples
 
@@ -56,4 +57,4 @@ Batch job examples use `submit_job()` with either `FileJob` or `FuncJob`, then m
 - `get_job_logs()` - Stream driver pod logs
 - `delete_job()` - Delete a batch job
 
-See the [Spark SDK API reference](../../docs/source/spark/api.rst) for the current API surface.
+See the [Spark SDK API reference](https://sdk.kubeflow.org/en/latest/spark/api.html) for the current API surface.

--- a/examples/spark/README.md
+++ b/examples/spark/README.md
@@ -2,12 +2,30 @@
 
 This directory contains examples for using the Kubeflow Spark SDK.
 
+The Spark SDK supports two ways to run Spark, matching the [Spark SDK documentation](../../docs/source/spark/index.rst):
+
+- **Interactive Sessions** - Connect to Spark from a notebook or script using Spark Connect.
+- **Batch Jobs** - Submit existing Spark applications as managed Kubernetes workloads.
+
+For the full batch job documentation, see [Batch Jobs](../../docs/source/spark/batch-jobs.rst) and [Job Lifecycle](../../docs/source/spark/lifecycle.rst).
+
 ## Examples
+
+### Interactive Sessions
 
 - **spark_connect_simple.py** - Basic SparkClient usage with simple API
 - **spark_advanced_options.py** - Advanced configuration with Driver/Executor objects
 - **demo_existing_sparkconnect.py** - Connect to existing SparkConnect cluster
+- **connect_existing_session.py** - Connect to an existing Spark Connect session through `base_url`
 - **test_connect_url.py** - Test URL-based connection to Spark Connect
+
+### Batch Jobs
+
+- **batch_job_lifecycle.py** - Submit a `FileJob` and exercise the batch job lifecycle (`get_job`, `list_jobs`, `get_job_logs`, `delete_job`)
+- **batch_func_job_lifecycle.py** - Submit a `FuncJob` and exercise the batch job lifecycle
+- **batch_failed_job.py** - Submit a `FileJob` expected to fail and inspect the `FAILED` state
+- **batch_job_options.py** - Submit a batch job with Kubernetes options (labels, annotations, node selector, tolerations, custom name)
+- **spark_job.py** - A simple Spark application used as the remote `file_source` for the batch job examples
 
 ## Prerequisites
 
@@ -16,9 +34,26 @@ Install spark dependencies:
 uv pip install kubeflow[spark]
 ```
 
+Batch job examples run against a Kubernetes cluster with the Spark Operator installed. Batch job submission requires a `spark-operator-spark` ServiceAccount in the target namespace with the required SparkApplication RBAC permissions. See the [Spark SDK docs](../../docs/source/spark/index.rst) for prerequisites.
+
 ## Running Examples
 
 ```bash
 # Run from repository root
 uv run python examples/spark/spark_connect_simple.py
+
+# Run a batch job lifecycle example
+uv run python examples/spark/batch_job_lifecycle.py
 ```
+
+## Batch Job APIs
+
+Batch job examples use `submit_job()` with either `FileJob` or `FuncJob`, then manage the job with the lifecycle APIs:
+
+- `submit_job()` - Submit a Spark application as a managed Kubernetes workload
+- `get_job()` / `list_jobs()` - Inspect batch jobs
+- `wait_for_job_status()` - Wait for a job to reach a target `SparkJobStatus`
+- `get_job_logs()` - Stream driver pod logs
+- `delete_job()` - Delete a batch job
+
+See the [Spark SDK API reference](../../docs/source/spark/api.rst) for the current API surface.


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates `examples/spark/README.md` to stay consistent with the new Spark batch job documentation and examples.

- Adds links to the Spark SDK docs (`docs/source/spark/index.rst`, `batch-jobs.rst`, `lifecycle.rst`, `api.rst`).
- Groups examples into Interactive Sessions and Batch Jobs.
- Documents the batch job examples and their purpose.
- Adds batch job prerequisites (Spark Operator + `spark-operator-spark` ServiceAccount/RBAC).
- Adds a Batch Job APIs section listing `submit_job()`, `get_job()`, `list_jobs()`, `wait_for_job_status()`, `get_job_logs()`, `delete_job()`.

**Which issue(s) this PR fixes**:

Fixes #737

**Checklist:**

- [X] Docs included if any changes are user facing
