### PR TITLE
fix(docs): resolve remaining Sphinx build warnings across modules

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -147,6 +147,7 @@ Getting Involved
    :hidden:
    :caption: Getting Started
 
+   getting-started/index
    getting-started/installation
    getting-started/quickstart
    getting-started/local-development

--- a/kubeflow/spark/api/spark_client.py
+++ b/kubeflow/spark/api/spark_client.py
@@ -184,7 +184,7 @@ class SparkClient:
         This method supports two job types:
 
         - **FileJob**: Submit a Spark application referenced by a local
-        or remote file source.
+          or remote file source.
         - **FuncJob**: Submit a Python function as a Spark batch job.
 
         Args:

--- a/kubeflow/trainer/types/types.py
+++ b/kubeflow/trainer/types/types.py
@@ -39,14 +39,22 @@ class CustomTrainer:
             are extra-index-urls.
         num_nodes (`Optional[int]`): The number of nodes to use for training.
         resources_per_node (`Optional[dict]`): The computing resources to allocate per node.
-          ```python
-          resources_per_node = {"gpu": 4, "cpu": 5, "memory": "10G"}
-          ```
-         If your compute supports fractional GPUs (e.g. multi-instance GPU),
-            you can set the resources as follows (request 1 GPU slice of 5Gb) :
-          ```python
-          resources_per_node = {"mig-1g.5gb": 1}
-          ```
+
+            Example::
+
+                resources_per_node = {
+                    "gpu": 4,
+                    "cpu": 5,
+                    "memory": "10G",
+                }
+
+            If your compute supports fractional GPUs (e.g. multi-instance GPU),
+            you can set the resources as follows (request 1 GPU slice of 5Gb):
+
+            Example::
+
+                resources_per_node = {"mig-1g.5gb": 1}
+
         env (`Optional[dict[str, str]]`): The environment variables to set in the training nodes.
     """
 
@@ -72,14 +80,22 @@ class CustomTrainerContainer:
         image (`str`): The container image that encapsulates the entire model training process.
         num_nodes (`Optional[int]`): The number of nodes to use for training.
         resources_per_node (`Optional[dict]`): The computing resources to allocate per node.
-          ```python
-          resources_per_node = {"gpu": 4, "cpu": 5, "memory": "10G"}
-          ```
-         If your compute supports fractional GPUs (e.g. multi-instance GPU),
-            you can set the resources as follows (request 1 GPU slice of 5Gb) :
-          ```python
-          resources_per_node = {"mig-1g.5gb": 1}
-          ```
+
+            Example::
+
+                resources_per_node = {
+                    "gpu": 4,
+                    "cpu": 5,
+                    "memory": "10G",
+                }
+
+            If your compute supports fractional GPUs (e.g. multi-instance GPU),
+            you can set the resources as follows (request 1 GPU slice of 5Gb):
+
+            Example::
+
+                resources_per_node = {"mig-1g.5gb": 1}
+
         env (`Optional[dict[str, str]]`): The environment variables to set in the training nodes.
     """
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This PR resolves three distinct Sphinx `[docutils]` formatting warnings that were triggered when generating the documentation via `make docs`.

**Summary of Fixes:**

1. **Fixed Bullet List Indentation in `spark_client.py`**
   * *The Issue:* A bullet point in the `submit_job` docstring spanned multiple lines, but the second line was not properly indented. Sphinx interpreted this as an unexpected end to the bullet list.
   * *The Fix:* Indented the second line by two additional spaces so it properly aligns with the text of the first line, allowing Sphinx to parse it as a single continuous bullet point.

2. **Fixed Code Block Formatting in `trainer/types/types.py`**
   * *The Issue:* The `CustomTrainer` and `CustomTrainerContainer` classes used Markdown-style code fences ( ````python` ) inside an RST docstring and lacked the required blank lines around the indented blocks, causing "unexpected unindent" errors.
   * *The Fix:* Replaced the Markdown fences with proper RST `Example::` directives, added the mandatory blank lines before and after the code blocks, and aligned the indentation of the surrounding text so the arguments parse correctly.

3. **Fixed Orphaned Document in `docs/source/index.rst`**
   * *The Issue:* The `getting-started/index.rst` file existed in the repository but was not referenced in any `toctree`. Sphinx generated a `toc.not_included` warning because the file was missing from the site's navigation.
   * *The Fix:* Added `getting-started/index` as the first entry under the "Getting Started" toctree in the main `index.rst` file, mirroring the structure used by all other modules and fixing the site navigation.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:
Fixes #746

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing