### PR TITLE
fix(trainer): validate TorchTune loss and dataset source enums

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -512,6 +512,9 @@ def get_args_using_torchtune_config(
 
     # Override the loss if it is provided.
     if fine_tuning_config.loss:
+        if not isinstance(fine_tuning_config.loss, types.Loss):
+            raise ValueError(f"Invalid loss: {fine_tuning_config.loss}.")
+
         args.append(f"loss={fine_tuning_config.loss.value}")
 
     # Override the data dir or data files if it is provided.
@@ -594,7 +597,7 @@ def get_args_from_dataset_preprocess_config(
     # Override the dataset source field if it is provided.
     if dataset_preprocess_config.source:
         if not isinstance(dataset_preprocess_config.source, types.DataFormat):
-            raise ValueError(f"Invalid data format: {dataset_preprocess_config.source.value}.")
+            raise ValueError(f"Invalid data format: {dataset_preprocess_config.source}.")
 
         args.append(f"dataset.source={dataset_preprocess_config.source.value}")
 

--- a/kubeflow/trainer/backends/kubernetes/utils_test.py
+++ b/kubeflow/trainer/backends/kubernetes/utils_test.py
@@ -858,6 +858,29 @@ def test_get_args_from_peft_config(test_case: TestCase):
                 "dataset.train_on_input=True",
             ],
         ),
+        TestCase(
+            name="source is serialized by value",
+            expected_status=SUCCESS,
+            config={
+                "dataset_preprocess_config": types.TorchTuneInstructDataset(
+                    source=types.DataFormat.JSON,
+                ),
+            },
+            expected_output=[
+                f"dataset={constants.TORCH_TUNE_INSTRUCT_DATASET}",
+                "dataset.source=json",
+            ],
+        ),
+        TestCase(
+            name="invalid source raises ValueError",
+            expected_status=FAILED,
+            config={
+                "dataset_preprocess_config": types.TorchTuneInstructDataset(
+                    source="json",
+                ),
+            },
+            expected_error=ValueError,
+        ),
     ],
 )
 def test_get_args_from_dataset_preprocess_config(test_case: TestCase):
@@ -1017,6 +1040,16 @@ def _build_builtin_runtime() -> types.Runtime:
             config={
                 "fine_tuning_config": types.TorchTuneConfig(
                     dtype="invalid",
+                ),
+            },
+            expected_error=ValueError,
+        ),
+        TestCase(
+            name="invalid loss raises ValueError",
+            expected_status=FAILED,
+            config={
+                "fine_tuning_config": types.TorchTuneConfig(
+                    loss="torchtune.modules.loss.CEWithChunkedOutputLoss",
                 ),
             },
             expected_error=ValueError,


### PR DESCRIPTION
**What this PR does / why we need it**:

`TorchTuneConfig.loss` and `TorchTuneInstructDataset.source` both raised `AttributeError`
from inside the SDK when they were given a plain string instead of an enum member, even
though `dtype` in the same code path already raised a clear `ValueError`. This PR makes
all three consistent.

Two distinct causes, both in `kubeflow/trainer/backends/kubernetes/utils.py`:

1. `loss` had no type check at all in `get_args_using_torchtune_config`, so
   `loss.value` was evaluated directly on whatever was passed in.
2. In `get_args_from_dataset_preprocess_config` the `ValueError` for an invalid
   `source` was unreachable: the branch is entered only when `source` is *not* a
   `DataFormat`, but the message then evaluated `.value` on that non-enum object, so
   constructing the exception raised `AttributeError` before it could be raised.

Behaviour, reproduced with a small script against `main` (`97ec647`) and after the fix:

| Input | Before | After |
| --- | --- | --- |
| `TorchTuneConfig(dtype="bf16")` | `ValueError: Invalid dtype: bf16.` | unchanged |
| `TorchTuneConfig(loss="torchtune.modules.loss.CEWithChunkedOutputLoss")` | `AttributeError: 'str' object has no attribute 'value'` | `ValueError: Invalid loss: torchtune.modules.loss.CEWithChunkedOutputLoss.` |
| `TorchTuneInstructDataset(source="json")` | `AttributeError: 'str' object has no attribute 'value'` | `ValueError: Invalid data format: json.` |

Passing a bare string is an easy mistake when a fine-tuning configuration is written by
hand, and `DataFormat.JSON.value` is literally `"json"`, so the invalid value tends to
look correct at a glance.

Scope is deliberately limited to type validation. No value-range or membership checks are
added, no public signature changes, and the only behaviour that changes is on inputs that
already failed.

Tests: three cases added to the existing parametrized tests in `utils_test.py`, following
the `TestCase` pattern already used there.

- `invalid loss raises ValueError`
- `invalid source raises ValueError`
- `source is serialized by value` — `get_args_from_dataset_preprocess_config` previously
  had no coverage for `source` at all, which is why the unreachable branch went unnoticed.

Both failure cases fail on `main` with `assert <class 'AttributeError'> is <class
'ValueError'>` and pass with the fix, so they are genuine regression tests.

Verification run locally: `uv run pytest -q kubeflow` (691 passed), `uv lock --check`,
`uv run ruff check .`, `uv run ruff format --check kubeflow`, `uv run ty check kubeflow/hub`,
and `uv run pre-commit run` on the changed files — all clean.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #741

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
