### PR TITLE
feat(spark): add get_job_ui_url() to reach a submitted job's Spark UI

### DIFF
--- a/docs/source/spark/lifecycle.rst
+++ b/docs/source/spark/lifecycle.rst
@@ -140,6 +140,22 @@ Lifecycle APIs
    exists — if it has been deleted (for example, due to TTL-based cleanup),
    logs may no longer be available.
 
+**View the job's Spark UI:**
+
+.. code-block:: python
+
+   ui_url, port_forward_process = client.get_job_ui_url(job_name)
+   print(f"Spark UI: {ui_url}")
+   # port_forward_process is None when running in-cluster; outside the
+   # cluster it's the kubectl port-forward process backing ui_url, keep a
+   # reference to it for as long as you need the UI reachable.
+
+.. note::
+   The Spark Operator creates a web UI Service for every job by default, so
+   this works without any extra configuration on ``submit_job()``. It only
+   fails if the operator was deployed with ``--enable-ui-service=false``, or
+   the job has already been cleaned up.
+
 **Delete a job:**
 
 .. code-block:: python
@@ -147,10 +163,10 @@ Lifecycle APIs
    client.delete_job(job_name)
 
 .. note::
-   ``get_job_logs()`` above covers raw pod logs. Structured metrics, job health,
-   event streaming, and Spark UI access are planned as a dedicated
-   **Observability** guide that builds on the job model defined here — watch
-   this page's "See also" once that lands.
+   ``get_job_logs()`` and ``get_job_ui_url()`` above cover raw logs and the
+   Spark UI. Structured metrics and event streaming are planned as a
+   dedicated **Observability** guide that builds on the job model defined
+   here — watch this page's "See also" once that lands.
 
 Common Patterns
 ----------------

--- a/kubeflow/spark/api/spark_client.py
+++ b/kubeflow/spark/api/spark_client.py
@@ -15,6 +15,7 @@
 """SparkClient for Kubeflow SDK."""
 
 from collections.abc import Iterator
+import subprocess
 
 from pyspark.sql import SparkSession
 
@@ -236,6 +237,26 @@ class SparkClient:
         """
 
         return self.backend.get_job(name)
+
+    def get_job_ui_url(
+        self, name: str, local_port: int | None = None
+    ) -> tuple[str, subprocess.Popen | None]:
+        """Build a URL to the submitted job's Spark UI, port forwarding to it if needed.
+
+        Args:
+            name: Name of the Spark job.
+            local_port: Local port for port-forward when running outside the cluster.
+                Defaults to a random port in the 4040-5040 range.
+
+        Returns:
+            (ui_url, port_forward_process or None). Caller may keep the process
+            reference; it exits when the Python process exits.
+
+        Raises:
+            RuntimeError: If the job's UI Service cannot be found, or if
+                port-forward fails.
+        """
+        return self.backend.get_job_ui_url(name=name, local_port=local_port)
 
     def list_jobs(
         self,

--- a/kubeflow/spark/backends/base.py
+++ b/kubeflow/spark/backends/base.py
@@ -182,6 +182,23 @@ class RuntimeBackend(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    def get_job_ui_url(
+        self,
+        name: str,
+        local_port: int | None = None,
+    ) -> tuple[str, object]:
+        """Build a URL to the submitted job's Spark UI, port forwarding to it if needed.
+
+        Args:
+            name: Name of the Spark job.
+            local_port: Local port for port-forward when running outside the cluster.
+
+        Returns:
+            (ui_url, port_forward_process_or_None).
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def list_jobs(
         self,
         status: set[SparkJobStatus] | None = None,

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -1028,6 +1028,78 @@ class KubernetesBackend(RuntimeBackend):
             raise RuntimeError(f"Failed to get Spark job: {self.namespace}/{name}") from e
         return get_spark_application_info_from_cr(spark_application)
 
+    def get_job_ui_url(
+        self, name: str, local_port: int | None = None
+    ) -> tuple[str, subprocess.Popen | None]:
+        """Build a URL to the submitted job's Spark UI, port forwarding to it if needed.
+
+        The Spark Operator creates a web UI Service for every SparkApplication by
+        default (gated by the operator's own --enable-ui-service flag, true unless a
+        cluster admin turned it off), independent of any per-job configuration. This
+        finds that Service via the sparkoperator.k8s.io/app-name label the operator
+        stamps on it rather than guessing its name, which the operator truncates and
+        hashes past 63 characters.
+
+        Args:
+            name: Name of the Spark job.
+            local_port: Local port for port-forward when running outside the cluster.
+                Defaults to a random port in the 4040-5040 range.
+
+        Returns:
+            (ui_url, port_forward_process or None). Caller may keep the process
+            reference; it exits when the Python process exits.
+
+        Raises:
+            RuntimeError: If the job's UI Service cannot be found (the operator may
+                have --enable-ui-service disabled, or the job may have been cleaned
+                up already), or if port-forward fails.
+        """
+        try:
+            services = self.core_api.list_namespaced_service(
+                namespace=self.namespace,
+                label_selector=f"{constants.SPARK_UI_SERVICE_APP_NAME_LABEL}={name}",
+            )
+        except client.ApiException as e:
+            raise RuntimeError(
+                f"Failed to look up Spark UI service for {self.namespace}/{name}: {e}"
+            ) from e
+
+        if not services.items:
+            raise RuntimeError(
+                f"No Spark UI service found for {self.namespace}/{name}. The Spark "
+                "Operator may have been deployed with --enable-ui-service=false, or "
+                "the job may already have been cleaned up."
+            )
+        service = services.items[0]
+        service_name = service.metadata.name
+        remote_port = service.spec.ports[0].port
+
+        if os.environ.get("KUBERNETES_SERVICE_HOST"):
+            url = f"http://{service_name}.{self.namespace}.svc:{remote_port}"
+            logger.info("In-cluster Spark UI URL: %s", url)
+            return (url, None)
+
+        port = local_port if local_port is not None else random.randint(4040, 5040)
+        cmd = [
+            "kubectl",
+            "port-forward",
+            f"svc/{service_name}",
+            f"{port}:{remote_port}",
+            "-n",
+            self.namespace,
+        ]
+        url = f"http://127.0.0.1:{port}"
+        logger.info("Port-forward command: %s (ui_url=%s)", " ".join(cmd), url)
+        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        time.sleep(3.0)  # Allow port-forward to fully establish
+        if proc.poll() is not None:
+            stderr = (proc.stderr and proc.stderr.read()) or b""
+            err_msg = stderr.decode("utf-8", errors="replace").strip() if stderr else ""
+            raise RuntimeError(
+                f"Port-forward to svc/{service_name} failed (exit {proc.returncode}): {err_msg}"
+            )
+        return (url, proc)
+
     def list_jobs(
         self,
         status: set[SparkJobStatus] | None = None,

--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -1033,12 +1033,11 @@ class KubernetesBackend(RuntimeBackend):
     ) -> tuple[str, subprocess.Popen | None]:
         """Build a URL to the submitted job's Spark UI, port forwarding to it if needed.
 
-        The Spark Operator creates a web UI Service for every SparkApplication by
-        default (gated by the operator's own --enable-ui-service flag, true unless a
-        cluster admin turned it off), independent of any per-job configuration. This
-        finds that Service via the sparkoperator.k8s.io/app-name label the operator
-        stamps on it rather than guessing its name, which the operator truncates and
-        hashes past 63 characters.
+        The Spark Operator records the web UI Service it created for a job on the
+        SparkApplication itself, under status.driverInfo, and reads that field back
+        when it manages the UI. Take the name and port from there rather than
+        searching for the Service, so a job whose UI Service carries custom labels
+        still resolves, and there is never a choice between several matches.
 
         Args:
             name: Name of the Spark job.
@@ -1050,29 +1049,38 @@ class KubernetesBackend(RuntimeBackend):
             reference; it exits when the Python process exits.
 
         Raises:
-            RuntimeError: If the job's UI Service cannot be found (the operator may
-                have --enable-ui-service disabled, or the job may have been cleaned
-                up already), or if port-forward fails.
+            TimeoutError: If getting the SparkApplication times out.
+            RuntimeError: If the job reports no UI Service (the driver may not be
+                running yet, or the operator may have --enable-ui-service disabled),
+                or if the port-forward never becomes reachable.
         """
         try:
-            services = self.core_api.list_namespaced_service(
+            thread = self.custom_api.get_namespaced_custom_object(
+                group=constants.SPARK_APPLICATION_GROUP,
+                version=constants.SPARK_APPLICATION_VERSION,
                 namespace=self.namespace,
-                label_selector=f"{constants.SPARK_UI_SERVICE_APP_NAME_LABEL}={name}",
+                plural=constants.SPARK_APPLICATION_PLURAL,
+                name=name,
+                async_req=True,
             )
+            response = thread.get(common_constants.DEFAULT_TIMEOUT)
+            spark_application = models.SparkV1beta2SparkApplication.from_dict(response)
+        except multiprocessing.TimeoutError as e:
+            raise TimeoutError(f"Timeout to get Spark job: {self.namespace}/{name}") from e
         except client.ApiException as e:
-            raise RuntimeError(
-                f"Failed to look up Spark UI service for {self.namespace}/{name}: {e}"
-            ) from e
+            if e.status == 404:
+                raise RuntimeError(f"Spark job not found: {self.namespace}/{name}") from e
+            raise RuntimeError(f"Failed to get Spark job: {self.namespace}/{name}: {e}") from e
 
-        if not services.items:
+        driver_info = spark_application.status.driver_info if spark_application.status else None
+        service_name = driver_info.web_ui_service_name if driver_info else None
+        remote_port = driver_info.web_ui_port if driver_info else None
+        if not service_name or not remote_port:
             raise RuntimeError(
-                f"No Spark UI service found for {self.namespace}/{name}. The Spark "
-                "Operator may have been deployed with --enable-ui-service=false, or "
-                "the job may already have been cleaned up."
+                f"No Spark UI service reported for {self.namespace}/{name}. The driver "
+                "may not be running yet, or the Spark Operator may have been deployed "
+                "with --enable-ui-service=false."
             )
-        service = services.items[0]
-        service_name = service.metadata.name
-        remote_port = service.spec.ports[0].port
 
         if os.environ.get("KUBERNETES_SERVICE_HOST"):
             url = f"http://{service_name}.{self.namespace}.svc:{remote_port}"
@@ -1091,14 +1099,21 @@ class KubernetesBackend(RuntimeBackend):
         url = f"http://127.0.0.1:{port}"
         logger.info("Port-forward command: %s (ui_url=%s)", " ".join(cmd), url)
         proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
-        time.sleep(3.0)  # Allow port-forward to fully establish
-        if proc.poll() is not None:
-            stderr = (proc.stderr and proc.stderr.read()) or b""
-            err_msg = stderr.decode("utf-8", errors="replace").strip() if stderr else ""
-            raise RuntimeError(
-                f"Port-forward to svc/{service_name} failed (exit {proc.returncode}): {err_msg}"
-            )
-        return (url, proc)
+        # A live process only means kubectl started, not that the UI answers, so
+        # wait for the port itself the same way get_connect_url() does. The wait can
+        # outlast the process, so confirm it is still up before handing it back.
+        if self._wait_for_connect_port("127.0.0.1", port, timeout_sec=90) and proc.poll() is None:
+            return (url, proc)
+
+        if proc.poll() is None:
+            proc.terminate()
+            proc.wait(timeout=5)
+        stderr = (proc.stderr and proc.stderr.read()) or b""
+        err_msg = stderr.decode("utf-8", errors="replace").strip() if stderr else ""
+        raise RuntimeError(
+            f"Port-forward to svc/{service_name} never became reachable on port {port} "
+            f"(exit {proc.returncode}): {err_msg}"
+        )
 
     def list_jobs(
         self,

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -759,6 +759,80 @@ def test_get_connect_url(kubernetes_backend, test_case):
     print("test execution complete")
 
 
+def _mock_ui_service(name="test-job-abc12345-ui-svc", port=4040):
+    service = Mock()
+    service.metadata.name = name
+    service.spec.ports = [Mock(port=port)]
+    return service
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        TestCase(
+            name="in-cluster returns svc DNS URL and no process",
+            expected_status=SUCCESS,
+            config={"in_cluster": True},
+            expected_output={"url_contains": "svc:4040", "proc_is_none": True},
+        ),
+        TestCase(
+            name="out-of-cluster starts port-forward and returns localhost URL",
+            expected_status=SUCCESS,
+            config={"in_cluster": False, "local_port": 4040},
+            expected_output={"url": "http://127.0.0.1:4040", "proc_is_none": False},
+        ),
+        TestCase(
+            name="no UI service found raises",
+            expected_status=FAILED,
+            config={"in_cluster": False, "no_service": True},
+            expected_error=RuntimeError,
+            expected_output="No Spark UI service found",
+        ),
+    ],
+)
+def test_get_job_ui_url(kubernetes_backend, test_case):
+    """Test get_job_ui_url for in-cluster, port-forward, and not-found scenarios."""
+    print("Executing test:", test_case.name)
+    service_list = Mock()
+    service_list.items = [] if test_case.config.get("no_service") else [_mock_ui_service()]
+    kubernetes_backend.core_api.list_namespaced_service = Mock(return_value=service_list)
+
+    if test_case.config["in_cluster"]:
+        with patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": "10.96.0.1"}, clear=False):
+            url, proc = kubernetes_backend.get_job_ui_url("test-job")
+    else:
+        mock_popen = Mock()
+        mock_popen.poll.return_value = None
+        with (
+            patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": ""}, clear=False),
+            patch(
+                "kubeflow.spark.backends.kubernetes.backend.subprocess.Popen",
+                return_value=mock_popen,
+            ),
+            patch("kubeflow.spark.backends.kubernetes.backend.time.sleep"),
+        ):
+            if test_case.expected_status == FAILED:
+                with pytest.raises(test_case.expected_error, match=test_case.expected_output):
+                    kubernetes_backend.get_job_ui_url("test-job")
+                print("test execution complete")
+                return
+            url, proc = kubernetes_backend.get_job_ui_url(
+                "test-job", local_port=test_case.config["local_port"]
+            )
+
+    if "url_contains" in test_case.expected_output:
+        assert test_case.expected_output["url_contains"] in url
+    else:
+        assert url == test_case.expected_output["url"]
+
+    if test_case.expected_output["proc_is_none"]:
+        assert proc is None
+    else:
+        assert proc is mock_popen
+
+    print("test execution complete")
+
+
 @pytest.mark.parametrize(
     "test_case",
     [

--- a/kubeflow/spark/backends/kubernetes/backend_test.py
+++ b/kubeflow/spark/backends/kubernetes/backend_test.py
@@ -759,11 +759,31 @@ def test_get_connect_url(kubernetes_backend, test_case):
     print("test execution complete")
 
 
-def _mock_ui_service(name="test-job-abc12345-ui-svc", port=4040):
-    service = Mock()
-    service.metadata.name = name
-    service.spec.ports = [Mock(port=port)]
-    return service
+def _mock_ui_cr(name="test-job-abc12345-ui-svc", port=4040, with_ui=True):
+    """A SparkApplication CR carrying (or missing) the operator's driverInfo UI fields."""
+    driver_info = {"podName": "test-job-driver"}
+    if with_ui:
+        driver_info["webUIServiceName"] = name
+        driver_info["webUIPort"] = port
+    return {
+        "apiVersion": "sparkoperator.k8s.io/v1beta2",
+        "kind": "SparkApplication",
+        "metadata": {"name": "test-job", "namespace": "default"},
+        "spec": {
+            "type": "Python",
+            "sparkVersion": "3.5.3",
+            "mainApplicationFile": "local:///opt/spark/examples/src/main/python/pi.py",
+            "driver": {},
+            "executor": {},
+        },
+        "status": {"driverInfo": driver_info},
+    }
+
+
+def _patch_ui_cr(backend, cr):
+    thread = Mock()
+    thread.get = Mock(return_value=cr)
+    backend.custom_api.get_namespaced_custom_object = Mock(return_value=thread)
 
 
 @pytest.mark.parametrize(
@@ -782,20 +802,28 @@ def _mock_ui_service(name="test-job-abc12345-ui-svc", port=4040):
             expected_output={"url": "http://127.0.0.1:4040", "proc_is_none": False},
         ),
         TestCase(
-            name="no UI service found raises",
+            name="driver reports no UI service raises",
             expected_status=FAILED,
             config={"in_cluster": False, "no_service": True},
             expected_error=RuntimeError,
-            expected_output="No Spark UI service found",
+            expected_output="No Spark UI service reported",
+        ),
+        TestCase(
+            name="port never becomes reachable raises and kills the port-forward",
+            expected_status=FAILED,
+            config={"in_cluster": False, "local_port": 4040, "port_ready": False},
+            expected_error=RuntimeError,
+            expected_output="never became reachable",
         ),
     ],
 )
 def test_get_job_ui_url(kubernetes_backend, test_case):
-    """Test get_job_ui_url for in-cluster, port-forward, and not-found scenarios."""
+    """Test get_job_ui_url for in-cluster, port-forward, missing-UI and unreachable cases."""
     print("Executing test:", test_case.name)
-    service_list = Mock()
-    service_list.items = [] if test_case.config.get("no_service") else [_mock_ui_service()]
-    kubernetes_backend.core_api.list_namespaced_service = Mock(return_value=service_list)
+    _patch_ui_cr(
+        kubernetes_backend,
+        _mock_ui_cr(with_ui=not test_case.config.get("no_service")),
+    )
 
     if test_case.config["in_cluster"]:
         with patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": "10.96.0.1"}, clear=False):
@@ -803,17 +831,22 @@ def test_get_job_ui_url(kubernetes_backend, test_case):
     else:
         mock_popen = Mock()
         mock_popen.poll.return_value = None
+        mock_popen.stderr.read.return_value = b""
+        port_ready = test_case.config.get("port_ready", True)
         with (
             patch.dict("os.environ", {"KUBERNETES_SERVICE_HOST": ""}, clear=False),
             patch(
                 "kubeflow.spark.backends.kubernetes.backend.subprocess.Popen",
                 return_value=mock_popen,
             ),
-            patch("kubeflow.spark.backends.kubernetes.backend.time.sleep"),
+            patch.object(kubernetes_backend, "_wait_for_connect_port", return_value=port_ready),
         ):
             if test_case.expected_status == FAILED:
                 with pytest.raises(test_case.expected_error, match=test_case.expected_output):
                     kubernetes_backend.get_job_ui_url("test-job")
+                if test_case.config.get("port_ready") is False:
+                    # an unreachable port must not leave the port-forward running
+                    mock_popen.terminate.assert_called_once()
                 print("test execution complete")
                 return
             url, proc = kubernetes_backend.get_job_ui_url(

--- a/kubeflow/spark/backends/kubernetes/constants.py
+++ b/kubeflow/spark/backends/kubernetes/constants.py
@@ -40,12 +40,6 @@ SPARK_APPLICATION_VERSION = "v1beta2"
 SPARK_APPLICATION_PLURAL = "sparkapplications"
 SPARK_APPLICATION_KIND = "SparkApplication"
 
-# Label the Spark Operator stamps on the driver's web UI Service it creates
-# for every SparkApplication by default (see pkg/util.GetResourceLabels in
-# kubeflow/spark-operator). Used to find that Service without guessing its
-# name, which the operator truncates and hashes past 63 characters.
-SPARK_UI_SERVICE_APP_NAME_LABEL = "sparkoperator.k8s.io/app-name"
-
 # Default values; keep major.minor aligned with pyspark-connect in pyproject.toml
 DEFAULT_SPARK_VERSION = "4.0.4"
 DEFAULT_SPARK_IMAGE = "apache/spark:4.0.4"

--- a/kubeflow/spark/backends/kubernetes/constants.py
+++ b/kubeflow/spark/backends/kubernetes/constants.py
@@ -40,6 +40,12 @@ SPARK_APPLICATION_VERSION = "v1beta2"
 SPARK_APPLICATION_PLURAL = "sparkapplications"
 SPARK_APPLICATION_KIND = "SparkApplication"
 
+# Label the Spark Operator stamps on the driver's web UI Service it creates
+# for every SparkApplication by default (see pkg/util.GetResourceLabels in
+# kubeflow/spark-operator). Used to find that Service without guessing its
+# name, which the operator truncates and hashes past 63 characters.
+SPARK_UI_SERVICE_APP_NAME_LABEL = "sparkoperator.k8s.io/app-name"
+
 # Default values; keep major.minor aligned with pyspark-connect in pyproject.toml
 DEFAULT_SPARK_VERSION = "4.0.4"
 DEFAULT_SPARK_IMAGE = "apache/spark:4.0.4"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #733, full description and root cause are there. tldr the Spark
Operator already creates a UI service for every job by default,
SparkClient just had no way to find or reach it. get_job_ui_url() looks
it up via the sparkoperator.k8s.io/app-name label (verified against the
actual operator source, not guessed) and port forwards to it, same
pattern as the existing get_connect_url().

**Which issue(s) this PR fixes**:

Fixes #733

**Checklist:**

- [x] Docs included if any changes are user facing
