### PR TITLE
fix(trainer): close throttle race in update_trainjob_status

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -739,9 +739,27 @@ def _should_throttle() -> bool:
     return (now - _last_update_time) < _MIN_UPDATE_INTERVAL_SECONDS
 
 
-def _update_last_time() -> None:
+def _reserve_throttle_slot() -> float | None:
+    """Atomically claim the next throttle slot, or return None if still throttled.
+
+    The reservation is made before the HTTP request is sent so concurrent callers
+    observe it immediately, instead of racing to send once the window expires.
+    """
     global _last_update_time
-    _last_update_time = time.monotonic()
+    with _throttle_lock:
+        if _should_throttle():
+            return None
+        reservation = time.monotonic()
+        _last_update_time = reservation
+        return reservation
+
+
+def _release_throttle_slot(reservation: float) -> None:
+    """Roll back a reservation, but only if no newer reservation has replaced it."""
+    global _last_update_time
+    with _throttle_lock:
+        if _last_update_time == reservation:
+            _last_update_time = 0.0
 
 
 def update_trainjob_status(
@@ -771,14 +789,15 @@ def update_trainjob_status(
     Returns:
         True if update was sent successfully, False otherwise.
     """
+    reservation: float | None = None
     try:
         url = os.environ.get(_ENV_SERVER_URL)
         if not url:
             return False
 
-        with _throttle_lock:
-            if _should_throttle():
-                return False
+        reservation = _reserve_throttle_slot()
+        if reservation is None:
+            return False
 
         ca_file = os.environ.get(_ENV_CA_CERT)
         token_path = os.environ.get(_ENV_TOKEN_PATH)
@@ -786,6 +805,7 @@ def update_trainjob_status(
         token = _get_cached_token(token_path)
         if not token:
             _logger.debug("No authentication token available")
+            _release_throttle_slot(reservation)
             return False
 
         trainer_status: dict = {
@@ -829,18 +849,22 @@ def update_trainjob_status(
         )
 
         if response.status_code == 200:
-            _update_last_time()
             _logger.debug("Status update sent: %s%%", progress_percent)
             return True
         else:
+            _release_throttle_slot(reservation)
             _logger.warning("Status update failed: HTTP %s", response.status_code)
             _logger.debug("Response body: %.500s", response.text)
             return False
 
     except requests.RequestException as e:
+        if reservation is not None:
+            _release_throttle_slot(reservation)
         _logger.warning("Failed to send status update: %s", e)
         return False
     except Exception as e:
+        if reservation is not None:
+            _release_throttle_slot(reservation)
         _logger.warning("Unexpected error in update_trainjob_status: %s", e)
         return False
 

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -14,6 +14,7 @@
 
 import os
 import tempfile
+import threading
 import time
 from unittest.mock import MagicMock, patch
 
@@ -1511,6 +1512,73 @@ def test_update_trainjob_status(test_case: TestCase):
         os.unlink(token_path)
         if ca_path:
             os.unlink(ca_path)
+    print("test execution complete")
+
+
+def test_update_trainjob_status_concurrent_calls_are_throttled():
+    """Concurrent callers within the throttle window must produce exactly one POST."""
+    utils._last_update_time = 0.0
+    utils._cached_token = None
+    utils._token_read_time = 0.0
+    utils._http_session = None
+
+    token_path = _make_token_file()
+    env = {
+        "KUBEFLOW_TRAINER_SERVER_URL": "https://trainer.example.com/status",
+        "KUBEFLOW_TRAINER_SERVER_TOKEN": token_path,
+    }
+
+    try:
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch("kubeflow.trainer.backends.kubernetes.utils._get_status_session") as session_fn,
+        ):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.text = ""
+            session_fn.return_value.post.return_value = mock_resp
+
+            results = []
+            threads = [
+                threading.Thread(
+                    target=lambda: results.append(utils.update_trainjob_status(progress_percent=50))
+                )
+                for _ in range(10)
+            ]
+
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            assert session_fn.return_value.post.call_count == 1
+            assert results.count(True) == 1
+            assert results.count(False) == 9
+    finally:
+        os.unlink(token_path)
+    print("test execution complete")
+
+
+def test_update_trainjob_status_rollback_does_not_clobber_newer_reservation():
+    """A late rollback from an older request must not erase a newer valid reservation."""
+    utils._last_update_time = 0.0
+
+    older_reservation = utils._reserve_throttle_slot()
+    assert older_reservation is not None
+
+    # Simulate a newer request winning the next reservation a moment later.
+    # Using a distinct offset (rather than a second real timestamp) keeps the
+    # test deterministic regardless of the platform's clock resolution.
+    newer_reservation = older_reservation + 1.0
+    utils._last_update_time = newer_reservation
+
+    # The older request's failure handling now rolls back its own reservation.
+    utils._release_throttle_slot(older_reservation)
+
+    # The newer reservation must survive, since it did not match what the
+    # older request tried to roll back.
+    assert utils._last_update_time == newer_reservation
+    assert utils._should_throttle()
     print("test execution complete")
 
 


### PR DESCRIPTION
## Summary

Fixes #639. `update_trainjob_status()` documents itself as throttled to one update per 5 seconds, but the throttle check and the timestamp write were two separate critical sections with an unguarded HTTP POST in between. The timestamp was only written after the request succeeded, so it gated on completion, not on attempt. Multiple threads could all observe `_should_throttle() == False` at once, all pass the check, and all fire a POST — a thundering herd instead of one request every 5 seconds.

## Fix

Reserve the throttle slot atomically, under the lock, before sending the request, instead of updating the timestamp after a successful response:

- `_reserve_throttle_slot()` checks-and-claims `_last_update_time` in one critical section and returns the reservation.
- `_release_throttle_slot(reservation)` rolls the reservation back, but only if `_last_update_time` still equals what this request reserved — compare-and-rollback, so a late-failing older request can't erase a newer valid reservation from another thread.
- `update_trainjob_status()` releases its reservation on every non-success path (missing token, non-200, exception) so a failed attempt still doesn't consume the window, matching existing behavior.

Out-of-order completion (a slower earlier update finishing after a faster later one) is a separate problem the issue itself calls out as needing server-side sequencing or full request serialization — not something a client-side throttle fix can solve, so it's out of scope here.

## Test plan

- Added `test_update_trainjob_status_concurrent_calls_are_throttled`, adapted from the issue's own repro: fires 10 threads concurrently and asserts exactly 1 HTTP POST. Verified this fails against the old code (7 of 10 threads got through) and passes reliably against the fix (5/5 runs, no flakiness observed).
- Added `test_update_trainjob_status_rollback_does_not_clobber_newer_reservation` to directly test the compare-and-rollback identity check.
- All existing throttle tests still pass unchanged, including "failed send does not consume throttle window."
- `make verify` (ruff check, ruff format, ty check) passes.
- Full `kubeflow/` unit test suite passes: 690 passed, no regressions.