### PR TITLE
fix(spark): remove redundant Spark Connect JAR download for Spark 4.x

### DIFF
--- a/kubeflow/spark/backends/kubernetes/constants.py
+++ b/kubeflow/spark/backends/kubernetes/constants.py
@@ -28,9 +28,6 @@ SPARK_CONNECT_PORT = 15002
 # Session name prefix
 SESSION_NAME_PREFIX = "spark-connect"
 
-# Spark Connect Maven package (required for Connect server main class on classpath)
-SPARK_CONNECT_PACKAGE_SCALA_VERSION = "2.13"
-
 # Spark job name prefix
 JOB_NAME_PREFIX = "spark-job"
 

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -562,24 +562,13 @@ def build_spark_connect_cr(
 
     image = driver.image if driver and driver.image else default_image
 
-    # Use direct JAR URL to avoid Ivy cache (container may not have writable ~/.ivy2)
-    connect_jar_url = (
-        f"https://repo1.maven.org/maven2/org/apache/spark/"
-        f"spark-connect_{constants.SPARK_CONNECT_PACKAGE_SCALA_VERSION}/{spark_version}/"
-        f"spark-connect_{constants.SPARK_CONNECT_PACKAGE_SCALA_VERSION}-{spark_version}.jar"
-    )
     # Server listens on all interfaces so port-forward and in-cluster access work (Spark Connect config)
     base_conf: dict[str, str] = {
-        "spark.jars": connect_jar_url,
         "spark.connect.grpc.binding.address": "0.0.0.0",
     }
+
     if spark_conf:
-        existing_jars = spark_conf.get("spark.jars", "").strip()
-        if existing_jars:
-            base_conf["spark.jars"] = f"{connect_jar_url},{existing_jars}"
-        for k, v in spark_conf.items():
-            if k != "spark.jars":
-                base_conf[k] = v
+        base_conf.update(spark_conf)
 
     # Build the typed SparkConnect model
     spark_connect = models.SparkV1alpha1SparkConnect(

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -505,6 +505,7 @@ def test_build_service_url(test_case: TestCase) -> None:
             config={
                 "spark_conf": {
                     "spark.sql.adaptive.enabled": "true",
+                    "spark.jars": "local:///opt/spark/jars/my.jar",
                 },
             },
         ),
@@ -665,6 +666,7 @@ def test_build_spark_connect_cr(test_case: TestCase, mock_k8s_backend) -> None:
         assert spark_connect.spec.server.cores == constants.DEFAULT_DRIVER_CPU
         assert spark_connect.spec.server.memory == "512m"
         assert spark_connect.spec.spark_conf["spark.connect.grpc.binding.address"] == "0.0.0.0"
+        assert "spark.jars" not in spark_connect.spec.spark_conf
 
     elif test_case.name == "spark connect cr with num executors":
         assert spark_connect.spec.executor.instances == 3
@@ -674,10 +676,7 @@ def test_build_spark_connect_cr(test_case: TestCase, mock_k8s_backend) -> None:
         assert spark_connect.spec.executor.memory == "4g"
 
     elif test_case.name == "spark connect cr with spark conf":
-        assert spark_connect.spec.spark_conf["spark.jars"].endswith(
-            f"spark-connect_{constants.SPARK_CONNECT_PACKAGE_SCALA_VERSION}-"
-            f"{constants.DEFAULT_SPARK_VERSION}.jar"
-        )
+        assert spark_connect.spec.spark_conf["spark.jars"] == "local:///opt/spark/jars/my.jar"
         assert spark_connect.spec.spark_conf["spark.sql.adaptive.enabled"] == "true"
 
     elif test_case.name == "spark conf overrides grpc binding address":
@@ -699,10 +698,6 @@ def test_build_spark_connect_cr(test_case: TestCase, mock_k8s_backend) -> None:
         assert spark_connect.spec.executor.memory == "8g"
 
     elif test_case.name == "spark connect cr with app name":
-        assert spark_connect.spec.spark_conf["spark.jars"].endswith(
-            f"spark-connect_{constants.SPARK_CONNECT_PACKAGE_SCALA_VERSION}-"
-            f"{constants.DEFAULT_SPARK_VERSION}.jar"
-        )
         assert spark_connect.spec.spark_conf["spark.app.name"] == "my-spark-app"
 
     elif test_case.name == "executor config overrides num executors":


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
When users have a pre-compiled Docker image with a Spark connection and all dependencies (e.g., in a private registry or air-gapped environment), the Kubeflow SDK currently forces the injection of the `spark-connect` jar from an external Maven repository (`repo1.maven.org`). This causes unnecessary downloads or failures if outbound internet access is blocked.

This PR introduces a custom property in `spark_conf`, `"spark.kubeflow.skipExternalConnectJar"`. When set to `"true"`, it bypasses the injection of the external Maven URL into `spark.jars`, allowing the runtime to rely purely on the JARs already baked into the image.

**Changes:**
- Updated `build_spark_connect_cr` in `kubeflow/spark/backends/kubernetes/utils.py` to check for `spark.kubeflow.skipExternalConnectJar`.
- If true, avoids appending the maven URL to `base_conf["spark.jars"]`.
- The custom property is filtered out before passing the final configurations to the `SparkConnect` CR to avoid polluting the Spark runtime configuration.
- Added a unit test in `utils_test.py` to verify the dictionary injection behavior.

**How to test:**
```python
client = SparkClient()
spark = client.connect(
    spark_conf={
        "spark.kubeflow.skipExternalConnectJar": "true"
    }
)
```
Verify that the generated SparkConnect CR no longer contains the `https://repo1.maven.org/...` jar link in the `spark.jars` conf.

Fixes #467

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing