### PR TITLE
fix(spark):  Extracting spark_version from driver image

### DIFF
--- a/kubeflow/spark/backends/kubernetes/backend.py
+++ b/kubeflow/spark/backends/kubernetes/backend.py
@@ -22,6 +22,7 @@ import math
 import multiprocessing
 import os
 import random
+import re
 import socket
 import subprocess
 import sys
@@ -86,6 +87,19 @@ def _enable_spark_debug_logging() -> None:
         root.addHandler(h)
 
 
+def spark_version_from_image(image: str | None) -> str | None:
+    """Extract version from a Spark image string using regex."""
+    if not image:
+        return None
+
+    tag_part = image.split(":")[-1] if ":" in image else ""
+
+    # Match versioning format (e.g: 4.0.0)
+    match = re.search(r"(\d+\.\d+\.\d+)", tag_part)
+
+    return match.group(1) if match else None
+
+
 class KubernetesBackend(RuntimeBackend):
     """Kubernetes backend for managing SparkConnect sessions and Spark batch jobs."""
 
@@ -148,12 +162,15 @@ class KubernetesBackend(RuntimeBackend):
         """
         name = generate_session_name()
 
+        extracted_spark_version = spark_version_from_image(driver.image) if driver else None
+
         spark_connect = build_spark_connect_cr(
             name=name,
             namespace=self.namespace,
             num_executors=num_executors,
             resources_per_executor=resources_per_executor,
             spark_conf=spark_conf,
+            spark_version=extracted_spark_version,
             driver=driver,
             executor=executor,
             options=options,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, check our contributor guidelines: https://www.kubeflow.org/docs/about/contributing
2. To know more about Kubeflow SDK, check the developer guide:
    https://github.com/kubeflow/sdk/blob/main/CONTRIBUTING.md
3. If you want *faster* PR reviews, check how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
Currently, the only caller of `build_spark_connect_cr ` does not use the spark version from the `driver.image`. Which means  that it was defaulting to the `DEFAULT_SPARK_VERSION` in every case.

This PR fixes this conflict by:
1. Extracting the spark version using regex from the driver image.
2. Passing the extracted version to `build_spark_connect_cr` inside `_create_session`. 

If a user doesn't provide an image, or uses a custom tag without a semantic version (e.g., `latest`), it falls back to returning `None`, preserving the existing default behavior.

**Which issue(s) this PR fixes** _(optional, in `Fixes #<issue number>, #<issue number>, ...` format, will close the issue(s) when PR gets merged)_:

Fixes #780

**Checklist:**

- [ ] [Docs](https://www.kubeflow.org/docs/) included if any changes are user facing
*(Note: No doc changes needed as this does not make any user facing changes.)*