### PR TITLE
fix(spark): avoid mutable default argument in wait_for_job_status

### DIFF
--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -1130,7 +1130,7 @@ class KubernetesBackend(RuntimeBackend):
     def wait_for_job_status(
         self,
         name: str,
-        status: set[SparkJobStatus] = {SparkJobStatus.COMPLETED},
+        status: set[SparkJobStatus] | None = None,  # Change from {SparkJobStatus.COMPLETED} to None
         timeout: int = 600,
         polling_interval: int = 2,
     ) -> SparkJob:
@@ -1151,6 +1151,9 @@ class KubernetesBackend(RuntimeBackend):
                 one of the target statuses.
             TimeoutError: If the target status is not reached within the timeout.
         """
+        if status is None:
+            status = {SparkJobStatus.COMPLETED}  # Safely instantiate a fresh set per call
+
         if timeout <= 0:
             raise ValueError("timeout must be positive.")
 

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -1704,7 +1704,7 @@ def test_delete_job(kubernetes_backend, test_case):
             config={
                 "job_name": "spark-job-completed",
                 "job_status": SparkJobStatus.COMPLETED,
-                "target_status": None,
+                "target_status": None,  # Tests the `if status is None:` fallback branch
             },
         ),
         TestCase(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fixes a mutable default parameter (`status: set = {SparkJobStatus.COMPLETED}`) in `KubernetesBackend.wait_for_job_status` by setting the default to `None` and instantiating the set inside the method body.

In Python, default arguments are evaluated at function definition time rather than execution time. Using a mutable `set` as a default parameter means all calls to `wait_for_job_status()` without an explicit `status` argument share the same `set` reference in memory. If `status` is ever mutated, those changes leak across subsequent calls. Updating the signature to `status: set[SparkJobStatus] | None = None` and initializing `{SparkJobStatus.COMPLETED}` inside the method ensures a fresh set is created for every call.

**Which issue(s) this PR fixes**:
Fixes #

**Checklist:**
- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing