### PR TITLE
fix(trainer): add input validation for podspecpatch and containerpatch fields

### DIFF
--- a/kubeflow/trainer/options/kubernetes.py
+++ b/kubeflow/trainer/options/kubernetes.py
@@ -45,6 +45,9 @@ class ContainerPatch:
         if not self.name or not self.name.strip():
             raise ValueError("Container name must be a non-empty string")
 
+        if self.security_context is not None and not isinstance(self.security_context, dict):
+            raise ValueError("security_context must be a dictionary")
+
         if self.env is not None:
             if not isinstance(self.env, list):
                 raise ValueError("env must be a list of dictionaries")
@@ -116,6 +119,23 @@ class PodSpecPatch:
     affinity: dict | None = None
     tolerations: list[dict] | None = None
     scheduling_gates: list[dict] | None = None
+
+    def __post_init__(self):
+        """Validate pod spec patch configuration."""
+        if self.security_context is not None and not isinstance(self.security_context, dict):
+            raise ValueError("security_context must be a dictionary")
+        if self.node_selector is not None and not isinstance(self.node_selector, dict):
+            raise ValueError("node_selector must be a dictionary")
+        if self.affinity is not None and not isinstance(self.affinity, dict):
+            raise ValueError("affinity must be a dictionary")
+        if self.volumes is not None and not isinstance(self.volumes, list):
+            raise ValueError("volumes must be a list of dictionaries")
+        if self.image_pull_secrets is not None and not isinstance(self.image_pull_secrets, list):
+            raise ValueError("image_pull_secrets must be a list of dictionaries")
+        if self.tolerations is not None and not isinstance(self.tolerations, list):
+            raise ValueError("tolerations must be a list of dictionaries")
+        if self.scheduling_gates is not None and not isinstance(self.scheduling_gates, list):
+            raise ValueError("scheduling_gates must be a list of dictionaries")
 
 
 @dataclass

--- a/kubeflow/trainer/options/kubernetes_test.py
+++ b/kubeflow/trainer/options/kubernetes_test.py
@@ -235,12 +235,59 @@ class TestContainerPatch:
                 {"name": "trainer", "volume_mounts": [{"name": "vol"}]},
                 "Each volume_mounts entry must have a 'mountPath' key",
             ),
+            (
+                {"name": "trainer", "security_context": "invalid_type"},
+                "security_context must be a dictionary",
+            ),
         ],
     )
     def test_container_patch_validation(self, kwargs, expected_error):
         """Test ContainerPatch validates inputs correctly."""
         with pytest.raises(ValueError) as exc_info:
             ContainerPatch(**kwargs)
+        assert expected_error in str(exc_info.value)
+
+
+class TestPodSpecPatch:
+    """Test PodSpecPatch validation."""
+
+    @pytest.mark.parametrize(
+        "kwargs,expected_error",
+        [
+            (
+                {"security_context": "invalid_type"},
+                "security_context must be a dictionary",
+            ),
+            (
+                {"node_selector": "invalid_type"},
+                "node_selector must be a dictionary",
+            ),
+            (
+                {"affinity": "invalid_type"},
+                "affinity must be a dictionary",
+            ),
+            (
+                {"volumes": "invalid_type"},
+                "volumes must be a list of dictionaries",
+            ),
+            (
+                {"image_pull_secrets": "invalid_type"},
+                "image_pull_secrets must be a list of dictionaries",
+            ),
+            (
+                {"tolerations": "invalid_type"},
+                "tolerations must be a list of dictionaries",
+            ),
+            (
+                {"scheduling_gates": "invalid_type"},
+                "scheduling_gates must be a list of dictionaries",
+            ),
+        ],
+    )
+    def test_pod_spec_patch_validation(self, kwargs, expected_error):
+        """Test PodSpecPatch validates field types correctly."""
+        with pytest.raises(ValueError) as exc_info:
+            PodSpecPatch(**kwargs)
         assert expected_error in str(exc_info.value)
 
 
@@ -327,7 +374,7 @@ class TestRuntimePatchApplication:
                                                         "spec": {
                                                             "nodeSelector": {
                                                                 "node-type": "gpu-a100"
-                                                            },
+                                                            }
                                                         },
                                                     },
                                                 },


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds type validation to `ContainerPatch` and `PodSpecPatch` options in `kubeflow.trainer.options.kubernetes`. 

Previously, fields such as `security_context`, `node_selector`, `affinity`, `volumes`, `image_pull_secrets`, `tolerations`, and `scheduling_gates` lacked type checks during dataclass initialization (`__post_init__`), which could result in invalid types silently passing until downstream Kubernetes serialization.

This PR ensures these fields strictly validate input types upfront and raise clear `ValueError` exceptions if invalid types are provided, matching the error-handling behavior of `env` and `volume_mounts`.

**Which issue(s) this PR fixes** *(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)*:
N/A (SDK maintenance & type safety enhancement)

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing