### PR TITLE
fix(ci): harden OSV-Scanner workflow and helper scripts

### DIFF
--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -15,6 +15,15 @@ import pytest
 SCRIPTS_DIR = Path(__file__).parent
 
 
+def _assert_valid_toml(content: str) -> None:
+    """Assert `content` parses as TOML. No-op on Python 3.10 (no stdlib tomllib)."""
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        return
+    tomllib.loads(content)
+
+
 class TestCompareVersions:
     """Tests for compare_versions.py"""
 
@@ -24,6 +33,7 @@ class TestCompareVersions:
             [sys.executable, SCRIPTS_DIR / "compare_versions.py", current, target],
             capture_output=True,
             text=True,
+            encoding="utf-8",
         )
         return result.returncode
 
@@ -73,6 +83,7 @@ class TestCompareVersions:
             [sys.executable, SCRIPTS_DIR / "compare_versions.py", "invalid", "2.0.0"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
         )
         assert result.returncode == 2
         assert "Error" in result.stderr
@@ -83,6 +94,7 @@ class TestCompareVersions:
             [sys.executable, SCRIPTS_DIR / "compare_versions.py", "2.0.0"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
         )
         assert result.returncode == 2
 
@@ -97,6 +109,7 @@ class TestExtractVersion:
             input=tree_output,
             capture_output=True,
             text=True,
+            encoding="utf-8",
         )
         return result.returncode, result.stdout.strip(), result.stderr.strip()
 
@@ -188,6 +201,7 @@ class TestUpdateOverrides:
                 ],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
             )
 
             updated_content = Path("pyproject.toml").read_text()
@@ -304,6 +318,37 @@ override-dependencies = ["pkg1==1.0.0", "pkg2==2.0.0"]
         assert "override-dependencies = [\n" in updated
         # Should not have duplicate override-dependencies
         assert updated.count("override-dependencies") == 1
+
+    def test_create_section_no_duplicate_key(self):
+        """Creating [tool.uv] from scratch emits exactly one override key"""
+        pyproject = "[project]\nname = 'test'\n"
+        exit_code, updated = self.run_update(
+            pyproject, "requests", "requests==2.31.0", "2025-01-15", "https://advisory.com"
+        )
+
+        assert exit_code == 0
+        assert updated.count("override-dependencies") == 1
+        _assert_valid_toml(updated)
+
+    def test_indented_override_dependencies(self):
+        """Indented override key is replaced, not duplicated"""
+        pyproject = (
+            "[project]\nname = 'test'\n\n[tool.uv]\n"
+            "  override-dependencies = [\n"
+            '      "flask==3.0.0",\n'
+            '      "requests==2.20.0",\n'
+            "  ]\n"
+        )
+        exit_code, updated = self.run_update(
+            pyproject, "requests", "requests==2.31.0", "2025-01-15", "https://advisory.com"
+        )
+
+        assert exit_code == 0
+        assert updated.count("override-dependencies") == 1
+        assert '"requests==2.31.0",' in updated
+        assert "2.20.0" not in updated  # old indented entry replaced
+        assert '"flask==3.0.0",' in updated  # sibling preserved
+        _assert_valid_toml(updated)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/update_overrides.py
+++ b/.github/scripts/update_overrides.py
@@ -84,9 +84,9 @@ def main():
 
     # Rebuild pyproject.toml
     if not has_tool_uv:
-        # Add [tool.uv] section at the end
+        # Add the [tool.uv] section; the header and array are inserted below.
+        # (Adding the header here too would duplicate the whole block -> invalid TOML.)
         content += "\n[tool.uv]\n"
-        content += "# Security overrides - Review periodically and remove if parent constraints allow natural upgrade\n"
         has_tool_uv = True
 
     if has_overrides:
@@ -94,14 +94,14 @@ def main():
         # Single-line: override-dependencies = ["pkg==1.0"]
         # Multi-line: override-dependencies = [\n    "pkg",\n]
         content = re.sub(
-            r"^override-dependencies\s*=\s*\[.*?\]",
+            r"^[ \t]*override-dependencies\s*=\s*\[.*?\]",
             "",
             content,
             flags=re.MULTILINE | re.DOTALL,
         )
         # Also remove any orphaned comments before override-dependencies
         content = re.sub(
-            r"^# Security overrides.*?\n(?:[ \t]*\n)?",
+            r"^[ \t]*# Security overrides.*?\n(?:[ \t]*\n)?",
             "",
             content,
             flags=re.MULTILINE,

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -26,8 +26,8 @@ jobs:
         # Bump cadence: check https://github.com/google/osv-scanner/releases monthly
         # Dependabot cannot bump curl-installed binaries — update version + checksum manually
         run: |
-          OSV_VERSION="2.3.8"
-          EXPECTED_SHA="bc98e15319ed0d515e3f9235287ba53cdc5535d576d24fd573978ecfe9ab92dc"
+          OSV_VERSION="2.5.0"
+          EXPECTED_SHA="edcfc41d257db36148f065055655fe3fcfc434b0b423ea67468a84c207524e0c"
           curl -fsSL "https://github.com/google/osv-scanner/releases/download/v${OSV_VERSION}/osv-scanner_linux_amd64" -o osv-scanner
           ACTUAL_SHA=$(sha256sum osv-scanner | awk '{print $1}')
           if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then

--- a/.github/workflows/osv-scanner.yaml
+++ b/.github/workflows/osv-scanner.yaml
@@ -38,8 +38,6 @@ jobs:
           sudo mv osv-scanner /usr/local/bin/
 
       - name: Run OSV-Scanner (SARIF for Security Tab)
-        # continue-on-error so a SARIF failure doesn't block the JSON scan + auto-fix below
-        continue-on-error: true
         run: |
           rc=0
           osv-scanner scan \
@@ -60,6 +58,8 @@ jobs:
           category: kubeflow-sdk-osv-scanner
 
       - name: Run OSV-Scanner (JSON for auto-fix)
+        # always() so a crash in the SARIF step above still doesn't skip the independent JSON scan
+        if: always()
         run: |
           rc=0
           osv-scanner scan \
@@ -149,7 +149,7 @@ jobs:
               continue
             fi
             EXTRACT_RC=0
-            NATURAL_VER=$(echo "$TREE_OUTPUT" | uv run python3 .github/scripts/extract_version.py "$pkg") || EXTRACT_RC=$?
+            NATURAL_VER=$(printf '%s\n' "$TREE_OUTPUT" | uv run python3 .github/scripts/extract_version.py "$pkg") || EXTRACT_RC=$?
             if [ "$EXTRACT_RC" -ne 0 ]; then
               echo "Warning: Could not parse version for $pkg from uv tree output, skipping"
               continue
@@ -165,7 +165,7 @@ jobs:
             # Compare: does natural version meet the fix?
             # compare_versions.py exits: 0 = upgrade needed, 1 = sufficient, 2 = parse error
             CMP_EXIT=0
-            uv run python3 .github/scripts/compare_versions.py "$NATURAL_VER" "$fix_ver" || CMP_EXIT=$?
+            uv run --with packaging python3 .github/scripts/compare_versions.py "$NATURAL_VER" "$fix_ver" || CMP_EXIT=$?
 
             if [ "$CMP_EXIT" -eq 2 ]; then
               echo "Warning: Could not parse versions for $pkg ($NATURAL_VER vs $fix_ver), skipping"
@@ -180,11 +180,11 @@ jobs:
                 echo "Warning: uv lock failed after adding override for $pkg (exit code $LOCK_RC), skipping"
                 continue
               fi
-              printf '%s\n' "- ${pkg}==${fix_ver} (override) | [$advisory_id]($advisory_url)" >> applied_fixes.txt
+              printf '%s\n' "| ${pkg}==${fix_ver} (override) | [$advisory_id]($advisory_url) |" >> applied_fixes.txt
             else
               # NATURAL_VER >= fix_ver — natural upgrade worked
               echo "Natural upgrade sufficient ($NATURAL_VER >= $fix_ver)"
-              printf '%s\n' "- ${pkg}==${NATURAL_VER} (upgraded) | [$advisory_id]($advisory_url)" >> applied_fixes.txt
+              printf '%s\n' "| ${pkg}==${NATURAL_VER} (upgraded) | [$advisory_id]($advisory_url) |" >> applied_fixes.txt
             fi
           done <<< "$FIX_DATA"
 
@@ -232,4 +232,4 @@ jobs:
           branch: security-nightly-updates
           delete-branch: true
           labels: |
-            "area/security"
+            area/security


### PR DESCRIPTION
**What this PR does / why we need it**:

Mirrors back the fixes found while porting this repo's OSV-Scanner workflow to kubeflow/mcp-server (kubeflow/mcp-server#30, merged and running nightly there — its auto-fix pipeline has already landed a real security bump, kubeflow/mcp-server#137). Three commits, separable by concern:

1. **`update_overrides.py` TOML fixes + tests** — creating `[tool.uv]` from scratch emitted a duplicate header+array block, and the column-0-anchored removal regexes missed indented (valid TOML) keys; both produced duplicate `override-dependencies` keys that `uv` rejects. Regression tests included, plus `encoding="utf-8"` on the test subprocesses so the `uv tree` box-drawing fixtures pass on Windows checkouts.
2. **Workflow hardening** — `continue-on-error` was swallowing genuine scanner crashes (exit >= 2) on the SARIF step; replaced with `if: always()` on the JSON step so crashes fail the job without blocking the independent auto-fix path. Also: the auto-fix PR changelog now emits real table rows, the `area/security` label loses its literal quotes (create-pull-request doesn't strip them), `compare_versions.py` runs with an explicit `--with packaging`, and tree output is piped via `printf`.
3. **Pin bump 2.3.8 -> 2.5.0** (was two releases stale) — checksum taken from the release's official `osv-scanner_SHA256SUMS` and cross-verified against the downloaded binary. Kept as its own commit so it's severable if you'd rather bump separately.

Note: #573 touches the same removal regex in `update_overrides.py` (trailing-comment tolerance) — the changes compose; happy to rebase whichever lands second.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #748

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing _(N/A — CI-internal)_
