### PR TITLE
feat(spark)!: delegate SparkApplication driver service account to the Spark Operator

### DIFF
--- a/docs/source/spark/index.rst
+++ b/docs/source/spark/index.rst
@@ -52,11 +52,28 @@ using ``num_executors`` and ``resources_per_executor``.
 
 .. note::
 
-   Batch job submission relies on the Spark Operator's fallback ServiceAccount
-   (``spark-operator-spark`` with the standard Helm install) having the
-   required SparkApplication RBAC permissions in the target namespace.
-   ``SparkClient`` does not set a ServiceAccount on the driver spec, so this
-   operator-configured fallback is always used for batch jobs.
+   ``SparkClient`` does not set a ServiceAccount on the driver spec. Both
+   interactive sessions and batch jobs need the driver to run as a
+   ServiceAccount with permission to create executor pods in the target
+   namespace. That ServiceAccount is provisioned and selected by the platform,
+   not by the SDK.
+
+   On a Kubeflow Platform install, the Profile controller creates a
+   ``default-editor`` ServiceAccount in every profile namespace and binds it to
+   the ``kubeflow-edit`` ClusterRole, which covers pods and services
+   in-namespace. Set ``controller.defaultServiceAccount=default-editor`` in the
+   Spark Operator Helm chart so the operator falls back to it. On a standalone
+   Spark Operator install, set it to a ServiceAccount that exists in every
+   namespace where you submit jobs — for example the ``<release>-spark``
+   account the chart creates in the namespaces listed under
+   ``spark.jobNamespaces``.
+
+   When ``controller.defaultServiceAccount`` is unset, the driver runs as the
+   namespace's ``default`` ServiceAccount and the job fails with a
+   ``403 Forbidden`` error when the driver tries to create executor pods.
+
+   Interactive sessions can override the ServiceAccount per session with
+   ``Driver(service_account=...)``; batch jobs have no per-job override.
 
 Two Ways to Run Spark
 -----------------------

--- a/docs/source/spark/index.rst
+++ b/docs/source/spark/index.rst
@@ -52,13 +52,11 @@ using ``num_executors`` and ``resources_per_executor``.
 
 .. note::
 
-   Batch job submission requires the ``spark-operator-spark`` ServiceAccount to
-   exist in the target namespace, with the required SparkApplication RBAC
-   permissions bound to it. Otherwise, ``submit_job()`` requests will fail.
-
-   This is a current Spark Operator requirement and is expected to be simplified
-   once `kubeflow/spark-operator#3049 <https://github.com/kubeflow/spark-operator/issues/3049>`_
-   is resolved.
+   Batch job submission relies on the Spark Operator's fallback ServiceAccount
+   (``spark-operator-spark`` with the standard Helm install) having the
+   required SparkApplication RBAC permissions in the target namespace.
+   ``SparkClient`` does not set a ServiceAccount on the driver spec, so this
+   operator-configured fallback is always used for batch jobs.
 
 Two Ways to Run Spark
 -----------------------

--- a/examples/spark/README.md
+++ b/examples/spark/README.md
@@ -35,7 +35,7 @@ Install spark dependencies:
 uv pip install kubeflow[spark]
 ```
 
-The Spark examples run against a Kubernetes cluster with the Spark Operator installed. Batch job submission relies on the Spark Operator's fallback ServiceAccount (`spark-operator-spark` by default with the standard Helm install) having the required SparkApplication RBAC permissions in the target namespace; the SDK does not set a ServiceAccount on the driver spec, so this operator-configured fallback is always used. See the [Spark SDK docs](https://sdk.kubeflow.org/en/latest/spark/index.html) for prerequisites.
+The Spark examples run against a Kubernetes cluster with the Spark Operator installed. The SDK does not set a ServiceAccount on the driver spec, so the Spark Operator must be configured with a fallback ServiceAccount that can create executor pods in the target namespace (`controller.defaultServiceAccount` in the Helm chart). See the [Spark SDK docs](https://sdk.kubeflow.org/en/latest/spark/index.html) for prerequisites.
 
 ## Running Examples
 

--- a/examples/spark/README.md
+++ b/examples/spark/README.md
@@ -35,7 +35,7 @@ Install spark dependencies:
 uv pip install kubeflow[spark]
 ```
 
-The Spark examples run against a Kubernetes cluster with the Spark Operator installed. Batch job submission requires a `spark-operator-spark` ServiceAccount in the target namespace with the required SparkApplication RBAC permissions. See the [Spark SDK docs](https://sdk.kubeflow.org/en/latest/spark/index.html) for prerequisites.
+The Spark examples run against a Kubernetes cluster with the Spark Operator installed. Batch job submission relies on the Spark Operator's fallback ServiceAccount (`spark-operator-spark` by default with the standard Helm install) having the required SparkApplication RBAC permissions in the target namespace; the SDK does not set a ServiceAccount on the driver spec, so this operator-configured fallback is always used. See the [Spark SDK docs](https://sdk.kubeflow.org/en/latest/spark/index.html) for prerequisites.
 
 ## Running Examples
 

--- a/kubeflow/spark/backends/kubernetes/constants.py
+++ b/kubeflow/spark/backends/kubernetes/constants.py
@@ -51,7 +51,6 @@ DEFAULT_DRIVER_CPU = 1
 DEFAULT_DRIVER_MEMORY = "512Mi"
 DEFAULT_EXECUTOR_CPU = 1
 DEFAULT_EXECUTOR_MEMORY = "512Mi"
-DEFAULT_SERVICE_ACCOUNT = "spark-operator-spark"
 
 # Function-based Spark job script
 FUNC_JOB_VOLUME_NAME = "spark-app-source"

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -670,8 +670,9 @@ def get_spark_job_driver_spec(
 ) -> models.SparkV1beta2DriverSpec:
     """Build DriverSpec for SparkApplication.
 
-    The service account is intentionally left unset so that the Spark
-    Operator's configured fallback service account is used.
+    If no service account is specified on the driver, it is intentionally
+    left unset so that the Spark Operator's configured fallback service
+    account is used.
 
     Returns:
         SparkApplication DriverSpec model.
@@ -681,10 +682,12 @@ def get_spark_job_driver_spec(
             If the default driver resource configuration is invalid.
     """
     cores, memory = _resolve_driver_resources(driver)
+    service_account = driver.service_account if driver else None
 
     return models.SparkV1beta2DriverSpec(
         cores=cores,
         memory=memory,
+        service_account=service_account,
     )
 
 

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -670,6 +670,10 @@ def get_spark_job_driver_spec(
 ) -> models.SparkV1beta2DriverSpec:
     """Build DriverSpec for SparkApplication.
 
+    The service account is intentionally left unset so that the Spark
+    Operator's fallback service account (configured cluster-wide by the
+    operator installation) is used unless overridden via `driver`.
+
     Returns:
         SparkApplication DriverSpec model.
 
@@ -682,7 +686,7 @@ def get_spark_job_driver_spec(
     return models.SparkV1beta2DriverSpec(
         cores=cores,
         memory=memory,
-        service_account=constants.DEFAULT_SERVICE_ACCOUNT,
+        service_account=driver.service_account if driver else None,
     )
 
 

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -670,9 +670,8 @@ def get_spark_job_driver_spec(
 ) -> models.SparkV1beta2DriverSpec:
     """Build DriverSpec for SparkApplication.
 
-    If no service account is specified on the driver, it is intentionally
-    left unset so that the Spark Operator's configured fallback service
-    account is used.
+    The service account is intentionally left unset so that the Spark
+    Operator's configured fallback service account is used.
 
     Returns:
         SparkApplication DriverSpec model.
@@ -682,12 +681,10 @@ def get_spark_job_driver_spec(
             If the default driver resource configuration is invalid.
     """
     cores, memory = _resolve_driver_resources(driver)
-    service_account = driver.service_account if driver else None
 
     return models.SparkV1beta2DriverSpec(
         cores=cores,
         memory=memory,
-        service_account=service_account,
     )
 
 

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -685,7 +685,6 @@ def get_spark_job_driver_spec(
     return models.SparkV1beta2DriverSpec(
         cores=cores,
         memory=memory,
-        service_account=driver.service_account if driver else None,
     )
 
 

--- a/kubeflow/spark/backends/kubernetes/utils.py
+++ b/kubeflow/spark/backends/kubernetes/utils.py
@@ -671,8 +671,7 @@ def get_spark_job_driver_spec(
     """Build DriverSpec for SparkApplication.
 
     The service account is intentionally left unset so that the Spark
-    Operator's fallback service account (configured cluster-wide by the
-    operator installation) is used unless overridden via `driver`.
+    Operator's configured fallback service account is used.
 
     Returns:
         SparkApplication DriverSpec model.

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -1247,12 +1247,7 @@ def test_read_pod_logs(test_case: TestCase) -> None:
         TestCase(
             name="default spark job driver spec leaves service account unset",
             expected_status=SUCCESS,
-            config={"driver": None},
-        ),
-        TestCase(
-            name="spark job driver spec honors service account override",
-            expected_status=SUCCESS,
-            config={"driver": Driver(service_account="custom-sa")},
+            config={},
         ),
     ],
 )

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -1270,7 +1270,7 @@ def test_get_spark_job_driver_spec(test_case: TestCase) -> None:
     assert spec.memory == _memory_kubernetes_to_spark(
         constants.DEFAULT_DRIVER_MEMORY,
     )
-    assert spec.service_account == (driver.service_account if driver else None)
+    assert spec.service_account is None
 
     print("test execution complete")
 

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -1247,7 +1247,12 @@ def test_read_pod_logs(test_case: TestCase) -> None:
         TestCase(
             name="default spark job driver spec leaves service account unset",
             expected_status=SUCCESS,
-            config={},
+            config={"driver": None},
+        ),
+        TestCase(
+            name="spark job driver spec passes through configured service account",
+            expected_status=SUCCESS,
+            config={"driver": Driver(service_account="something")},
         ),
     ],
 )
@@ -1256,7 +1261,8 @@ def test_get_spark_job_driver_spec(test_case: TestCase) -> None:
 
     print("Executing test:", test_case.name)
 
-    spec = get_spark_job_driver_spec()
+    driver = test_case.config["driver"]
+    spec = get_spark_job_driver_spec(driver)
 
     assert test_case.expected_status == SUCCESS
 
@@ -1264,7 +1270,7 @@ def test_get_spark_job_driver_spec(test_case: TestCase) -> None:
     assert spec.memory == _memory_kubernetes_to_spark(
         constants.DEFAULT_DRIVER_MEMORY,
     )
-    assert spec.service_account is None
+    assert spec.service_account == (driver.service_account if driver else None)
 
     print("test execution complete")
 

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -1245,9 +1245,14 @@ def test_read_pod_logs(test_case: TestCase) -> None:
     "test_case",
     [
         TestCase(
-            name="default spark job driver spec",
+            name="default spark job driver spec leaves service account unset",
             expected_status=SUCCESS,
-            config={},
+            config={"driver": None},
+        ),
+        TestCase(
+            name="spark job driver spec honors service account override",
+            expected_status=SUCCESS,
+            config={"driver": Driver(service_account="custom-sa")},
         ),
     ],
 )
@@ -1256,7 +1261,8 @@ def test_get_spark_job_driver_spec(test_case: TestCase) -> None:
 
     print("Executing test:", test_case.name)
 
-    spec = get_spark_job_driver_spec()
+    driver = test_case.config["driver"]
+    spec = get_spark_job_driver_spec(driver=driver)
 
     assert test_case.expected_status == SUCCESS
 
@@ -1264,7 +1270,7 @@ def test_get_spark_job_driver_spec(test_case: TestCase) -> None:
     assert spec.memory == _memory_kubernetes_to_spark(
         constants.DEFAULT_DRIVER_MEMORY,
     )
-    assert spec.service_account == constants.DEFAULT_SERVICE_ACCOUNT
+    assert spec.service_account == (driver.service_account if driver else None)
 
     print("test execution complete")
 

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -1247,12 +1247,7 @@ def test_read_pod_logs(test_case: TestCase) -> None:
         TestCase(
             name="default spark job driver spec leaves service account unset",
             expected_status=SUCCESS,
-            config={"driver": None},
-        ),
-        TestCase(
-            name="spark job driver spec passes through configured service account",
-            expected_status=SUCCESS,
-            config={"driver": Driver(service_account="something")},
+            config={},
         ),
     ],
 )
@@ -1261,8 +1256,7 @@ def test_get_spark_job_driver_spec(test_case: TestCase) -> None:
 
     print("Executing test:", test_case.name)
 
-    driver = test_case.config["driver"]
-    spec = get_spark_job_driver_spec(driver)
+    spec = get_spark_job_driver_spec()
 
     assert test_case.expected_status == SUCCESS
 
@@ -1270,7 +1264,7 @@ def test_get_spark_job_driver_spec(test_case: TestCase) -> None:
     assert spec.memory == _memory_kubernetes_to_spark(
         constants.DEFAULT_DRIVER_MEMORY,
     )
-    assert spec.service_account == (driver.service_account if driver else None)
+    assert spec.service_account is None
 
     print("test execution complete")
 

--- a/kubeflow/spark/backends/kubernetes/utils_test.py
+++ b/kubeflow/spark/backends/kubernetes/utils_test.py
@@ -1261,8 +1261,7 @@ def test_get_spark_job_driver_spec(test_case: TestCase) -> None:
 
     print("Executing test:", test_case.name)
 
-    driver = test_case.config["driver"]
-    spec = get_spark_job_driver_spec(driver=driver)
+    spec = get_spark_job_driver_spec()
 
     assert test_case.expected_status == SUCCESS
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the hardcoded `spark-operator-spark` default service account for the `SparkApplication` driver spec. The Spark Operator now supports a fallback service account mechanism for the driver ([kubeflow/spark-operator#3092](https://github.com/kubeflow/spark-operator/pull/3092), merged), so the SDK no longer needs to set this default itself. `get_spark_job_driver_spec` now leaves `service_account` unset unless a caller explicitly provides one via `Driver.service_account`, keeping the SDK decoupled from operator cluster-admin concerns.

**Which issue(s) this PR fixes**:

Fixes #616

**Checklist:**

- [x] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing