### PR TITLE
fix(trainer): preserve local job status in list_jobs

### DIFF
--- a/kubeflow/trainer/backends/localprocess/backend.py
+++ b/kubeflow/trainer/backends/localprocess/backend.py
@@ -152,6 +152,7 @@ class LocalProcessBackend(RuntimeBackend):
         for _job in self.__local_jobs:
             if runtime and _job.runtime.name != runtime.name:
                 continue
+            status = self.__get_job_status(_job)
             result.append(
                 types.TrainJob(
                     name=_job.name,
@@ -162,6 +163,7 @@ class LocalProcessBackend(RuntimeBackend):
                         types.Step(name=s.step_name, pod_name=s.step_name, status=s.job.status)
                         for s in _job.steps
                     ],
+                    status=status,
                 )
             )
         return result

--- a/kubeflow/trainer/backends/localprocess/backend_test.py
+++ b/kubeflow/trainer/backends/localprocess/backend_test.py
@@ -22,7 +22,10 @@ import pytest
 
 from kubeflow.trainer.backends.localprocess.backend import LocalProcessBackend
 from kubeflow.trainer.backends.localprocess.constants import LOCAL_RUNTIME_IMAGE
+from kubeflow.trainer.backends.localprocess.job import LocalJob
 from kubeflow.trainer.backends.localprocess.types import (
+    LocalBackendJobs,
+    LocalBackendStep,
     LocalProcessBackendConfig,
     LocalRuntimeTrainer,
 )
@@ -409,6 +412,24 @@ def test_list_jobs(local_backend, test_case):
     runtime = test_case.config.get("runtime")
     jobs = local_backend.list_jobs(runtime=runtime)
     assert isinstance(jobs, list)
+
+
+def test_list_jobs_returns_overall_status(local_backend):
+    """Test that list_jobs returns the overall status for each job."""
+    runtime = local_backend.get_runtime(TORCH_RUNTIME)
+    job = LocalJob(name="test-job", command=[])
+    job._status = constants.TRAINJOB_COMPLETE
+    local_backend._LocalProcessBackend__local_jobs.append(
+        LocalBackendJobs(
+            name="test-job",
+            runtime=runtime,
+            steps=[LocalBackendStep(step_name="train", job=job)],
+        )
+    )
+
+    listed_job = local_backend.list_jobs()[0]
+
+    assert listed_job.status == constants.TRAINJOB_COMPLETE
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**What this PR does / why we need it**:

`LocalProcessBackend.list_jobs()` currently omits the overall status when constructing each `TrainJob`. As a result, listed jobs report the default `Unknown` status even when they are complete, failed, running, or created.

This change calculates each job status using the same logic as `get_job()` and includes it in the returned `TrainJob`. It also adds a regression test confirming that a completed local job is listed with the `Complete` status.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #703

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) are not needed because this corrects existing behavior without changing the public interface
