### PR TITLE
fix(trainer): support S3 and DataCache initializers in TorchTune dataset args

### DIFF
--- a/kubeflow/trainer/backends/kubernetes/utils.py
+++ b/kubeflow/trainer/backends/kubernetes/utils.py
@@ -492,6 +492,8 @@ def get_args_using_torchtune_config(
 ) -> list[str]:
     """
     Get the Trainer args from the TorchTuneConfig.
+    This function generates arguments for TorchTune. It supports HuggingFace,
+    S3 and DataCache initializers to properly set the dataset arguments.
     """
     args = []
 
@@ -531,6 +533,16 @@ def get_args_using_torchtune_config(
             args.append(f"dataset.data_files={os.path.join(constants.DATASET_PATH, relative_path)}")
         else:
             args.append(f"dataset.data_dir={os.path.join(constants.DATASET_PATH, relative_path)}")
+
+    if isinstance(initializer, types.Initializer) and isinstance(
+            initializer.dataset, types.S3DatasetInitializer
+    ):
+        args.append(f"dataset.data_dir={initializer.dataset.storage_uri}")
+
+    if isinstance(initializer, types.Initializer) and isinstance(
+        initializer.dataset, types.DataCacheInitializer
+    ):
+        args.append(f"dataset.data_dir={initializer.dataset.storage_uri}")
 
     if fine_tuning_config.peft_config:
         args += get_args_from_peft_config(fine_tuning_config.peft_config)


### PR DESCRIPTION
Hi! As discussed in issue #741, I opened this PR to fix the missing dataset arguments for S3DatasetInitializer and DataCacheInitializer inside get_args_using_torchtune_config. The function now should properly emits the dataset.data_dir arg instead skipping it. Thanks for the guidance!
