### PR TITLE
fix(trainer): resolve LocalProcessBackend Windows compatibility issues

### DIFF
--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -106,6 +106,7 @@ class LocalProcessBackend(RuntimeBackend):
         # create temp dir
         venv_dir = tempfile.mkdtemp(prefix=trainjob_name)
         logger.debug(f"operating in {venv_dir}")
+        venv_dir = venv_dir.replace("\\", "/")
 
         # get local runtime trainer
         runtime.trainer = local_utils.get_local_runtime_trainer(

--- a/kubeflow/trainer/backends/localprocess/constants.py
+++ b/kubeflow/trainer/backends/localprocess/constants.py
@@ -78,8 +78,9 @@ LOCAL_EXEC_JOB_TEMPLATE = textwrap.dedent(
     set -e
     $OS_PYTHON_BIN -m venv --without-pip $PYENV_LOCATION
     echo "Operating inside $PYENV_LOCATION"
-    source $PYENV_LOCATION/bin/activate
-    $PYENV_LOCATION/bin/python -m ensurepip --upgrade --default-pip
+    if [ -d "$PYENV_LOCATION/Scripts" ]; then VENV_BIN="$PYENV_LOCATION/Scripts"; else VENV_BIN="$PYENV_LOCATION/bin"; fi
+    source $VENV_BIN/activate
+    $VENV_BIN/python.exe -m ensurepip --upgrade --default-pip
     $DEPENDENCIES_SCRIPT
     $ENTRYPOINT
     $CLEANUP_SCRIPT

--- a/kubeflow/trainer/backends/localprocess/job.py
+++ b/kubeflow/trainer/backends/localprocess/job.py
@@ -83,7 +83,7 @@ class LocalJob(threading.Thread):
                 text=True,
                 encoding="utf-8",
                 bufsize=1,
-                env=self.env,
+                env={**os.environ, **self.env},
             )
             # set job status
             self._status = constants.TRAINJOB_RUNNING

--- a/kubeflow/trainer/backends/localprocess/utils.py
+++ b/kubeflow/trainer/backends/localprocess/utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import re
 import shutil
 from string import Template
+import subprocess
 import textwrap
 from typing import Any
 
@@ -137,12 +138,16 @@ def get_local_runtime_trainer(
     )
 
     # set command to run from venv
-    venv_bin_dir = str(Path(venv_dir) / "bin")
+    venv_bin_dir = str(Path(venv_dir) / ("Scripts" if os.name == "nt" else "bin")).replace(
+        "\\", "/"
+    )
     default_cmd = [str(Path(venv_bin_dir) / local_exec_constants.DEFAULT_COMMAND)]
     # Set the Trainer entrypoint.
     if framework == local_exec_constants.TORCH_FRAMEWORK_TYPE:
-        _c = [os.path.join(venv_bin_dir, local_exec_constants.TORCH_COMMAND)]
-        trainer.set_command(tuple(_c))
+        torch_command = str(
+            Path(venv_bin_dir) / f"{local_exec_constants.TORCH_COMMAND}.exe"
+        ).replace("\\", "/")
+        trainer.set_command((torch_command,))
     else:
         trainer.set_command(tuple(default_cmd))
 
@@ -246,6 +251,38 @@ def get_cleanup_venv_script(venv_dir: str, cleanup_venv: bool = True) -> str:
     return t.substitute(**mapping)
 
 
+def _resolve_bash() -> str:
+    """Find a working bash executable, validating it actually runs."""
+    candidates = []
+    which_result = shutil.which("bash")
+    if which_result:
+        candidates.append(which_result)
+
+    candidates.extend(
+        [
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files\Git\usr\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+        ]
+    )
+
+    for candidate in candidates:
+        if not candidate or not os.path.isfile(candidate):
+            continue
+        try:
+            result = subprocess.run([candidate, "--version"], capture_output=True, timeout=5)
+            if result.returncode == 0:
+                return candidate
+        except Exception:
+            continue
+
+    raise RuntimeError(
+        "Could not find a working bash executable. On Windows, install Git "
+        "for Windows (https://git-scm.com/download/win), or ensure WSL is "
+        "properly configured and running."
+    )
+
+
 def get_local_train_job_script(
     train_job_name: str,
     venv_dir: str,
@@ -261,6 +298,10 @@ def get_local_train_job_script(
         python_bin = shutil.which("python3")
     if not python_bin:
         raise ValueError("No python executable found")
+    # Windows paths use backslashes which bash interprets as escape characters.
+
+    python_bin = python_bin.replace("\\", "/")
+    # Bash (including Git Bash on Windows) requires forward slashes;
 
     # workout if dependencies needs to be installed
     if isinstance(runtime.trainer, LocalRuntimeTrainer):
@@ -290,14 +331,17 @@ def get_local_train_job_script(
 
     cleanup_script = get_cleanup_venv_script(cleanup_venv=cleanup_venv, venv_dir=venv_dir)
 
+    venv_bin = f"{venv_dir}/Scripts" if os.name == "nt" else f"{venv_dir}/bin"
+
     mapping = {
         "OS_PYTHON_BIN": python_bin,
         "PYENV_LOCATION": venv_dir,
+        "VENV_BIN": venv_bin,
         "DEPENDENCIES_SCRIPT": dependency_script,
         "ENTRYPOINT": entrypoint,
         "CLEANUP_SCRIPT": cleanup_script,
     }
 
     command = t.safe_substitute(**mapping)
-
-    return "bash", "-c", command
+    bash_path = _resolve_bash()
+    return bash_path, "-c", command


### PR DESCRIPTION
**What this PR does / why we need it**:

Resolves both issues discussed in #757:

1. **Bash resolution** — `LocalProcessBackend` called `subprocess.Popen` with the bare string `"bash"`, which on Windows could resolve to a broken WSL relay launcher instead of a working Git Bash install. Now validates that the resolved bash actually runs before using it.

2. **Environment wiping** — `LocalJob` called `subprocess.Popen(..., env=self.env)` with an explicit `env` dict. On Windows, passing any explicit `env=` replaces the entire parent environment instead of extending it, wiping PATH for the training subprocess regardless of the user's system PATH. Now merges `self.env` into `os.environ`.

While verifying these two fixes end-to-end on Windows, I also had to fix two supporting issues that were blocking the training subprocess from starting at all:

3. **Path normalization** — Windows paths (`venv_dir`, `python_bin`) use backslashes, which bash interprets as escape characters, corrupting paths inside the generated bash script. Now normalized to forward slashes.

4. **Scripts/ vs bin/** — Python's `venv` module creates a `Scripts/` folder on Windows, not `bin/` (the Unix convention the code assumed). The activate script and binary paths now detect this dynamically.

**Verification**:

I tested this locally on Windows with `LocalProcessBackend` + the `torch-distributed` runtime, before and after the fix:

- **Before**: the job crashed immediately with a misleading, unrelated error (`RPC call... handle differs...`) caused by bash resolving to a broken WSL relay.
- **After**: I confirmed the backend successfully resolves a working bash, creates and activates the venv, and installs dependencies (`torch`, `torchvision`) end-to-end via pip — verified across multiple runs with full logs.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #757

**Checklist:**
- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing